### PR TITLE
Update XIAO_ESP32S3_Pin_Multiplexing.md

### DIFF
--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Pin_Multiplexing.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Pin_Multiplexing.md
@@ -645,7 +645,7 @@ void setup()
     MySerial0.print("MySerial0");
 
     // And configure MySerial1 on pins RX=D9, TX=D10
-    MySerial1.begin(115200, SERIAL_8N1, 9, 10);
+    MySerial1.begin(115200, SERIAL_8N1, D9, D10);
     MySerial1.print("MySerial1");
 }
 


### PR DESCRIPTION
### Description

This pull request fixes the example code for configuring the second hardware serial port (`MySerial1`) on the Seeed Studio XIAO ESP32S3.

#### Changes Made:
- Corrected the `Serial.begin()` statement to match the correct order of parameters: `(baud rate, config, RX pin, TX pin)`.
- Updated the example line to:

  ```cpp
  MySerial1.begin(115200, SERIAL_8N1, D9, D10);

This ensures the serial port is correctly initialized using the intended RX (D9) and TX (D10) pins with a baud rate of 115200 and 8N1 configuration.
