### PR TITLE
Zephyr: Update location of uf2 file given change to underlying wiki page

### DIFF
--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS.md
@@ -233,7 +233,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/drivers/counter/alarm -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.conf
 ```
 
-You can find the uf2 file at `~/zephyrproject/applications/counter_alarm/build/zephyr/zephyr.uf2`
+You can find the uf2 file at `~/zephyrproject/zephyr/build/zephyr/zephyr.uf2`
 
 After uploading the uf2 file connect to monitor (after quickly resetting your board to ensure it restarts):
 ```
@@ -276,7 +276,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/modules/tflite-micro/hello_world -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/console.conf
 ```
 
-You can find the uf2 file at `~/zephyrproject/applications/tflite_hello_world/build/zephyr/zephyr.uf2`
+You can find the uf2 file at `~/zephyrproject/zephyr/build/zephyr/zephyr.uf2`
 
 After uploading the uf2 file connect to monitor:
 ```


### PR DESCRIPTION
Relates to: https://github.com/Seeed-Studio/wiki-documents/pull/1120

Noticed I had kept the location of the uf2 file mentioned as being in the applications folder wrt a copied application but I had modified the examples to avoid the need to copy so this can be modified to point to where the samples are built. Sorry about that.

Should I also add a note about waiting for the Xiao RP2040 to merge in zephyr for the PR there? I have been working on the PR to get it to merge so should be soon but not sure on if they will want further changes.