### PR TITLE
fix: added variant ATH20

### DIFF
--- a/docs/Edge/ODYSSEY/ODYSSEY_X86J4105/Application/Home-Assistant_for_ODYSSEY/Connect-Grove-to-Home-Assistant-ESPHome.md
+++ b/docs/Edge/ODYSSEY/ODYSSEY_X86J4105/Application/Home-Assistant_for_ODYSSEY/Connect-Grove-to-Home-Assistant-ESPHome.md
@@ -414,6 +414,7 @@ i2c:
 
 sensor:
   - platform: aht10
+    variant: AHT20
     temperature:
       name: "Temperature"
     humidity:


### PR DESCRIPTION
When using both `Grove - VOC and eCO2 Gas Sensor (SGP30)` and `Grove - Temperature and Humidity Sensor (AHT20)`, the temperature wouldn't work, when added this it worked