### PR TITLE
Fix example code for Grove Air Quality Sensor v1.3

### DIFF
--- a/docs/Sensor/Grove/Grove_Sensors/Air_Quality/Grove-Air_Quality_Sensor_v1.3.md
+++ b/docs/Sensor/Grove/Grove_Sensors/Air_Quality/Grove-Air_Quality_Sensor_v1.3.md
@@ -112,46 +112,71 @@ Let's try it out!
 - **Step 3.** Copy the code into Arduino IDE and upload. If you do not know how to upload the code, please check [how to upload code](https://wiki.seeedstudio.com/Upload_Code/).
 
 ```c
-#include"AirQuality.h"
-#include"Arduino.h"
-AirQuality airqualitysensor;
-int current_quality =-1;
-void setup()
-{
+/*
+    Grove_Air_Quality_Sensor.ino
+    Demo for Grove - Air Quality Sensor.
+
+    Copyright (c) 2019 seeed technology inc.
+    Author    : Lets Blu
+    Created Time : Jan 2019
+    Modified Time:
+
+    The MIT License (MIT)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+#include "Air_Quality_Sensor.h"
+
+AirQualitySensor sensor(A0);
+
+void setup(void) {
     Serial.begin(9600);
-    airqualitysensor.init(A0);
-}
-void loop()
-{
-    current_quality=airqualitysensor.slope();
-    if (current_quality >= 0)// if a valid data returned.
-    {
-        if (current_quality==0)
-            Serial.println("High pollution! Force signal active");
-        else if (current_quality==1)
-            Serial.println("High pollution!");
-        else if (current_quality==2)
-            Serial.println("Low pollution!");
-        else if (current_quality ==3)
-            Serial.println("Fresh air");
-    }
-}
-ISR(TIMER2_OVF_vect)
-{
-    if(airqualitysensor.counter==122)//set 2 seconds as a detected duty
-    {
-        airqualitysensor.last_vol=airqualitysensor.first_vol;
-        airqualitysensor.first_vol=analogRead(A0);
-        airqualitysensor.counter=0;
-        airqualitysensor.timer_index=1;
-        PORTB=PORTB^0x20;
-    }
-    else
-    {
-        airqualitysensor.counter++;
+    while (!Serial);
+
+    Serial.println("Waiting sensor to init...");
+    delay(20000);
+
+    if (sensor.init()) {
+        Serial.println("Sensor ready.");
+    } else {
+        Serial.println("Sensor ERROR!");
     }
 }
 
+void loop(void) {
+    int quality = sensor.slope();
+
+    Serial.print("Sensor value: ");
+    Serial.println(sensor.getValue());
+
+    if (quality == AirQualitySensor::FORCE_SIGNAL) {
+        Serial.println("High pollution! Force signal active.");
+    } else if (quality == AirQualitySensor::HIGH_POLLUTION) {
+        Serial.println("High pollution!");
+    } else if (quality == AirQualitySensor::LOW_POLLUTION) {
+        Serial.println("Low pollution!");
+    } else if (quality == AirQualitySensor::FRESH_AIR) {
+        Serial.println("Fresh air.");
+    }
+
+    delay(1000);
+}
 ```
 
 - **Step 4.** We will see the distance display on terminal as below.


### PR DESCRIPTION
The example code gives a compile error (`AirQuality.h` not found). The Grove Air Quality Sensor v1.3 library doesn't have that file either. The example from the library works, though (https://github.com/Seeed-Studio/Grove_Air_quality_Sensor/blob/master/examples/Grove_Air_Quality_Sensor/Grove_Air_Quality_Sensor.ino). Maybe the code in the current example is simply outdated.