### PR TITLE
Fix incorrect import of gc module

### DIFF
--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_with_MicroPython.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_with_MicroPython.md
@@ -118,7 +118,7 @@ Go to Run-->Configure Interpreter, and ensure that the Interpreter tab in the Th
 Click "OK" on the dialog and you should be presented with the Micropython shell at the bottom of the thonny window as shown in the figure below.
 Enter scripy line by line to the Shell to get the flash and sram size:
 ```python
-import pc
+import gc
 gc.mem_free()
 
 import esp


### PR DESCRIPTION
```diff
- import pc
^^^^^^^^^^^ (incorrect, produces ModuleNotFoundError exception)
+ import gc
^^^^^^^^^^^ (import garbage collector, as intended)
gc.mem_free()

import esp
esp.flash_size()
```
Fix incorrect import of `gc`.