### PR TITLE
Add zephyr documentation around Xiao RP2040

### DIFF
--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS.md
@@ -1,0 +1,593 @@
+---
+description: XIAO RP2040 With Zephyr(RTOS)
+title:  XIAO RP2040 With Zephyr(RTOS)
+keywords:
+- Sorftware
+image: https://files.seeedstudio.com/wiki/wiki-platform/S-tempor.png
+slug: /XIAO-RP2040-Zephyr-RTOS
+last_update:
+  date: 3/20/2024
+  author: timo614
+---
+
+# XIAO RP2040 With Zephyr(RTOS)
+
+<div align="center"><img width ="{600}" src="https://files.seeedstudio.com/wiki/xiao_topicpage/zephyr-rp2040.png"/></div>
+
+This wiki covers [Zephyr](https://www.zephyrproject.org/) support for the [Seeed Studio XIAO RP2040](https://wiki.seeedstudio.com/xiao_rp2040_getting_started/). With the assistance of this guide you will be able to utilize the feature set available to the board.
+
+## What is [Zephyr](https://www.zephyrproject.org/)
+
+<div align="center"><img width ="{200}" src="https://files.seeedstudio.com/wiki/XIAO/Zephyr_logo.png"/></div>
+
+The [**Zephyr**](https://www.zephyrproject.org/) OS is based on a small-footprint kernel designed for use on resource-constrained and embedded systems: from simple embedded environmental sensors and LED wearables to sophisticated embedded controllers, smart watches, and IoT wireless applications.
+
+For each supported device Zephyr has a [devicetree](https://docs.zephyrproject.org/latest/build/dts/index.html) file that describes the board and its features. The [Xiao RP2040 Zephyr board page](https://docs.zephyrproject.org/latest/boards/seeed/xiao_rp2040/doc/index.html#supported-features) describes the supported features currently available which is defined by the [board's dts file](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/seeed/xiao_rp2040/xiao_rp2040.yaml#L7).
+
+*Reference: [**Zephyr Project**](https://docs.zephyrproject.org/latest/introduction/index.html#)*
+
+## Getting Started
+
+The first step to working with Zephyr is to get the SDK and toolchain setup for local development. The [Zephyr getting started guide](https://docs.zephyrproject.org/latest/develop/getting_started/index.html) should be referenced for the associated setup procedure needed for your environment.
+
+Once the Zephyr toolchain has been setup and an associated SDK has been downloaded you can begin application development.
+
+For the Xiao RP2040 the [board description file](https://docs.zephyrproject.org/latest/boards/seeed/xiao_rp2040/doc/index.html) can be referenced for further setup information.
+
+To program the Xiao RP2040 the following steps can be taken:
+1. Build an example or your application
+2. Plugin the Xiao RP2040
+3. Hold the button designated `B` (boot) and press `R` (reset) which will mount the device as a mass storage device
+4. Drag the uf2 file (ie `build/zephyr/zephyr.uf2`) generated during the build process to the device triggering an update
+
+The simplest example is to run the "Hello World" sample on the board. After changing to the directory of the Zephyr install run the following commands.
+
+```
+west build -p always -b xiao_rp2040 samples/subsys/usb/console
+```
+
+After this completes enter the `build/zephyr` folder and drag `zephyr.uf2` to your waiting RP2040 mounted drive. The device will reset after it receives the file and your machine should now be connected over USB for serial.
+
+Find the port for your device by typing `ls /dev/tty*` and confirming which device appears when your USB has been plugged in.
+
+In my example I see `/dev/ttyACM0` as the newly added device.
+
+Using screen you can then connect and monitor the serial response:
+```
+screen /dev/ttyACM0 115200
+```
+
+You should see a response similar to the following:
+```
+*** Booting Zephyr OS build v3.6.0-2212-gc38ea288eee9 ***
+Hello World! arm
+Hello World! arm
+Hello World! arm
+```
+
+To assist with the process of using Zephyr with Xiao and its expansion board a repository has been constructed with several overlays and configurations used here. The commands included in this wiki article assume it is located `../applications/xiao-zephyr-examples` relative to the zephyr root. An alternative path can be provided to the commands below by updating it.
+
+```
+git clone https://github.com/Cosmic-Bee/xiao-zephyr-examples
+```
+
+Additional sample projects will be placed in this same applications folder and further modified as we will need to alter them to allow for USB console support to connect for serial output.
+
+## Hardware Preparation
+
+If you want to follow this tutorial through everything, you will need to prepare the following.
+
+<table align="center">
+  <tbody><tr>
+      <th>Seeed Studio XIAO RP2040 Sense</th>
+      <th>Seeed Studio Expansion Board</th>
+    </tr>
+    <tr>
+      <td><div align="center"><img src="https://files.seeedstudio.com/wiki/XIAO-RP2040/img/102010428_Preview-07.jpg" style={{width:300, height:'auto'}}/></div></td>
+      <td><div align="center"><img src="https://files.seeedstudio.com/wiki/Seeeduino-XIAO-Expansion-Board/Update_pic/zheng1.jpg" style={{width:210, height:'auto'}}/></div></td>
+    </tr>
+    <tr>
+        <td align="center"><div class="get_one_now_container" style={{textAlign: 'center'}}>
+            <a class="get_one_now_item" href="https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html">
+            <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+            </a>
+        </div></td>
+        <td align="center"><div class="get_one_now_container" style={{textAlign: 'center'}}>
+            <a class="get_one_now_item" href="https://www.seeedstudio.com/Seeeduino-XIAO-Expansion-board-p-4746.html">
+            <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now🖱️</font></span></strong>
+            </a>
+        </div></td>
+    </tr>
+  </tbody></table>
+
+### Developer Knowledge
+
+#### XIAO Expansion Board
+
+  In order to use Grove modules with Seeed Studio XIAO RP2040, we will use a [Seeed Studio Expansion Base for XIAO](https://www.seeedstudio.com/Seeeduino-XIAO-Expansion-board-p-4746.html) and connect XIAO RP2040 on it.
+
+  After that, the Grove connectors on the board can be used to connect Grove modules
+
+  <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/wiki-ranger/Contributions/C3-ESPHome-full_function/29.png"style={{width:700, height:'auto'}}/></div>
+
+#### Pin Definitions
+
+  You need to follow the graphic below to use the appropriate internal pin numbers when connecting the Grove modules to the Grove connectors on Grove Shield for Seeed Studio XIAO.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/XIAO-RP2040/img/xinpin.jpg"style={{width:900, height:'auto'}}/></div>
+
+### Enabling Xiao RP2040 as a USB serial device
+
+In order to make the Xiao RP2040 available for serial connectivity you will need to modify examples to enable the USB features. The following steps can be followed to perform these modifications to get an example ready for console use. You will be referenced back to this section several times throughout this documentation as you progress through the examples.
+
+To do this we'll need to make two modifications:
+1. Adjust the prj.conf to include additional ENV variables
+2. Enable USB from your application
+
+#### Adjust the prj.conf by adding the following variables:
+```
+CONFIG_USB_DEVICE_STACK=y
+CONFIG_USB_DEVICE_PRODUCT="Xiao RP2040"
+CONFIG_USB_DEVICE_PID=0x0004
+CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=n
+CONFIG_UART_LINE_CTRL=y
+```
+
+#### Enable USB for your application by editing `main.c`:
+
+Add the following include:
+```
+#include <zephyr/usb/usb_device.h>
+```
+
+In your main method add the following line:
+```
+	if (usb_enable(NULL)) {
+		return 0;
+	}
+```
+
+#### app.overlay changes to support USB console
+
+For the examples used in this article we'll be relying on an overlay we have prepared as part of the example additional files we had you previously download. This overlay enables the USB console.
+
+If you want to make the changes yourself to support Xiao RP2040 with USB console enabled you will need the follow in your app.overlay:
+```
+ / {
+	chosen {
+		zephyr,console = &cdc_acm_uart0;
+	};
+};
+
+&zephyr_udc0 {
+	cdc_acm_uart0: cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+	};
+};
+```
+
+### Primary Functionality
+
+<ul>
+  <li>WS2812 LED</li>
+  <li>LED PWM</li>
+  <li>Clock</li>
+  <li>TFLite</li>
+</ul>
+
+#### WS2812 LED
+
+For this example the Xiao RP2040 utilizes its onboard LED and flashes through red, green, and blue continually.
+
+To test this setup we can use an existing sample with Zephyr:
+
+```
+cd ~/zephyrproject/zephyr
+west build -p always -b xiao_rp2040 samples/drivers/led_strip
+```
+
+You'll see the onboard WS2812 LED cycling through red, blue and green continually in a flashing pattern.
+
+Let's dive into this example a bit to see why it works:
+```
+
+ / {
+     aliases {
+         led-strip = &ws2812;
+     };
+ }
+ &gpio0 {
+     status = "okay";
+     neopixel-power-enable {
+		gpio-hog;
+		gpios = <11 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+ };
+ &pio0 {
+     status = "okay";
+
+     pio-ws2812 {
+         compatible = "worldsemi,ws2812-rpi_pico-pio";
+         status = "okay";
+         pinctrl-0 = <&ws2812_pio0_default>;
+         pinctrl-names = "default";
+         bit-waveform = <3>, <3>, <4>;
+
+         ws2812: ws2812 {
+             status = "okay";
+             gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+             chain-length = <1>;
+             color-mapping = <LED_COLOR_ID_GREEN
+                      LED_COLOR_ID_RED
+                      LED_COLOR_ID_BLUE>;
+             reset-delay = <280>;
+             frequency = <800000>;
+         };
+     };
+ };
+```
+
+These elements of the device tree show the onboard WS2812 and its utilization. Given the WS2812 has its VCC line set to the RP2040's pin 11 the devicetree utilizes the gpio-hog functionality to allow the LED to be enabled via environment variables. In this case pin 12 is the one setup for the WS2812 dataline so with the CONFIG_GPIO_HOGS environment variable enabled the LED strip is able to be used for the example.
+
+This works in part because the example has an xiao_rp2040.conf file as part of its boards directory so it merges that configuration with the board's configuration and enables it.
+
+```
+CONFIG_GPIO=y
+CONFIG_GPIO_HOGS=y
+```
+
+If you wish to utilize the onboard WS2812 it is advisable to enable this variable to allow it to draw power.
+
+<div style={{textAlign:'center'}}><img src="https://raw.githubusercontent.com/Cosmic-Bee/xiao-zephyr-examples/main/images/rp2040/ws2812.gif" style={{width:300, height:'auto'}}/></div>
+
+#### LED PWM
+
+This example we'll demonstrate the PWM capabilities of the Xiao RP2040. To do such we'll be using the onboard blue LED and use PWM to fade it continuously.
+
+To test this setup we can use an existing sample with Zephyr:
+
+```
+cd ~/zephyrproject/zephyr
+west build -p always -b xiao_rp2040 samples/basic/fade_led
+```
+
+You'll see the blue light of the RGB onboard LED slowly fade and repeat the process again.
+
+Let's dive into this example a bit to see why it works:
+```
+&pwm {
+	status = "okay";
+	divider-int-4 = <255>;
+};
+```
+
+This bit of logic in the `boards/xiao_rp2040.overlay` for the example enables the PWM functionality from the devicetree that is normally disabled. The Xiao RP2040 setup has the blue onboard RGB LED setup as the default PWM.
+
+As can be seen by the `xiao_rp2040-pinctrl.dtsi` from the zephyr board files the following exists:
+```
+	pwm_ch4b_default: pwm_ch4b_default {
+		group1 {
+			pinmux = <PWM_4B_P25>;
+		};
+	};
+```
+
+In this case the PWM is using the configured devicetree pwm LED which is associated back with pin 25 (the blue LED). The PWM pins can be referenced from the [RP2040 documentation](https://docs.zephyrproject.org/apidoc/latest/rpi-pico-rp2040-pinctrl_8h.html).
+
+<div style={{textAlign:'center'}}><img src="https://raw.githubusercontent.com/Cosmic-Bee/xiao-zephyr-examples/main/images/rp2040/led_fade.gif" style={{width:300, height:'auto'}}/></div>
+
+#### Clock
+
+For this example we're going to copy the clock sample and adjust it such that the console will display the output.
+
+```
+cp -r ~/zephyrproject/zephyr/samples/drivers/counter/alarm ~/zephyrproject/applications/counter_alarm
+cd ~/zephyrproject/applications/counter_alarm
+```
+
+To start we'll enable the USB console. Please refer to the modifications to support USB console output listed above in the "Enabling Xiao RP2040 as a USB serial device" section.
+
+Now build the project:
+```
+west build -p always -b xiao_rp2040 . -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/console.overlay
+```
+
+You can find the uf2 file at `~/zephyrproject/applications/counter_alarm/build/zephyr/zephyr.uf2`
+
+After uploading the uf2 file connect to monitor (after quickly resetting your board to ensure it restarts):
+```
+screen /dev/ttyACM0 115200
+```
+
+You will see a series of timers going off after a set delay one after another:
+```
+*** Booting Zephyr OS build v3.6.0-2212-gc38ea288eee9 ***
+Counter alarm sample
+
+Set alarm in 2 sec (2000000 ticks)
+!!! Alarm !!!
+Now: 2
+Set alarm in 4 sec (4000000 ticks)
+!!! Alarm !!!
+Now: 6
+Set alarm in 8 sec (8000000 ticks)
+!!! Alarm !!!
+Now: 14
+Set alarm in 16 sec (16000000 ticks)
+!!! Alarm !!!
+Now: 30
+Set alarm in 32 sec (32000000 ticks)
+```
+
+
+#### TFLite - Hello World
+
+Enable TFLite with Zephyr and update:
+```
+west config manifest.project-filter -- +tflite-micro
+west update
+```
+
+For this example we're going to copy the tflite "Hello World" sample and adjust it such that the console will display the output.
+
+```
+cp -r ~/zephyrproject/zephyr/samples/modules/tflite-micro/hello_world ~/zephyrproject/applications/tflite_hello_world
+cd ~/zephyrproject/applications/tflite_hello_world
+```
+
+To start we'll enable the USB console. Please refer to the modifications to support USB console output listed above in the "Enabling Xiao RP2040 as a USB serial device" section.
+
+Now build the project:
+```
+west build -p always -b xiao_rp2040 . -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/console.overlay
+```
+
+You can find the uf2 file at `~/zephyrproject/applications/tflite_hello_world/build/zephyr/zephyr.uf2`
+
+After uploading the uf2 file connect to monitor:
+```
+screen /dev/ttyACM0 115200
+```
+
+You will see results returned from the console:
+```
+*** Booting Zephyr OS build v3.6.0-1155-g1a55caf8263e ***
+x_value: 1.0*2^-127, y_value: 1.0*2^-127
+
+x_value: 1.2566366*2^-2, y_value: 1.4910772*2^-2
+
+x_value: 1.2566366*2^-1, y_value: 1.1183078*2^-1
+
+x_value: 1.8849551*2^-1, y_value: 1.677462*2^-1
+
+x_value: 1.2566366*2^0, y_value: 1.9316229*2^-1
+
+x_value: 1.5707957*2^0, y_value: 1.0420598*2^0
+
+x_value: 1.8849551*2^0, y_value: 1.9146791*2^-1
+
+x_value: 1.0995567*2^1, y_value: 1.6435742*2^-1
+
+x_value: 1.2566366*2^1, y_value: 1.0674761*2^-1
+
+x_value: 1.4137159*2^1, y_value: 1.8977352*2^-3
+```
+
+### Additional Components
+
+<ul>
+  <li>[Grove - Expansion Board](https://www.seeedstudio.com/Seeeduino-XIAO-Expansion-board-p-4746.html) - I2C Display</li>
+  <li>[Grove - Expansion Board](https://www.seeedstudio.com/Seeeduino-XIAO-Expansion-board-p-4746.html) - Button</li>
+  <li>[Grove - Temperature and Humidity Sensor (SHT31)](https://www.seeedstudio.com/Grove-Temperature-Humidity-Sensor-SHT31.html)</li>
+  <li>[1.69inch LCD Display Module, 240×280 Resolution, SPI Interface](https://www.seeedstudio.com/1-69inch-240-280-Resolution-IPS-LCD-Display-Module-p-5755.html)</li>
+</ul>
+
+#### Grove - Expansion Board - I2C Display
+
+<div style={{textAlign:'center'}}><img src="https://github.com/Cosmic-Bee/xiao-zephyr-examples/blob/main/images/rp2040/xiao_expansion_oled.jpg?raw=true" style={{width:300, height:'auto'}}/></div>
+
+To test this setup we can use an existing sample with Zephyr:
+
+```
+cd ~/zephyrproject/zephyr
+west build -p always -b xiao_rp2040 samples/drivers/display -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/xiao-expansion.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/samples.conf
+```
+
+You'll see a display showing multiple black boxes and a blinking box in the corner given this display only supports two colors.
+
+Let's dive into this example a bit to see why it works:
+```
+/ {
+    chosen {
+      zephyr,display = &ssd1306;
+    };
+};
+
+&i2c1 {
+  status = "okay";
+
+  ssd1306: ssd1306@3c {
+    compatible = "solomon,ssd1306fb";
+    reg = <0x3c>;
+    width = <128>;
+    height = <64>;
+    segment-offset = <0>;
+    page-offset = <0>;
+    display-offset = <0>;
+    multiplex-ratio = <63>;
+    segment-remap;
+    com-invdir;
+    prechargep = <0x22>;
+  };
+};
+
+```
+
+The app overlay file in this example sets up a SSD1306 OLED screen at the 0x3C register. It is selected as the zephyr display in the chosen section.
+
+```
+CONFIG_LV_Z_VDB_SIZE=64
+CONFIG_LV_COLOR_DEPTH_1=y
+CONFIG_I2C=y
+```
+
+The associated configuration file enables the OLED screen to properly render by setting its depth to 1 and enabling I2C for the project.
+
+#### Grove - Expansion Board - Button
+
+To test this setup we can use an existing sample with Zephyr which we will modify to enable USB console support.
+
+```
+cp -r ~/zephyrproject/zephyr/samples/basic/button ~/zephyrproject/applications/basic_button
+cd ~/zephyrproject/applications/basic_button
+```
+
+To start we'll enable the USB console. Please refer to the modifications to support USB console output listed above in the "Enabling Xiao RP2040 as a USB serial device" section.
+
+```
+west build -p always -b xiao_rp2040 . -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/xiao-expansion.overlay $(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/console.overlay"
+```
+
+After uploading the uf2 file connect to monitor:
+```
+screen /dev/ttyACM0 115200
+```
+
+Pressing the button with the sample will trigger the onboard LED to light up.
+
+You will see results returned from the console:
+
+```
+*** Booting Zephyr OS build v3.6.0-2212-gc38ea288eee9 ***
+Set up button at gpio@40014000 pin 27
+Set up LED at gpio@40014000 pin 25
+Press the button
+Button pressed at 1934761489
+Button pressed at 2178879257
+Button pressed at 3084766465
+Button pressed at 3388674993
+```
+
+Let's dive into this example a bit to see why it works:
+```
+/ {
+    aliases {
+		sw0 = &button0;
+    };
+
+    buttons {
+            compatible = "gpio-keys";
+            button0: button_0 {
+                gpios = <&gpio0 27 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+                label = "Expansion Board Button";
+            };
+    };
+};
+```
+
+The app overlay file is used to setup various board components. Using this file the button example can be utilized as the overlay allows the Zephyr to configure the button and make it available for the associated code.
+
+In this case GPIO 27 corresponds with Pin A1/D1 on the Xiao RP2040. It is setup in this overlay to act as a button and is aliased to the sw0 name to allow it to be used for the sample which has code expecting this.
+
+
+#### Grove - Temperature and Humidity Sensor (SHT31)
+
+First solder on pins and connect your Xiao RP2040 to the expansion board. Then connect a grove connector cable between the Grove SHT31 and one of the I2C ports on the expansion board.
+
+<div style={{textAlign:'center'}}><img src="https://github.com/Cosmic-Bee/xiao-zephyr-examples/blob/main/images/rp2040/xiao_sht31.jpg?raw=true" style={{width:300, height:'auto'}}/></div>
+
+To test this setup we can use an existing sample with Zephyr which we will modify to enable USB console support.
+
+```
+cp -r ~/zephyrproject/zephyr/samples/sensor/sht3xd ~/zephyrproject/applications/sht3xd
+cd ~/zephyrproject/applications/sht3xd
+```
+
+To start we'll enable the USB console. Please refer to the modifications to support USB console output listed above in the "Enabling Xiao RP2040 as a USB serial device" section.
+
+```
+west build -p always -b xiao_rp2040 . -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/sht31.overlay $(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/console.overlay"
+```
+
+After uploading the uf2 file connect to monitor:
+```
+screen /dev/ttyACM0 115200
+```
+
+You will see results returned from the console:
+```
+*** Booting Zephyr OS build v3.6.0-2212-gc38ea288eee9 ***
+SHT3XD: 26.20 Cel ; 52.49 %RH
+SHT3XD: 26.19 Cel ; 52.69 %RH
+SHT3XD: 26.20 Cel ; 52.75 %RH
+SHT3XD: 26.24 Cel ; 52.88 %RH
+SHT3XD: 26.24 Cel ; 52.67 %RH
+SHT3XD: 26.23 Cel ; 52.49 %RH
+SHT3XD: 26.23 Cel ; 52.48 %RH
+SHT3XD: 26.24 Cel ; 52.30 %RH
+```
+
+Let's dive into this example a bit to see why it works:
+```
+ &i2c1 {
+	sht3xd@44 {
+			compatible = "sensirion,sht3xd";
+			reg = <0x44>;
+		};
+	};
+```
+
+The app overlay file is used to setup various board components. Using this file the SHT31 example can be utilized as the overlay informs the [sample logic](https://github.com/zephyrproject-rtos/zephyr/blob/main/samples/sensor/sht3xd/src/main.c) how to configure the sensor for our board.
+
+#### 1.69inch LCD Display Module, 240×280 Resolution, SPI Interface
+
+For this example we'll use SPI to connect to a 1.69 inch LCD with a 240x280 resolution.
+
+First connect your board to the LCD screen using the following image as a guide (in this case we're using the Xiao RP2040 but the same pin layout is used for connecting here).
+
+| 1.69-inch LCD SPI Display| XIAO RP2040 |
+| ------------- | ------------------------- |
+| VCC | 3V3 |
+| GND | GND |
+| DIN | D10 |
+| CLK | D8 |
+| CS | D1 |
+| DC | D3 |
+| RST | D0 |
+| BL | D6 |
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/lcd_spi_display/10.png" style={{width:700, height:'auto'}}/></div>
+
+Next with the hardware prepared we can build the uf2 file for flashing:
+```
+cd ~/zephyrproject/zephyr
+west build -p always -b xiao_rp2040 samples/drivers/display -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/240x280_st7789v2.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/240x280_st7789v2.conf
+```
+
+When this completes, move the build file from `build/zephyr/zephyr.uf2` to the mounted Xiao RP2040 (remember you can hold the boot button down while plugging in to enter this state) which will reset the device with the new firmware.
+
+With the new firmware in place the device now shows the same demo screen we saw previously on the expansion board just now updated for the color LCD over SPI.
+
+<div style={{textAlign:'center'}}><img src="https://github.com/Cosmic-Bee/xiao-zephyr-examples/blob/main/images/rp2040/spi_lcd.jpg?raw=true" style={{width:300, height:'auto'}}/></div>
+
+
+## ✨ Contributor Project
+
+- This project is supported by the Seeed Studio [Contributor Project](https://github.com/orgs/Seeed-Studio/projects/6/views/1?pane=issue&itemId=57293558).
+- Thanks **Tim's efforts** and your work will be [exhibited](https://wiki.seeedstudio.com/Honorary-Contributors/).
+
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="button_tech_support_container">
+<a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+<a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+</div>
+
+<div class="button_tech_support_container">
+<a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+<a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+</div>

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS.md
@@ -71,8 +71,6 @@ To assist with the process of using Zephyr with Xiao and its expansion board a r
 git clone https://github.com/Cosmic-Bee/xiao-zephyr-examples
 ```
 
-Additional sample projects will be placed in this same applications folder and further modified as we will need to alter them to allow for USB console support to connect for serial output.
-
 ## Hardware Preparation
 
 If you want to follow this tutorial through everything, you will need to prepare the following.
@@ -115,56 +113,6 @@ If you want to follow this tutorial through everything, you will need to prepare
   You need to follow the graphic below to use the appropriate internal pin numbers when connecting the Grove modules to the Grove connectors on Grove Shield for Seeed Studio XIAO.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/XIAO-RP2040/img/xinpin.jpg"style={{width:900, height:'auto'}}/></div>
-
-### Enabling Xiao RP2040 as a USB serial device
-
-In order to make the Xiao RP2040 available for serial connectivity you will need to modify examples to enable the USB features. The following steps can be followed to perform these modifications to get an example ready for console use. You will be referenced back to this section several times throughout this documentation as you progress through the examples.
-
-To do this we'll need to make two modifications:
-1. Adjust the prj.conf to include additional ENV variables
-2. Enable USB from your application
-
-#### Adjust the prj.conf by adding the following variables:
-```
-CONFIG_USB_DEVICE_STACK=y
-CONFIG_USB_DEVICE_PRODUCT="Xiao RP2040"
-CONFIG_USB_DEVICE_PID=0x0004
-CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=n
-CONFIG_UART_LINE_CTRL=y
-```
-
-#### Enable USB for your application by editing `main.c`:
-
-Add the following include:
-```
-#include <zephyr/usb/usb_device.h>
-```
-
-In your main method add the following line:
-```
-	if (usb_enable(NULL)) {
-		return 0;
-	}
-```
-
-#### app.overlay changes to support USB console
-
-For the examples used in this article we'll be relying on an overlay we have prepared as part of the example additional files we had you previously download. This overlay enables the USB console.
-
-If you want to make the changes yourself to support Xiao RP2040 with USB console enabled you will need the follow in your app.overlay:
-```
- / {
-	chosen {
-		zephyr,console = &cdc_acm_uart0;
-	};
-};
-
-&zephyr_udc0 {
-	cdc_acm_uart0: cdc_acm_uart0 {
-		compatible = "zephyr,cdc-acm-uart";
-	};
-};
-```
 
 ### Primary Functionality
 
@@ -279,18 +227,10 @@ In this case the PWM is using the configured devicetree pwm LED which is associa
 
 #### Clock
 
-For this example we're going to copy the clock sample and adjust it such that the console will display the output.
-
+For this we'll use an existing sample and our console overlay:
 ```
-cp -r ~/zephyrproject/zephyr/samples/drivers/counter/alarm ~/zephyrproject/applications/counter_alarm
-cd ~/zephyrproject/applications/counter_alarm
-```
-
-To start we'll enable the USB console. Please refer to the modifications to support USB console output listed above in the "Enabling Xiao RP2040 as a USB serial device" section.
-
-Now build the project:
-```
-west build -p always -b xiao_rp2040 . -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/console.overlay
+cd ~/zephyrproject/zephyr
+west build -p always -b xiao_rp2040 samples/drivers/counter/alarm -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.conf
 ```
 
 You can find the uf2 file at `~/zephyrproject/applications/counter_alarm/build/zephyr/zephyr.uf2`
@@ -329,18 +269,11 @@ west config manifest.project-filter -- +tflite-micro
 west update
 ```
 
-For this example we're going to copy the tflite "Hello World" sample and adjust it such that the console will display the output.
+For this example we're going to use the sample tflite "Hello World" along with our console overlay and conf to read the response over USB serial.
 
 ```
-cp -r ~/zephyrproject/zephyr/samples/modules/tflite-micro/hello_world ~/zephyrproject/applications/tflite_hello_world
-cd ~/zephyrproject/applications/tflite_hello_world
-```
-
-To start we'll enable the USB console. Please refer to the modifications to support USB console output listed above in the "Enabling Xiao RP2040 as a USB serial device" section.
-
-Now build the project:
-```
-west build -p always -b xiao_rp2040 . -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/console.overlay
+cd ~/zephyrproject/zephyr
+west build -p always -b xiao_rp2040 samples/modules/tflite-micro/hello_world -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.conf
 ```
 
 You can find the uf2 file at `~/zephyrproject/applications/tflite_hello_world/build/zephyr/zephyr.uf2`
@@ -436,17 +369,11 @@ The associated configuration file enables the OLED screen to properly render by 
 
 #### Grove - Expansion Board - Button
 
-To test this setup we can use an existing sample with Zephyr which we will modify to enable USB console support.
+To test this setup we can use an existing sample with Zephyr which we will use along with the USB console overlay and conf.
 
 ```
-cp -r ~/zephyrproject/zephyr/samples/basic/button ~/zephyrproject/applications/basic_button
-cd ~/zephyrproject/applications/basic_button
-```
-
-To start we'll enable the USB console. Please refer to the modifications to support USB console output listed above in the "Enabling Xiao RP2040 as a USB serial device" section.
-
-```
-west build -p always -b xiao_rp2040 . -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/xiao-expansion.overlay $(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/console.overlay"
+cd ~/zephyrproject/zephyr
+west build -p always -b xiao_rp2040 samples/basic/button -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/xiao-expansion.overlay $(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.overlay" -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.conf
 ```
 
 After uploading the uf2 file connect to monitor:
@@ -497,17 +424,11 @@ First solder on pins and connect your Xiao RP2040 to the expansion board. Then c
 
 <div style={{textAlign:'center'}}><img src="https://github.com/Cosmic-Bee/xiao-zephyr-examples/blob/main/images/rp2040/xiao_sht31.jpg?raw=true" style={{width:300, height:'auto'}}/></div>
 
-To test this setup we can use an existing sample with Zephyr which we will modify to enable USB console support.
+To test this setup we can use an existing sample with Zephyr which we will enable USB console support with our overlay and conf.
 
 ```
-cp -r ~/zephyrproject/zephyr/samples/sensor/sht3xd ~/zephyrproject/applications/sht3xd
-cd ~/zephyrproject/applications/sht3xd
-```
-
-To start we'll enable the USB console. Please refer to the modifications to support USB console output listed above in the "Enabling Xiao RP2040 as a USB serial device" section.
-
-```
-west build -p always -b xiao_rp2040 . -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/sht31.overlay $(dirname $(pwd))/xiao-zephyr-examples/xiao-rp2040/console.overlay"
+cd ~/zephyrproject/zephyr
+west build -p always -b xiao_rp2040 samples/sensor/sht3xd -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/sht31.overlay $(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.overlay" -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.conf
 ```
 
 After uploading the uf2 file connect to monitor:

--- a/sidebars.js
+++ b/sidebars.js
@@ -135,7 +135,7 @@ const sidebars = {
             {
               type: 'category',
               label: 'AI-powered',
-              items: [        
+              items: [
                 'Sensor/Grove/Grove_Sensors/AI-powered/Grove-Vision-AI-Module',
                 {
                   type: 'category',
@@ -154,7 +154,7 @@ const sidebars = {
                     'Sensor/Grove/Grove_Sensors/AI-powered/Grove-vision-ai-v2/grove-vision-ai-v2-himax-sdk',
                     'Sensor/Grove/Grove_Sensors/AI-powered/Grove-vision-ai-v2/grove-vision-ai-v2-sensecap-app',
                   ],
-                },    
+                },
                 'Sensor/Grove/Grove_Sensors/AI-powered/Train-Deploy-AI-Model-Grove-Vision-AI',
                 'Sensor/Grove/Grove_Sensors/AI-powered/edge-impulse-vision-ai',
                 'Sensor/Grove/Grove_Sensors/AI-powered/Grove-Gesture_sensor_paj7660',
@@ -723,10 +723,10 @@ const sidebars = {
                    ],
           },
           'Sensor/SenseCAP/SenseCAP_T1000_Tracker/FAQ',
-          'Sensor/SenseCAP/SenseCAP_T1000_Tracker/Firmware_release_note',          
+          'Sensor/SenseCAP/SenseCAP_T1000_Tracker/Firmware_release_note',
               ],
         },
-        
+
         {
           type: 'category',
           label: 'SenseCAP Sensor',
@@ -742,7 +742,7 @@ const sidebars = {
               type: 'category',
               label: 'SenseCAP LoRaWAN Sensor',
 
-              items: [  
+              items: [
                 {
                   type: 'category',
                   label: 'SenseCAP S210X Series',
@@ -987,6 +987,7 @@ const sidebars = {
                 'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-with-CircuitPython',
               ],
             },
+            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS',
             {
               type: 'category',
               label: 'Embedded ML',
@@ -2088,7 +2089,7 @@ const sidebars = {
             },
           ],
         },
-        
+
         {
           type: 'category',
           label: 'Helium Gateway',
@@ -2367,7 +2368,7 @@ const sidebars = {
           'Network/RK_Devices/H28K/H28K-install-system',
         ],
       },
-  
+
       ],
     },
 
@@ -2434,13 +2435,13 @@ const sidebars = {
               'Edge/Raspberry_Pi_Devices/reTerminal/reTerminal-hardware-interfaces-usage',
               'Edge/Raspberry_Pi_Devices/reTerminal/reTerminal-piCam',
               'Edge/Raspberry_Pi_Devices/reTerminal/reTerminal-FAQ',
-              
+
               {
                 type: 'category',
                 label: 'Application',
                 items: [
-                  
-      
+
+
                   {
                     type: 'category',
                     label: 'Home Assistant',
@@ -2471,7 +2472,7 @@ const sidebars = {
                       'Edge/Raspberry_Pi_Devices/reTerminal/Application/OpenCV/reTerminal_DM_Shape_detection',
                       'Edge/Raspberry_Pi_Devices/reTerminal/Application/OpenCV/reTerminal_DM-tracking',
                       'Edge/Raspberry_Pi_Devices/reTerminal/Application/OpenCV/reTerminal_DM_Object_detection',
-                      
+
                     ],
                   },
                   {
@@ -2537,7 +2538,7 @@ const sidebars = {
                   'Edge/Raspberry_Pi_Devices/reTerminal-DM/SenseCraft_Edge/reterminal-dm-sensecraft-edge-os-intro',
                 ],
               },
-      
+
               {
                 type: 'category',
                 label: 'Home-Assistant',
@@ -2599,7 +2600,7 @@ const sidebars = {
           },
 
         ],
-      
+
       },
       {
         type: 'category',
@@ -2633,9 +2634,9 @@ const sidebars = {
           },
         ],
       },
-        
+
       ],
-        
+
 
 
 
@@ -2731,7 +2732,7 @@ const sidebars = {
             //   type: 'category',
             //   label: 'J202',
             //   items: [
-                
+
             //   ],
             // },
 
@@ -2739,7 +2740,7 @@ const sidebars = {
             //   type: 'category',
             //   label: 'J401',
             //   items: [
-              
+
             //   ],
             // },
 
@@ -2775,7 +2776,7 @@ const sidebars = {
                 {
                   type: 'category',
                   label: 'reComputer J1010',
-                  items: [ 
+                  items: [
                   'Edge/NVIDIA_Jetson/reComputer_Jetson_Series/reComputer_J10/reComputer_J1010/reComputer_J1010_with_Jetson_getting_start',
                   'Edge/NVIDIA_Jetson/reComputer_Jetson_Series/reComputer_J10/reComputer_J1010/J101_Enable_SD_Card',
                   'Edge/NVIDIA_Jetson/reComputer_Jetson_Series/reComputer_J10/reComputer_J1010/J1010_Boot_From_SD_Card',
@@ -2837,7 +2838,7 @@ const sidebars = {
 
 
         ]},
-        
+
         {
           type: 'category',
           label: 'Other Devices',
@@ -2948,7 +2949,7 @@ const sidebars = {
             'Edge/NVIDIA_Jetson/FAQs/Solution_for_the_Compatibility_Issue_between_reComputer_and_VEYE_Camera',
           ]}
 
-          
+
         // {
         //   type: 'category',
         //   label: 'reComputer Industrial',
@@ -3713,7 +3714,7 @@ const sidebars = {
           ]
         },
 
-        
+
       ],
     },
 
@@ -4140,7 +4141,7 @@ const sidebars = {
         'zh-CN/Sensor/Grove/Grove_Sensors/AI-powered/Grove-vision-ai-v2/cn-grove-vision-ai-v2-himax-sdk',
         'zh-CN/Sensor/Grove/Grove_Sensors/AI-powered/Grove-vision-ai-v2/cn-grove-vision-ai-v2-sensecap-app',
       ],
-    },    
+    },
 
     {
       type: 'doc',
@@ -4354,7 +4355,7 @@ const sidebars = {
          },
        ],
      },
- 
+
      {
       type: 'category',
       label: 'XIAO 的兼容扩展板',


### PR DESCRIPTION
Issue: https://github.com/orgs/Seeed-Studio/projects/6?pane=issue&itemId=57293558

I ended up having to do a bit more with this one as Zephyr didn't have support for the board. I based it off the pico 2040 and I put together board support files and some additional examples for SPI, etc. to confirm everything was working as it was my first zephyr board.

I am still trying to debug why my development laptop (it's rather old) is having issues building the zephyr documentation so I can't test the board file. I did see some html generated which looked good but my machine dies mid build so need to retest once I figure out the issues.

Board support for Xiao RP2040 with Zephyr: https://github.com/zephyrproject-rtos/zephyr/pull/71585

![xiao_expansion_oled](https://github.com/Seeed-Studio/wiki-documents/assets/1319304/8ceb1542-c44f-4eed-8d57-5ad9271146b4)
