### PR TITLE
Fix bgt typo

### DIFF
--- a/docs/Grove-Doppler-Radar.md
+++ b/docs/Grove-Doppler-Radar.md
@@ -220,6 +220,7 @@ And if there's an object approaching the radar or passing by, the outcome will a
 
 ## Resources
 
+- **[CODE]** [GitHub](https://github.com/Seeed-Studio/Seeed_Arduino_DopplerRadar)
 - **[ZIP]** [Demo Code library](https://files.seeedstudio.com/wiki/Grove-Doppler-Radar/Seeed_Arduino_DopplerRadar.zip)
 - **[PDF]** [Grove_DopplerRadar(BGT24LTR11)Radar_module_communication_protocol_v1.1.pdf](https://files.seeedstudio.com/wiki/Grove-Doppler-Radar/Grove_DopplerRadar(BGT24LTR11)Radar_module_communication_protocol_v1.1.pdf)
 

--- a/docs/Grove-Doppler-Radar.md
+++ b/docs/Grove-Doppler-Radar.md
@@ -133,7 +133,7 @@ Doppler radar works by sending a beam of electromagnetic radiation waves from th
 
 #### Software Code
 ```C++
-#include "GBT24LTR11.h"
+#include "BGT24LTR11.h"
 
 #ifdef __AVR__
     #include <SoftwareSerial.h>
@@ -141,28 +141,28 @@ Doppler radar works by sending a beam of electromagnetic radiation waves from th
     #define COMSerial SSerial
     #define ShowSerial Serial
 
-    GBT24LTR11<SoftwareSerial> GBT;
+    BGT24LTR11<SoftwareSerial> BGT;
 #endif
 
 #ifdef ARDUINO_SAMD_VARIANT_COMPLIANCE
     #define COMSerial Serial1
     #define ShowSerial SerialUSB
 
-    GBT24LTR11<Uart> GBT;
+    BGT24LTR11<Uart> BGT;
 #endif
 
 #ifdef ARDUINO_ARCH_STM32F4
     #define COMSerial Serial
     #define ShowSerial SerialUSB
 
-    GBT24LTR11<HardwareSerial> GBT;
+    BGT24LTR11<HardwareSerial> BGT;
 #endif
 
 void setup() {
     // put your setup code here, to run once:
     ShowSerial.begin(9600);
     COMSerial.begin(115200);
-    GBT.init(COMSerial);
+    BGT.init(COMSerial);
     while (!ShowSerial)
         ;
     while (!COMSerial)
@@ -171,7 +171,7 @@ void setup() {
         MODE 0 -->detection target mode
         MODE 1 -->I/Q ADC mode
     */
-    while (!GBT.setMode(0))
+    while (!BGT.setMode(0))
         ;
 }
 
@@ -179,8 +179,8 @@ void loop() {
     // put your main code here, to run repeatedly:
     uint16_t state = 0;
     ShowSerial.print("target speed:");
-    ShowSerial.println(GBT.getSpeed());
-    state = GBT.getTargetState();
+    ShowSerial.println(BGT.getSpeed());
+    state = BGT.getTargetState();
     //2 --> target approach
     //1 --> target leave
     //0 --> Not Found target

--- a/docs/Grove-Doppler-Radar.md
+++ b/docs/Grove-Doppler-Radar.md
@@ -123,7 +123,7 @@ Doppler radar works by sending a beam of electromagnetic radiation waves from th
 
 
 
-- **Step 1.** Download the [Demo code](https://files.seeedstudio.com/wiki/Grove-Doppler-Radar/Seeed_Arduino_DopplerRadar.zip).
+- **Step 1.** Download the [Demo code](https://github.com/Seeed-Studio/Seeed_Arduino_DopplerRadar/archive/refs/tags/v1.0.1.zip).
 
 - **Step 2.** Copy the whole **Seeed_Arduino_DopplerRadar** file and paste it into your Arduino IDE library file.
 
@@ -221,7 +221,7 @@ And if there's an object approaching the radar or passing by, the outcome will a
 ## Resources
 
 - **[CODE]** [GitHub](https://github.com/Seeed-Studio/Seeed_Arduino_DopplerRadar)
-- **[ZIP]** [Demo Code library](https://files.seeedstudio.com/wiki/Grove-Doppler-Radar/Seeed_Arduino_DopplerRadar.zip)
+- **[ZIP]** [Demo Code library](https://github.com/Seeed-Studio/Seeed_Arduino_DopplerRadar/archive/refs/tags/v1.0.1.zip)
 - **[PDF]** [Grove_DopplerRadar(BGT24LTR11)Radar_module_communication_protocol_v1.1.pdf](https://files.seeedstudio.com/wiki/Grove-Doppler-Radar/Grove_DopplerRadar(BGT24LTR11)Radar_module_communication_protocol_v1.1.pdf)
 
 ## Tech Support


### PR DESCRIPTION
as the sensor is called `BGT24LTR11` by infineon and not `GBT24LTR11`.

This was incorporated in the library with [this commit](https://github.com/Seeed-Studio/Seeed_Arduino_DopplerRadar/commit/e5a6904f65c34634c0fc1f70b9b3daf3043d65cc) but did not make it into the wiki.

Also, using the latest release of the lib makes it less confusing to first time users.