### PR TITLE
Fix gitorious and dfu-util links

### DIFF
--- a/docs/DSO_Nano-gcc.md
+++ b/docs/DSO_Nano-gcc.md
@@ -31,9 +31,9 @@ If you can not find a pre-built ARM toolchain for your platform, or otherwise wa
 
 ##   Get and build the firmware source code
 
-For now, get the code from Tormod's gitorious tree:
+For now, get the code from Tormod's gitlab tree:
 ```
-git clone [git://gitorious.org/dsonano/dso-firmware.git](git://gitorious.org/dsonano/dso-firmware.git)
+git clone https://gitlab.com/dsonano/dso-firmware.git
 cd dso-firmware
 ```
 

--- a/docs/DSO_Nano.md
+++ b/docs/DSO_Nano.md
@@ -211,7 +211,7 @@ To upgrade the firmware to the latest version, you have a few options:
 *   Please visit our [DSO Nano forum](https://community.seeedstudio.com/discover.html?t=DSO) for prompt technical support and usage discussion.
 *   [Official firmware, schematics and development documentation](http://code.google.com/p/dsonano/)
 
-*   [Community firmware source git tree](http://gitorious.org/dsonano/dso-firmware) (for gcc and IAR)
+*   [Community firmware source git tree](https://gitlab.com/dsonano/dso-firmware) (for gcc and IAR)
 
 *   [MOD your DSO nano UI](https://files.seeedstudio.com/wiki/DSO_Nano/res/DSOUI.pdf)
 

--- a/docs/Dfu-util.md
+++ b/docs/Dfu-util.md
@@ -36,7 +36,7 @@ dfu-util -a 0 --dfuse-address 0x0800C000 -D your-app.bin
 
 ##   How to build dfu-util from source
 
-See the [build instructions](http://dfu-util.gnumonks.org/build.html) at the dfu-util home page.
+See the [build instructions](http://dfu-util.sourceforge.net/build.html) at the dfu-util home page.
 
 ##   Links
 
@@ -48,7 +48,7 @@ Original forum posts and discussion:
 
 Official home page
 
-*   [dfu-util homepage](http://dfu-util.gnumonks.org/)
+*   [dfu-util homepage](http://dfu-util.sourceforge.net/)
 
 ## Tech Support
 Please submit any technical issue into our [forum](https://forum.seeedstudio.com/). <br /><p style="text-align:center"><a href="https://www.seeedstudio.com/act-4.html?utm_source=wiki&utm_medium=wikibanner&utm_campaign=newproducts" target="_blank"><img src="https://files.seeedstudio.com/wiki/Wiki_Banner/new_product.jpg" /></a></p>

--- a/docs/FST-01.md
+++ b/docs/FST-01.md
@@ -45,9 +45,9 @@ As explained in the section above, we intend to run [Gnuk](http://www.fsij.org/g
 
 ![](https://files.seeedstudio.com/wiki/FST-01/img/Gnuk-sticker.png)
 
-Gnuk is an implementation of Cryptographic Token for GnuPG, and it runs on STM32F103.  Source code is available at gniibe.org or gitorious.org.  FOr source code, please visit: [https://gitorious.org/gnuk/gnuk/trees/release/1.0.1](https://gitorious.org/gnuk/gnuk/trees/release/1.0.1)
+Gnuk is an implementation of Cryptographic Token for GnuPG, and it runs on STM32F103.  Source code is available at http://www.gniibe.org/ (https://git.gniibe.org/cgit/chopstx/ttxs.git/)
 
-For more information about Gnuk, please visit: [Gnuk WiKi](https://gitorious.org/gnuk/pages/Home) and [Official Gnuk Documentation](http://www.fsij.org/doc-gnuk/).
+For more information about Gnuk, please visit: [Official Gnuk Documentation](http://www.fsij.org/doc-gnuk/).
 
 Also, we intend to run NeuG on FST-01.
 


### PR DESCRIPTION
Replace gitorious.org links (site no longer existing) and update dfu-util links (host changed many years ago).

Also remove the search index which isn't maintained by hand.