### PR TITLE
Update Grove-Multichannel_Gas_Sensor.md

### DIFF
--- a/docs/Sensor/Grove/Grove_Sensors/Gas/Grove-Multichannel_Gas_Sensor.md
+++ b/docs/Sensor/Grove/Grove_Sensors/Gas/Grove-Multichannel_Gas_Sensor.md
@@ -198,7 +198,7 @@ void setup()
 {
     Serial.begin(115200);  // start serial for output
     Serial.println("power on!");
-    gas.begin(0x04);//the default I2C address of the slave is 0x04
+    gas.begin(0x04);//the default I2C address of the slave is 0x04 ; for verison 2 of the multichannel gas sensor the i2c address is 0x08
     gas.powerOn();
     Serial.print("Firmware Version = ");
     Serial.println(gas.getVersion());


### PR DESCRIPTION
This commit adds a comment explicitly mentioning that the I2C address for the Grove Multichannel Gas Sensor v2.0 is 0x08. This clarification ensures that users correctly initialize the sensor when using the gas.begin(0x08); function in their code.

The update helps avoid confusion, as different versions of the sensor may have varying default I2C addresses. This  improvement makes the code more readable and easier to use, especially for those unfamiliar with the sensor’s communication settings.