### PR TITLE
docs: Add initial NuttX Page for XIAO-ESP32S3

### DIFF
--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-NuttX-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-NuttX-RTOS.md
@@ -302,9 +302,12 @@ led_daemon: LED set 0x00
 
 Check the video below with the demo for gpio and leds:
 
-<div align="center"><video width={800} height={600} controls>
-    <source src="https://files.seeedstudio.com/wiki/XIAO-ESP32S3/img/xiao-esp32s3-nuttx-demo.mp4" type="video/mp4" />
-</video></div>
+<div style={{ maxWidth: '100%', textAlign: 'center' }}>
+  <video style={{ width: '100%', height: 'auto' }} controls>
+    <source src="https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/img/xiao-esp32s3-nuttx-demo.mp4" type="video/mp4" />
+  </video>
+</div>
+
 
 For more information about NuttX RTOS, please visit [NuttX Documentation](https://nuttx.apache.org/docs/latest/index.html)
 

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-NuttX-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-NuttX-RTOS.md
@@ -1,0 +1,328 @@
+---
+description: XIAO ESP32S3 With NuttX(RTOS)
+title: XIAO ESP32S3 With NuttX(RTOS)
+keywords:
+- xiao
+image: https://files.seeedstudio.com/wiki/XIAO-nRF52840-NuttX/nuttx.webp
+slug: /xiao-esp32s3-nuttx
+sidebar_position: 2
+last_update:
+    date: 04/08/2025
+    author: rcsim
+---
+
+# Seeed Studio XIAO ESP32S3 with NuttX(RTOS)
+
+## Introduction
+
+[NuttX](https://nuttx.apache.org/) is a mature real-time operating system (RTOS) widely recognized for its standards compliance and small footprint. One of NuttX's main features is its scalability, which allows it to be used in environments ranging from 8-bit microcontrollers to 64-bit systems. This flexibility is achieved through adherence to POSIX and ANSI standards, enabling you to experiment with similar NuttX features across a wide range of chips from different architectures, families, and semiconductor vendors.
+
+<div align="center"><img width ="{200}" src="https://files.seeedstudio.com/wiki/XIAO-RP2040/img/NuttX/nuttx.svg"/></div>
+
+Additionally, NuttX offers many advanced and useful features, such as USB, Ethernet, Audio, and Graphics subsystems. These characteristics make NuttX an attractive choice for developers seeking a versatile, robust RTOS capable of operating on various types of hardware.
+
+NuttX supports a vast and continually expanding number of boards. [The official documentation](https://nuttx.apache.org/docs/latest/platforms/) provides a comprehensive list of supported boards, organized by architecture and System-on-Chip (SoC) series.
+
+For instance, the [Seeed Studio XIAO ESP32S3](https://nuttx.apache.org/docs/latest/platforms/arm/esp32s3/boards/xiao-esp32s3/index.html) page in the NuttX documentation offers detailed descriptions of each supported feature and instructions on how to utilize them. Also there is a specific page in the NuttX documentation for [Espressif ESP32S3](https://nuttx.apache.org/docs/latest/platforms/xtensa/esp32s3/index.html) series chips, where you can find the list of MCUs and peripherals supported.
+
+## Installation
+
+The Nuttx documentation provides a [guide](https://nuttx.apache.org/docs/latest/quickstart/install.html) to different platforms.For Seeed Studio XIAO ESP32S3 please follow these steps:
+
+1. Download Espressif esptool(https://docs.espressif.com/projects/esptool/en/latest/esp32/): 
+
+    ```bash
+    ~/nuttxspace/nuttx$ esptool.py version
+    esptool.py v4.8.1
+    4.8.1
+    ```
+
+2. Create a workspace
+
+    ```bash
+    mkdir nuttxspace
+    ```
+
+3. Clone the repositories
+
+    ```bash
+    cd nuttxspace
+    git clone https://github.com/apache/nuttx.git nuttx
+    git clone https://github.com/apache/nuttx-apps apps
+    ```
+
+The Apache Nuttx it's divided into two project:
+
+- Nuttx: contains implemented the kernel, driver and subsystems.
+- Apps: contains a collection of tools, shells, network utilities, libraries and interpreters.
+
+## Applications
+
+To start an application it's necessary to load a configuration on NuttX, calling the command:
+
+```bash
+./tools/configurate.sh board_name:your_application
+```
+
+Also it's possible to check the list of board-supported a running the command:
+
+```bash
+./tools/configurate.sh -L
+```
+
+4. Build NuttX (build process will generate the firmware binaries, including nuttx.uf2):
+
+    ```bash
+    cd nuttx
+    make distclean
+    ./tools/configure.sh xiao-esp32s3:nsh
+    make V=1
+    ```
+5. The RESET and BOOT buttons can be used to enter “Bootloader” mode by press and hold the BOOT key while powering up and then press the RESET key once.
+
+6. Load the firmware using esptool.py:
+
+    ```bash
+    make flash ESPTOOL_PORT=/dev/ttyACM0 ESPTOOL_BINDIR=./
+    ```
+
+## Hands-on
+
+It's time to explore NuttX practically. In this session, two applications are available: USBNSH and COMBO.
+
+### NSH
+
+The NuttShell(NSH) is a shell system to be used in NuttX, similar to bash and other similar options. It supports a rich set of included commands, scripting and the ability to run your own applications as “builtin” (part of the same NuttX binary). The NSH configuration enables console at USB using 115200 bps.
+
+We can start the build process clearing the previous configuration
+
+```bash
+cd ~/nuttxspace/nuttx
+make distclean
+```
+
+Now we select the NSH configuration to the xiao-esp32s3 board:
+
+```bash
+./tools/configurate.sh xiao-esp32s3:usbnsh
+```
+
+Compile the source code.
+
+```bash
+make -j
+```
+
+Load the firmware into you board, reboot the board and connect NuttShell (NSH) console over USB using
+the CDC/ACM serial interface:
+
+```bash
+picocom -b 115200 /dev/ttyACM0
+```
+
+Access the NuttShell console:
+
+```bash
+NuttShell (NSH) NuttX-12.8.0
+nsh> uname -a
+NuttX 12.8.0 2c845426da-dirty Apr  6 2025 22:53:57 xtensa esp32s3-xiao
+nsh> 
+```
+
+Typing `?`, you will access the available options for commands and built-in applications.
+
+```bash
+nsh> ?
+help usage: [-v] [<cmd>]
+
+    .           cp          exec        ls          reboot      truncate    
+    [           cmp         exit        mkdir       rm          uname       
+    ?           dirname     expr        mkrd        rmdir       umount      
+    alias       date        false       mount       set         unset       
+    unalias     dd          fdinfo      mv          sleep       uptime      
+    basename    df          free        pidof       source      usleep      
+    break       dmesg       help        printf      test        xd          
+    cat         echo        hexdump     ps          time        
+    cd          env         kill        pwd         true        
+
+Builtin Apps:
+    getprime    hello       nsh         ostest      sh 
+```
+
+Let's say hello to NuttX, type `hello` and then it executes the command:
+
+```bash
+nsh> hello
+Hello, World!!
+```
+
+Congratulations, your first interation with NuttX was completed.
+
+### COMBO
+
+This configuration enables three example applications, gpio and leds. The General Purpose Input/Output (GPIO) is a microcontroller's most fundamental part, allowing it to connect to the external world. This way we will use the NSH to access and configure those pins as we wish. But first, let's clear the previous configuration.
+
+```bash
+cd ~/nuttxspace/nuttx
+make distclean
+```
+
+Select the combo configuration to the xiao-esp32s3 board.
+
+```bash
+./tools/configurate.sh xiao-esp32s3:combo
+```
+
+Compile de the source code.
+
+```bash
+make -j
+```
+
+Load the firmware into you board, run a serial communication program such as minicon or picocom:
+
+```bash
+picocom -b 115200 /dev/ttyACM0
+```
+
+```bash
+NuttShell (NSH) NuttX-12.8.0
+nsh>
+```
+
+To check which options are accepted to interact with this application, type `gpio -h`, and it will return a list of parameters.
+
+```bash
+NuttShell (NSH) NuttX-12.8.0
+nsh> gpio -h
+USAGE: gpio [-t <pintype>] [-w <signo>] [-o <value>] <driver-path>
+       gpio -h
+Where:
+ <driver-path>: The full path to the GPIO pin driver.
+ -t <pintype>:  Change the pin to this pintype (0-10):
+ -w <signo>:    Wait for a signal if this is an interrupt pin.
+ -o <value>:    Write this value (0 or 1) if this is an output pin.
+mation and exit.
+Pintypes:
+  0: GPIO_INPUT_PIN
+  1: GPIO_INPUT_PIN_PULLUP
+IO_INPUT_PIN_PULLDOWN
+  3: GPIO_OUTPUT_PIN
+  4: GPIO_OUTPUT_PIN_OPENDRAIN
+  5: GPIO_INTERRUPT_PIN
+  6: GPIO_INTERRUPT_HIGH_PIN
+  7: GPIO_INTERRUPT_LOW_PIN
+  8: GPIO_INTERRUPT_RISING_PIN
+  9: GPIO_INTERRUPT_FALLING_PIN
+ 10: GPIO_INTERRUPT_BOTH_PIN
+```
+
+To confirm the GPIO device files were created, type `ls/dev`. After typing, you can see some gpios were declared define on boards/arm/ra/xiao-esp32s3/include/board.h, which represent :
+
+- On board LED:
+  - Yellow            -> GPIO21
+ 
+- GPIOs
+  - 1 Input           -> GPIO1
+  - 1 Input w/ IRQ    -> GPIO3
+  - 1 Output          -> GPIO2
+
+```bash
+nsh> ls /dev
+/dev:
+ console
+ gpio0
+ gpio1
+ gpio2
+ null
+ ttyACM0
+ ttyS0
+ userleds
+ zero
+nsh> 
+```
+
+Following these commands to read GPIO1(/dev/gpio1) and GPIO3(/dev/gpio2) (with interruption)
+and write at GPIO2(/dev/gpio0).
+
+```bash
+NuttShell (NSH) NuttX-12.8.0
+nsh> gpio -o 1 /dev/gpio0
+Driver: /dev/gpio0
+  Output pin:    Value=0
+  Writing:       Value=1
+  Verify:        Value=1
+nsh> gpio -o 0 /dev/gpio0
+  Driver: /dev/gpio0
+  Output pin:    Value=1
+  Writing:       Value=0
+  Verify:        Value=0
+nsh> gpio /dev/gpio1
+Driver: /dev/gpio1
+  Input pin:     Value=0
+nsh> gpio /dev/gpio1
+Driver: /dev/gpio1
+  Input pin:     Value=1
+nsh> gpio /dev/gpio1
+Driver: /dev/gpio1
+  Input pin:     Value=0
+nsh> gpio -w 1 /dev/gpio2
+Driver: /dev/gpio2
+  Interrupt pin: Value=0
+  Verify:        Value=1
+nsh> gpio -w 1 /dev/gpio2
+Driver: /dev/gpio2
+  Interrupt pin: Value=0
+  Verify:        Value=1
+```
+
+The USERLEDS is a subsystem that allows to control of the LEDs with single operation. Also, you can use commands-line like the printf. In this demo we will turn on and turn off the Yellow LED on-board each 1 seconds.
+
+Typing `leds`, you observe the LEDs blinky same time.
+
+```bash
+NuttShell (NSH) NuttX-12.8.0
+nsh> leds
+leds_main: Starting the led_daemon
+leds_main: led_daemon started
+
+led_daemon (pid# 7): Running
+led_daemon: Opening /dev/userleds
+led_daemon: Supported LEDs 0x01
+led_daemon: LED set 0x01
+nsh> led_daemon: LED set 0x00
+led_daemon: LED set 0x01
+led_daemon: LED set 0x00
+led_daemon: LED set 0x01
+led_daemon: LED set 0x00
+led_daemon: LED set 0x01
+led_daemon: LED set 0x00
+
+```
+
+Check the video below with the demo for gpio and leds:
+
+<div align="center"><video width={800} height={600} controls>
+    <source src="https://files.seeedstudio.com/wiki/XIAO-ESP32S3/img/xiao-esp32s3-nuttx-demo.mp4" type="video/mp4" />
+</video></div>
+
+For more information about NuttX RTOS, please visit [NuttX Documentation](https://nuttx.apache.org/docs/latest/index.html)
+
+## ✨ Contributor Project
+
+- This project is supported by the Seeed Studio [Contributor Project](https://github.com/orgs/Seeed-Studio/projects/6/views/1?pane=issue&itemId=30957479).
+- A special thanks to [Rodrigo](https://github.com/orgs/Seeed-Studio/projects/6/views/1?pane=issue&itemId=92947609) for his dedicated efforts. Your work will be [exhibited](https://wiki.seeedstudio.com/contributors/).
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="button_tech_support_container">
+<a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+<a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+</div>
+
+<div class="button_tech_support_container">
+<a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+<a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+</div>

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RA4M1/XIAO-RA4M1-NuttX-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RA4M1/XIAO-RA4M1-NuttX-RTOS.md
@@ -286,9 +286,11 @@ led_daemon: LED set 0x00
 
 Check the video below with the demo for gpio and leds:
 
-<div align="center"><video width={800} height={600} controls>
+<div style={{ maxWidth: '100%', textAlign: 'center' }}>
+  <video style={{ width: '100%', height: 'auto' }} controls>
     <source src="https://files.seeedstudio.com/wiki/XIAO-R4AM1/img/xiao-ra4m1-nuttx-demo.mp4" type="video/mp4" />
-</video></div>
+  </video>
+</div>
 
 For more information about NuttX RTOS, please visit [NuttX Documentation](https://nuttx.apache.org/docs/latest/index.html)
 

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2350/XIAO-RP2350-NuttX-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2350/XIAO-RP2350-NuttX-RTOS.md
@@ -335,9 +335,12 @@ nsh> ws2812
 
 Check the video below with the demo for gpio, leds and ws2812 example:
 
-<div align="center"><video width={800} height={600} controls>
+<div style={{ maxWidth: '100%', textAlign: 'center' }}>
+  <video style={{ width: '100%', height: 'auto' }} controls>
     <source src="https://files.seeedstudio.com/wiki/XIAO-RP2350/img/Nuttx/xiao-rp2350-nuttx-demo.mp4" type="video/mp4" />
-</video></div>
+  </video>
+</div>
+
 
 For more information about NuttX RTOS, please visit [NuttX Documentation](https://nuttx.apache.org/docs/latest/index.html)
 

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF52840-Sense/XIAO-nRF52840-NuttX-RTOS.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF52840-Sense/XIAO-nRF52840-NuttX-RTOS.md
@@ -335,9 +335,12 @@ led_daemon: LED set 0x07
 
 Check the video below with the demo for gpio and leds example:
 
-<div align="center"><video width={800} height={600} controls>
+<div style={{ maxWidth: '100%', textAlign: 'center' }}>
+  <video style={{ width: '100%', height: 'auto' }} controls>
     <source src="https://files.seeedstudio.com/wiki/XIAO-nRF52840-NuttX/nrf52840_nuttx_demo.mp4" type="video/mp4" />
-</video></div>
+  </video>
+</div>
+
 
 For more information about NuttX RTOS, please visit [NuttX Documentation](https://nuttx.apache.org/docs/latest/index.html)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -1150,8 +1150,14 @@ const sidebars = {
                 'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-with-CircuitPython',
               ],
             },
-            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-with-NuttX-RTOS',
-            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS',
+            {
+              type: 'category',
+              label: 'RTOS',
+              items: [
+                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-with-NuttX-RTOS',
+                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS',
+              ],
+            },
             {
               type: 'category',
               label: 'Embedded ML',
@@ -1176,8 +1182,14 @@ const sidebars = {
           label: 'XIAO nRF52840 Series',
           items: [
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF52840-Sense/XIAO_BLE',
-            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF52840-Sense/XIAO-nRF52840-NuttX-RTOS',
-            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF52840-Sense/XIAO-nRF52840-Zephyr-RTOS',
+            {
+              type: 'category',
+              label: 'RTOS',
+              items: [
+                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF52840-Sense/XIAO-nRF52840-NuttX-RTOS',
+                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF52840-Sense/XIAO-nRF52840-Zephyr-RTOS',
+              ],
+            },
             {
               type: 'category',
               label: 'Programming Language',
@@ -1237,6 +1249,7 @@ const sidebars = {
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_Getting_Started',
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_Pin_Multiplexing',
      //       'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_MicroPython',
+            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO-ESP32C3-Zephyr',
             {
               type: 'category',
               label: 'Wireless Connection',
@@ -1249,7 +1262,6 @@ const sidebars = {
               type: 'category',
               label: 'Programming Language',
               items: [
-            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO-ESP32C3-Zephyr',
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_with_CircuitPython',
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_with_MicroPython',
               ],
@@ -1327,8 +1339,6 @@ const sidebars = {
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Getting_Started',
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Pin_Multiplexing',
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Sense_Consumption',
-            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-NuttX-RTOS',
-  
             {
               type: 'category',
               label: 'Wireless Connection',
@@ -1341,11 +1351,18 @@ const sidebars = {
               type: 'category',
               label: 'Programming Language',
               items: [
-                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-Zephyr-RTOS',
-                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-FreeRTOS',
                 'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_with_MicroPython',
                 'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_CircuitPython',
                 // 'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Micropython',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'RTOS',
+              items: [
+                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-Zephyr-RTOS',
+                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-FreeRTOS',
+                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-NuttX-RTOS',
               ],
             },
             {

--- a/sidebars.js
+++ b/sidebars.js
@@ -1151,9 +1151,14 @@ const sidebars = {
                 'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-with-CircuitPython',
               ],
             },
-          
-            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-with-NuttX-RTOS',
-            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS',
+            {
+              type: 'category',
+              label: 'RTOS',
+              items: [
+                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-with-NuttX-RTOS',
+                'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO-RP2040-Zephyr-RTOS',
+              ],
+            },
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_RP2040/XIAO_RP2040_with_PlatformIO',
             {
               type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1327,6 +1327,7 @@ const sidebars = {
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Getting_Started',
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Pin_Multiplexing',
             'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Sense_Consumption',
+            'Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO-ESP32S3-NuttX-RTOS',
   
             {
               type: 'category',


### PR DESCRIPTION
This PR adds the NuttX Page support for XIAO-ESP32S3.

Basics of NuttX
How to Install NuttX
How to build and load NuttX on XIAO-ESP32S3.
A Demo video running NuttX on XIAO-ESP32S3.