### PR TITLE
Update A603 Carrier Board JP62 Docs with some clarity about the driver installation pre flash

### DIFF
--- a/docs/Edge/NVIDIA_Jetson/Carrier_Boards/A603/A603_Flash_JetPack.md
+++ b/docs/Edge/NVIDIA_Jetson/Carrier_Boards/A603/A603_Flash_JetPack.md
@@ -532,11 +532,9 @@ wget https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.3/releas
 
 **Step 2:** Assemble the Flashing Package
 
-Please note you will likely need to move the USB drivers you downloaded into the directory you have downloaded the Jetson Linux tools. For example if you opened your terminal and didn't change directories, you are likely in your user home `~/` folder, and if you downloaded the drivers via the browser, the drivers are likely in `~/Downloads`.
+Please note that we need to put the Nvidia driver and the peripheral drivers in the same directory, and then open the terminal in that directory and execute the following code:
 
-If you just copy and paste these terminal commands and the drivers are NOT in the same directory, the commands will still mostly execute but without the USB drivers. If you flash the OS without the USB drivers, you're going to be sad.
-
-Execute the following commands in order:
+<div align="center"><img width={800} src="https://files.seeedstudio.com/wiki/reComputer-Jetson/A603/driver_files_directory_layout.png" /></div>
 
 ```bash
 tar xf Jetson_Linux_r36.4.3_aarch64.tbz2

--- a/docs/Edge/NVIDIA_Jetson/Carrier_Boards/A603/A603_Flash_JetPack.md
+++ b/docs/Edge/NVIDIA_Jetson/Carrier_Boards/A603/A603_Flash_JetPack.md
@@ -531,6 +531,11 @@ wget https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.3/releas
 ```
 
 **Step 2:** Assemble the Flashing Package
+
+Please note you will likely need to move the USB drivers you downloaded into the directory you have downloaded the Jetson Linux tools. For example if you opened your terminal and didn't change directories, you are likely in your user home `~/` folder, and if you downloaded the drivers via the browser, the drivers are likely in `~/Downloads`.
+
+If you just copy and paste these terminal commands and the drivers are NOT in the same directory, the commands will still mostly execute but without the USB drivers. If you flash the OS without the USB drivers, you're going to be sad.
+
 Execute the following commands in order:
 
 ```bash


### PR DESCRIPTION
I had a problem where I didn't notice the tar command was failing for the USB drivers because the download wasn't in the right place. I subsequently flashed the Jetson without the USB drivers and you'll be surprised to find out that the USB ports didn't work. After much banging my head against various walls, I found out I messed up and didn't inject the drivers. I did and the USB ports worked. Woot.

I have created this PR to add a blurb about this in the docs to hopefully help others from going down this dark and twisted path.

[Issue Here](https://github.com/Seeed-Studio/wiki-documents/issues/2058)