### PR TITLE
Update os_version_control.md

### DIFF
--- a/docs/Edge/reCamera/reCamera 2002 Series/software/os_version_control.md
+++ b/docs/Edge/reCamera/reCamera 2002 Series/software/os_version_control.md
@@ -63,7 +63,7 @@ If you are developing OS and you have your own branch in github, you can also up
 ### Device management by local package
 You can also update/upgrade the firmware manually using the local ota package. The ota firmwares can be [downloaded here](https://github.com/Seeed-Studio/reCamera-OS/releases/). Use tools like scp to transfer the files to reCamera.
 ```bash
-scp sg2002_reCamera_0.1.3_emmc_ota.zip recamera@ip_address
+scp sg2002_reCamera_0.1.3_emmc_ota.zip recamera@ip_address:~/
 ```
 Then use the bash to deploy.
 ```bash


### PR DESCRIPTION
On Windows, `scp sg2002_reCamera_0.1.3_emmc_ota.zip recamera@ip_address` create a local file.
It don't transfer the file to reCamera.

**Log:**

```
C:\Users\takashi\Desktop\Seeed\reCamera>scp sg2002_reCamera_0.1.3_emmc_ota.zip recamera@192.168.42.1
        1 file(s) copied.

C:\Users\takashi\Desktop\Seeed\reCamera>dir sg2002_reCamera_0.1.3_emmc_ota.zip recamera*
 ドライブ C のボリューム ラベルは Local Disk です
 ボリューム シリアル番号は 7436-7447 です

 C:\Users\takashi\Desktop\Seeed\reCamera のディレクトリ

2024/12/27  18:54        86,574,176 sg2002_reCamera_0.1.3_emmc_ota.zip

 C:\Users\takashi\Desktop\Seeed\reCamera のディレクトリ

2024/12/27  18:54        86,574,176 recamera@192.168.42.1
               2 個のファイル         173,148,352 バイト
               0 個のディレクトリ  202,054,184,960 バイトの空き領域

C:\Users\takashi\Desktop\Seeed\reCamera>
```
