### PR TITLE
Zephyr additions, adjustments to flash command

### DIFF
--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO-ESP32C3-Zephyr.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO-ESP32C3-Zephyr.md
@@ -350,7 +350,7 @@ Additional information about TFLite is outside of the scope of this guide but th
 - [Grove - Expansion Board](https://www.seeedstudio.com/Seeeduino-XIAO-Expansion-board-p-4746.html) - Button
 - [Grove - Temperature and Humidity Sensor (SHT31)](https://www.seeedstudio.com/Grove-Temperature-Humidity-Sensor-SHT31.html)
 - [1.69inch LCD Display Module, 240×280 Resolution, SPI Interface](https://www.seeedstudio.com/1-69inch-240-280-Resolution-IPS-LCD-Display-Module-p-5755.html)
-
+- [Round Display for Xiao](https://www.seeedstudio.com/Seeed-Studio-Round-Display-for-XIAO-p-5638.html)
 
 #### Grove - Expansion Board - I2C Display
 
@@ -641,6 +641,90 @@ With the new firmware in place the device now shows the same demo screen we saw 
 
 <!-- <div style={{textAlign:'center'}}><img src="https://github.com/Cosmic-Bee/xiao-zephyr-examples/blob/main/images/esp32c3/spi_lcd.jpg?raw=true" style={{width:300, height:'auto'}}/></div> -->
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/wiki-ranger/Contributions/xiao_esp23c3_zephyr/spi_lcd.jpg" style={{width:600, height:'auto'}}/></div>
+
+
+#### Round Display for Xiao
+
+To test this setup we can use an existing sample with Zephyr:
+
+```
+west build -p always -b xiao_esp32c3 samples/drivers/display --  -DSHIELD=seeed_xiao_round_display
+```
+
+Enter bootloader mode and flash your device:
+```
+west flash
+```
+
+You'll see a display showing multiple colored corners with a black corner blinking.
+
+Another example demonstrates the use of the touchscreen:
+
+```
+west build -p always -b xiao_esp32c3 samples/modules/lvgl/demos --  -DSHIELD=seeed_xiao_round_display -DCONFIG_LV_Z_DEMO_MUSIC=y
+```
+
+The music demo shown here is only a portion of the actual screen but still demonstrates the touch screen in action. As you can see touching the play button turns on the music animation.
+
+You can see from the [shield file](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/shields/seeed_xiao_round_display/seeed_xiao_round_display.overlay) that this works by intefacing with the GC9A01 round display driver over SPI and the CHSC6X touch module over i2c.
+
+Let's dive into this example a bit to see how it works:
+```
+/ {
+    chosen {
+      zephyr,display = &gc9a01_xiao_round_display;
+    };
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&chsc6x_xiao_round_display>;
+	};
+};
+
+/*
+ * xiao_serial uses pins D6 and D7 of the Xiao, which are used respectively to
+ * control the screen backlight and as touch controller interrupt.
+ */
+&xiao_serial {
+	status = "disabled";
+};
+
+&xiao_i2c {
+	clock-frequency = < I2C_BITRATE_FAST >;
+
+	chsc6x_xiao_round_display: chsc6x@2e {
+		status = "okay";
+		compatible = "chipsemi,chsc6x";
+		reg = <0x2e>;
+		irq-gpios = <&xiao_d 7 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&xiao_spi {
+	status = "okay";
+	cs-gpios = <&xiao_d 1 GPIO_ACTIVE_LOW>, <&xiao_d 2 GPIO_ACTIVE_LOW>;
+
+	gc9a01_xiao_round_display: gc9a01@0 {
+		status = "okay";
+		compatible = "galaxycore,gc9x01x";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(100)>;
+		cmd-data-gpios = <&xiao_d 3 GPIO_ACTIVE_HIGH>;
+		pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+		width = <240>;
+		height = <240>;
+		display-inversion;
+	};
+};
+```
+
+This shield does the following:
+- Selects the GC9A01 display as the chosen Zephyr display
+- Sets the LVGL pointer logic to use the CHSC6X module
+- Disable serial as the pins are used for backlight and touch interrupt (as seen above via: `irq-gpios = <&xiao_d 7 GPIO_ACTIVE_LOW>;`)
+- Configures the round display for SPI using the D1, D2, and D3 pins
+
+The [sample logic](https://github.com/zephyrproject-rtos/zephyr/blob/main/samples/modules/lvgl/demos/src/main.c) relies on the [LVGL demo example code](https://github.com/lvgl/lvgl/tree/master/demos/music) which can be further examined.
 
 
 ## ✨ Contributor Project

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS.md
@@ -38,7 +38,7 @@ To program the Xiao RP2040 the following steps can be taken:
 1. Build an example or your application
 2. Plugin the Xiao RP2040
 3. Hold the button designated `B` (boot) and press `R` (reset) which will mount the device as a mass storage device
-4. Drag the uf2 file (ie `build/zephyr/zephyr.uf2`) generated during the build process to the device triggering an update
+4. Run the flash command to flash the device `west flash -r uf2`
 
 The simplest example is to run the "Hello World" sample on the board. After changing to the directory of the Zephyr install run the following commands.
 
@@ -46,9 +46,15 @@ The simplest example is to run the "Hello World" sample on the board. After chan
 west build -p always -b xiao_rp2040 samples/subsys/usb/console
 ```
 
-After this completes enter the `build/zephyr` folder and drag `zephyr.uf2` to your waiting RP2040 mounted drive. The device will reset after it receives the file and your machine should now be connected over USB for serial.
+Enter into bootloader mode as previously described and then flash the device:
 
-Find the port for your device by typing `ls /dev/tty*` and confirming which device appears when your USB has been plugged in.
+```
+west flash -r uf2
+```
+
+The device will reset after it receives the file and your machine should now be connected over USB for serial.
+
+Find the port for your device, for example on Ubuntu by typing `ls /dev/tty*`, and confirm which device appears when your USB has been plugged in.
 
 In my example I see `/dev/ttyACM0` as the newly added device.
 
@@ -130,6 +136,11 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/drivers/led_strip
 ```
 
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
+
 You'll see the onboard WS2812 LED cycling through red, blue and green continually in a flashing pattern.
 
 Let's dive into this example a bit to see why it works:
@@ -197,6 +208,11 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/basic/fade_led
 ```
 
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
+
 You'll see the blue light of the RGB onboard LED slowly fade and repeat the process again.
 
 Let's dive into this example a bit to see why it works:
@@ -231,9 +247,12 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/drivers/counter/alarm -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.conf
 ```
 
-You can find the uf2 file at `~/zephyrproject/zephyr/build/zephyr/zephyr.uf2`
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
 
-After uploading the uf2 file connect to monitor (after quickly resetting your board to ensure it restarts):
+Connect to monitor (after quickly resetting your board to ensure it restarts):
 ```
 screen /dev/ttyACM0 115200
 ```
@@ -273,9 +292,12 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/modules/tflite-micro/hello_world -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.conf
 ```
 
-You can find the uf2 file at `~/zephyrproject/zephyr/build/zephyr/zephyr.uf2`
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
 
-After uploading the uf2 file connect to monitor:
+Connect to monitor:
 ```
 screen /dev/ttyACM0 115200
 ```
@@ -325,6 +347,11 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/drivers/display -- -DSHIELD=seeed_xiao_expansion_board
 ```
 
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
+
 You'll see a display showing multiple black boxes and a blinking box in the corner given this display only supports two colors.
 
 Let's dive into this example a bit to see why it works:
@@ -366,7 +393,12 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/basic/button -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/console.overlay" -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.conf -DSHIELD=seeed_xiao_expansion_board
 ```
 
-After uploading the uf2 file connect to monitor:
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
+
+Connect to monitor:
 ```
 screen /dev/ttyACM0 115200
 ```
@@ -417,7 +449,12 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/basic/blinky_pwm -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/xiao-rp2040/xiao_expansion_buzzer.overlay"
 ```
 
-After uploading the uf2 file you should begin hearing a series of buzzes which change in sound as the sample runs its course.
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
+
+After flashing the uf2 file you should begin hearing a series of buzzes which change in sound as the sample runs its course.
 
 Let's look at why this works:
 ```
@@ -468,7 +505,12 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/subsys/fs/fs_sample -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/console.overlay" -DEXTRA_CONF_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/console.conf $(dirname $(pwd))/applications/xiao-zephyr-examples/xiao_expansion_sd.conf" -DSHIELD=seeed_xiao_expansion_board
 ```
 
-After uploading the uf2 file connect to monitor:
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
+
+Connect to monitor:
 ```
 screen /dev/ttyACM0 115200
 ```
@@ -533,7 +575,12 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/sensor/sht3xd -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/sht31.overlay $(dirname $(pwd))/applications/xiao-zephyr-examples/console.overlay" -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.conf
 ```
 
-After uploading the uf2 file connect to monitor:
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
+
+Connect to monitor:
 ```
 screen /dev/ttyACM0 115200
 ```
@@ -588,13 +635,15 @@ cd ~/zephyrproject/zephyr
 west build -p always -b xiao_rp2040 samples/drivers/display -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/240x280_st7789v2.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/240x280_st7789v2.conf
 ```
 
-When this completes, move the build file from `build/zephyr/zephyr.uf2` to the mounted Xiao RP2040 (remember you can hold the boot button down while plugging in to enter this state) which will reset the device with the new firmware.
+Enter bootloader mode and flash your device:
+```
+west flash -r uf2
+```
 
 With the new firmware in place the device now shows the same demo screen we saw previously on the expansion board just now updated for the color LCD over SPI.
 
 <!-- <div style={{textAlign:'center'}}><img src="https://github.com/Cosmic-Bee/xiao-zephyr-examples/blob/main/images/rp2040/spi_lcd.jpg?raw=true" style={{width:300, height:'auto'}}/></div> -->
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/wiki-ranger/Contributions/xiao_rp2040_zephyr/spi_lcd.jpg" style={{width:500, height:'auto'}}/></div>
-
 
 ## ✨ Contributor Project
 

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_SAMD21/XIAO-SAMD21-Zephyr-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_SAMD21/XIAO-SAMD21-Zephyr-RTOS.md
@@ -91,7 +91,7 @@ The simplest example is to run the "Hello World" sample on the board. After chan
 west build -p always -b seeeduino_xiao samples/subsys/usb/console
 ```
 
-Double press RESET or short the RST pin to the GND.
+Double press RESET or short the RST pin to the GND:
 
 ```
 west flash
@@ -178,7 +178,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b seeeduino_xiao samples/basic/blinky
 ```
 
-Double press RESET or short the RST pin to the GND.
+Double press RESET or short the RST pin to the GND:
 
 ```
 west flash
@@ -248,7 +248,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b seeeduino_xiao samples/subsys/usb/hid-mouse --  -DDTC_OVERLAY_FILE=/home/nineso/zephyrproject/zephyr/boards/shields/seeed_xiao_expansion_board/seeed_xiao_expansion_board.overlay
 ```
 
-Double press RESET or short the RST pin to the GND.
+Double press RESET or short the RST pin to the GND:
 
 ```
 west flash
@@ -288,7 +288,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b seeeduino_xiao samples/subsys/fs/littlefs -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/console.overlay" -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.conf
 ```
 
-Double press RESET or short the RST pin to the GND.
+Double press RESET or short the RST pin to the GND:
 
 ```
 west flash
@@ -373,7 +373,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b seeeduino_xiao samples/modules/tflite-micro/hello_world -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.conf
 ```
 
-Double press RESET or short the RST pin to the GND.
+Double press RESET or short the RST pin to the GND:
 
 ```
 west flash
@@ -429,7 +429,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b seeeduino_xiao samples/drivers/display -- -DSHIELD=seeed_xiao_expansion_board
 ```
 
-Double press RESET or short the RST pin to the GND.
+Double press RESET or short the RST pin to the GND:
 
 ```
 west flash
@@ -474,7 +474,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b seeeduino_xiao samples/basic/button -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/console.overlay" -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.conf -DSHIELD=seeed_xiao_expansion_board
 ```
 
-Double press RESET or short the RST pin to the GND.
+Double press RESET or short the RST pin to the GND:
 
 ```
 west flash
@@ -654,7 +654,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b seeeduino_xiao samples/sensor/sht3xd -- -DDTC_OVERLAY_FILE="$(dirname $(pwd))/applications/xiao-zephyr-examples/sht31.overlay $(dirname $(pwd))/applications/xiao-zephyr-examples/console.overlay" -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/console.conf
 ```
 
-Double press RESET or short the RST pin to the GND.
+Double press RESET or short the RST pin to the GND:
 
 ```
 west flash
@@ -728,7 +728,7 @@ cd ~/zephyrproject/zephyr
 west build -p always -b seeeduino_xiao samples/drivers/display -- -DDTC_OVERLAY_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/240x280_st7789v2.overlay -DEXTRA_CONF_FILE=$(dirname $(pwd))/applications/xiao-zephyr-examples/240x280_st7789v2.conf
 ```
 
-Double press RESET or short the RST pin to the GND.
+Double press RESET or short the RST pin to the GND:
 
 ```
 west flash


### PR DESCRIPTION
The Xiao round display shield works well with the xiao nrf52840, esp32s3, and esp32c3. The former had no issues with the SD function from it as well so included an example there. Was unable to get the demo working on the SAMD21 as it didn't have enough memory.

In addition I've switched the logic to rely on the `west flash -r uf2` versus the comments re: moving the uf2 file manually. 

This is unrelated to the task for adding the lvgl 9 support for the round display just saw the shield was added recently in passing so wanted to add it for completeness sake.