### PR TITLE
Fixed some issues in the ESPhome firmware of MR60BHA2

### DIFF
--- a/docs/Sensor/mmWave_radar_sensor/mr60bha2-mmwave-kit/ha_with_mr60bha2.md
+++ b/docs/Sensor/mmWave_radar_sensor/mr60bha2-mmwave-kit/ha_with_mr60bha2.md
@@ -231,35 +231,29 @@ To get started with ESPHome, follow these steps:
   ```yaml showLineNumbers title=example/mr60bha2.yaml
   # template from https://github.com/limengdu/MR60BHA2_ESPHome_external_components
 
-  substitutions:
-    name: "seeedstudio-mr60bha2-kit"
-    friendly_name: "Seeed Studio MR60BHA2 Kit"
+  # substitutions:
+  #   name: "seeedstudio-mr60bha2-kit"
+  #   friendly_name: "Seeed Studio MR60BHA2 Kit"
 
   esphome:
-    name: "${name}"
-    friendly_name: "${friendly_name}"
-    name_add_mac_suffix: true
-    project:
-      name: "seeedstudio.mr60bha2_kit"
-      version: "2.0"
-    platformio_options:
-      board_upload.maximum_size: 4194304
-    min_version: "2024.3.2" # Fix logger compile error on ESP32-C6 esphome#6323
+    name: seeed-mr60bha2
+    friendly_name: seeed-mr60bha2
 
   esp32:
     board: esp32-c6-devkitc-1
-    variant: esp32c6
-    flash_size: 4MB # upload.flash_size
+    # variant: esp32c6
+    # flash_size: 4MB # upload.flash_size
     framework:
       type: esp-idf
 
-  external_components:
-    - source:
-        type: git
-        url: https://github.com/limengdu/MR60BHA2_ESPHome_external_components
-        ref: main
-      components: [ seeed_mr60bha2 ]
-      refresh: 0s
+  # If it is indicated that this library does not exist, you can choose to remove this comment.
+  # external_components:
+  #   - source:
+  #       type: git
+  #       url: https://github.com/limengdu/MR60BHA2_ESPHome_external_components
+  #       ref: main
+  #     components: [ seeed_mr60bha2 ]
+  #     refresh: 0s
 
   # Enable logging
   logger:
@@ -268,22 +262,22 @@ To get started with ESPHome, follow these steps:
 
   # Enable Home Assistant API
   api:
+    encryption:
+      key: "ThVm4U+W/dxSbk9yHbeWuDnkGZJ5R2Bsb62hSaNuc2w=" # The content in "Show API key"
 
   ota:
     - platform: esphome
+      password: "84fd31bc8c1ba852d687e90ef654c232"  # Your own password as specified by ESPhome
 
   wifi:
-    # Enable fallback hotspot (captive portal) in case wifi connection fails
+    ssid: "Maker_HA_2.4G"
+    password: "maker2025"
+
     ap:
-      ssid: "seeedstudio-mr60bha2"
+      ssid: "seeed-mr60bha2 Fallback Hotspot"
+      password: "rKa7nM3Pe4vX"
 
   captive_portal:
-
-  # For XIAO ESP32C6 Onboard LED
-  # light:
-  #   - platform: status_led
-  #     name: "Switch state"
-  #     pin: GPIO15
 
   light:
     - platform: esp32_rmt_led_strip
@@ -291,7 +285,6 @@ To get started with ESPHome, follow these steps:
       name: "Seeed MR60BHA2 RGB Light"
       pin: GPIO1
       num_leds: 1
-      rmt_channel: 0
       rgb_order: GRB
       chipset: ws2812
 
@@ -314,8 +307,9 @@ To get started with ESPHome, follow these steps:
 
   binary_sensor:
     - platform: seeed_mr60bha2
-      people_exist:
+      has_target:
         name: "Person Information"
+
 
   sensor:
     - platform: bh1750
@@ -329,8 +323,8 @@ To get started with ESPHome, follow these steps:
         name: "Real-time heart rate"
       distance:
         name: "Distance to detection object"
-      target_num:
-        name: "Target Number"
+      num_targets:
+        name: "Target number"
   ```
 
 3. **Customize Functionality**: You can enhance the sensor's capabilities by exploring various features available in ESPHome, allowing for flexible adjustments to suit your specific needs.

--- a/docs/es/Sensor/mmWave_radar_sensor/mr60bha2-mmwave-kit/es_ha_with_mr60bha2.md
+++ b/docs/es/Sensor/mmWave_radar_sensor/mr60bha2-mmwave-kit/es_ha_with_mr60bha2.md
@@ -1,7 +1,7 @@
 ---
 title: Sensor de Respiración-Latido MR60BHA2 con Home Assistant
 description: | 
-  Sensor de Latido mmWave MR60BHA2 con Home Assistant
+  Sensor mmWave de Latido MR60BHA2 con Home Assistant
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /es/ha_with_mr60bha2
 keywords:
@@ -15,17 +15,17 @@ last_update:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::danger Acerca del alcance del uso del radar en Home Assistant
-Las actualizaciones del firmware del RADAR y las actualizaciones del YAML de ESPHome son dos piezas de software diferentes. El YAML de ESPHome se puede actualizar por OTA, mientras que la placa RADAR SOLO se puede actualizar mediante USB dentro de la carcasa, con el software especializado que proporciona SEEED. Puede personalizar el software de ESPHome, pero [NO puede personalizar el firmware del RADAR](https://wiki.seeedstudio.com/getting_started_with_mr60bha2_mmwave_kit/#module-firmware-upgrade). Seeed Studio solo permite la personalización del RADAR si está realizando una aplicación comercial.
+:::danger Sobre el alcance del uso de radar en Home Assistant
+Las actualizaciones del firmware del RADAR y las actualizaciones del YAML de ESPHome son 2 piezas de software diferentes. El YAML de ESPHome puede actualizarse OTA, mientras que la placa RADAR SOLO puede actualizarse vía USB dentro de la carcasa, con software especializado que SEEED proporciona. Puedes personalizar el software ESPHome, [NO puedes personalizar el firmware del RADAR](https://wiki.seeedstudio.com/es/getting_started_with_mr60bha2_mmwave_kit/#module-firmware-upgrade). Seeed Studio solo permite personalización del RADAR si estás haciendo una aplicación comercial.
 :::
 
-## Introducción {#introduction}
+## Introducción {#introducción}
 
 El MR60BHA2 es un módulo sensor de detección de respiración y latido mmWave de 60GHz diseñado para integración con el microcontrolador XIAO ESP32C6. Este sensor avanzado utiliza tecnología de ondas milimétricas para proporcionar monitoreo no invasivo de signos vitales y detección de presencia.
 
-Esta guía tiene como objetivo proporcionar un recorrido claro y completo para integrar el sensor mmWave MR60BHA2 con Home Assistant usando el microcontrolador XIAO ESP32C6. Siguiendo esta guía, los usuarios aprenderán cómo configurar el sensor para detección de latidos, conectarlo a su entorno de Home Assistant, y utilizar ESPHome para gestionar y monitorear el dispositivo de manera efectiva.
+Esta guía tiene como objetivo proporcionar un recorrido claro y completo para integrar el Sensor mmWave MR60BHA2 con Home Assistant usando el microcontrolador XIAO ESP32C6. Siguiendo esta guía, los usuarios aprenderán cómo configurar el sensor para detección de latidos, conectarlo a su entorno Home Assistant, y utilizar ESPHome para gestionar y monitorear el dispositivo de manera efectiva.
 
-Esta integración permite a los usuarios mejorar sus sistemas de hogar inteligente con capacidades de detección avanzadas, habilitando respuestas automatizadas y monitoreo en tiempo real para diversas aplicaciones.
+Esta integración permite a los usuarios mejorar sus sistemas de hogar inteligente con capacidades de detección avanzadas, habilitando respuestas automatizadas y monitoreo en tiempo real para varias aplicaciones.
 
 <div><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-sensor-light-on.png" style={{"border-radius": '6px'}}/></div>
 
@@ -49,42 +49,42 @@ Esta integración permite a los usuarios mejorar sus sistemas de hogar inteligen
    </table>
 </div>
 
-### Sensor MR60BHA2 mmWave con XIAO ESP32C6
+### Sensor mmWave MR60BHA2 con XIAO ESP32C6
 
-Para integrar efectivamente el Sensor MR60BHA2 mmWave con Home Assistant usando el XIAO ESP32C6, sigue estos pasos esenciales:
+Para integrar efectivamente el Sensor mmWave MR60BHA2 con Home Assistant usando el XIAO ESP32C6, sigue estos pasos esenciales:
 
 :::caution
 Por favor asegúrate de haber [actualizado el firmware](/es/getting_started_with_mr60bha2_mmwave_kit#module-firmware-upgrade) del módulo MR60BHA2 a la versión más reciente.  
-El firmware más reciente añade la función de detección de presencia humana y detección de personal.
+El firmware más reciente añade detección de presencia humana y función de detección de personal.
 :::
 
-1. **[Configurar Home Assistant](#setting-up-home-assistant)**: Comienza instalando y configurando Home Assistant para gestionar tus dispositivos de hogar inteligente, asegurando una conexión perfecta con el sensor.
-2. **[Conectar el Sensor MR60BHA2](#discovering-and-adding-the-device-in-home-assistant)**: Aprende cómo descubrir y añadir el Sensor MR60BHA2 a tu configuración de Home Assistant, habilitando el monitoreo en tiempo real de signos vitales.
-3. **[Monitorear Datos del Sensor](#sensor-data-monitoring)**: Una vez integrado, puedes monitorear los datos del sensor efectivamente, permitiendo obtener información sobre patrones de frecuencia cardíaca y respiración.
-4. **[Implementar Automatización](#implementing-automation-in-home-assistant)**: Explora las potentes funciones de automatización de Home Assistant para crear acciones responsivas basadas en los datos del sensor, mejorando tu entorno de hogar inteligente.
-5. **[Modificar Firmware con ESPHome](#modifying-the-firmware-with-esphome)**: Utiliza ESPHome para personalizar la funcionalidad del sensor, adaptándolo para satisfacer tus necesidades específicas para mayor flexibilidad y control.
+1. **[Configurar Home Assistant](#configurar-home-assistant)**: Comienza instalando y configurando Home Assistant para gestionar tus dispositivos de hogar inteligente, asegurando una conexión perfecta con el sensor.
+2. **[Conectar el Sensor MR60BHA2](#descubrir-y-añadir-el-dispositivo-en-home-assistant)**: Aprende cómo descubrir y añadir el Sensor MR60BHA2 a tu configuración de Home Assistant, habilitando monitoreo en tiempo real de signos vitales.
+3. **[Monitorear Datos del Sensor](#monitoreo-de-datos-del-sensor)**: Una vez integrado, puedes monitorear los datos del sensor de manera efectiva, permitiendo obtener información sobre patrones de frecuencia cardíaca y respiración.
+4. **[Implementar Automatización](#implementar-automatización-en-home-assistant)**: Explora las poderosas características de automatización de Home Assistant para crear acciones responsivas basadas en los datos del sensor, mejorando tu entorno de hogar inteligente.
+5. **[Modificar Firmware con ESPHome](#modificar-el-firmware-con-esphome)**: Utiliza ESPHome para personalizar la funcionalidad del sensor, adaptándolo para satisfacer tus necesidades específicas para mayor flexibilidad y control.
 
-Estos pasos te guiarán a través del proceso de integración, ayudándote a aprovechar al máximo tu configuración del Sensor MR60BHA2 mmWave y XIAO ESP32C6.
+Estos pasos te guiarán a través del proceso de integración, ayudándote a aprovechar al máximo tu configuración del Sensor mmWave MR60BHA2 y XIAO ESP32C6.
 
-## Comenzando {#getting-started}
+## Comenzando {#comenzando}
 
 :::note Atención
-Ten en cuenta que cuando nos referimos a actualizaciones o modificaciones de firmware, estamos abordando específicamente el firmware en el XIAO ESP32C6.
+Por favor ten en cuenta que cuando nos referimos a actualizaciones o modificaciones de firmware, estamos específicamente abordando el firmware en el XIAO ESP32C6.
 :::
 
-Para integrar exitosamente el Sensor MR60BHA2 mmWave con Home Assistant, necesitarás los siguientes componentes:
+Para integrar exitosamente el Sensor mmWave MR60BHA2 con Home Assistant, necesitarás los siguientes componentes:
 
 - **Home Assistant**: Una plataforma de hogar inteligente que gestionará los datos del sensor.
-- **Complemento ESPHome**: Firmware que permite la configuración y gestión fácil de dispositivos ESP32.
+- **Complemento ESPHome**: Firmware que permite configuración y gestión fácil de dispositivos ESP32.
 
-### Paso 1: Configurando Home Assistant {#setting-up-home-assistant}
+### Paso 1: Configurar Home Assistant {#configurar-home-assistant}
 
 1. **Instalación**: Para un rendimiento óptimo, se recomienda instalar [Home Assistant OS](https://www.home-assistant.io/installation/) en una Máquina Virtual o Raspberry Pi. Sigue la guía de instalación oficial en el sitio web de Home Assistant.
-2. **Habilitando el Complemento ESPHome**:
+2. **Habilitar el Complemento ESPHome**:
    - Accede al panel de Home Assistant.
-   - Navega a la sección "Add-ons" y busca el complemento ESPHome.
-   - Haz clic en "Install" y luego "Start" para habilitarlo.
-   - Una vez instalado, configura el complemento para asegurar la comunicación adecuada con el XIAO ESP32C6.
+   - Navega a la sección "Complementos" y busca el complemento ESPHome.
+   - Haz clic en "Instalar" y luego "Iniciar" para habilitarlo.
+   - Una vez instalado, configura el complemento para asegurar comunicación adecuada con el XIAO ESP32C6.
 
 :::caution Atención
 Debido a los nuevos iconos, por favor instala la versión 2024.12.0 y superior del plugin ESPHome.
@@ -92,35 +92,35 @@ Debido a los nuevos iconos, por favor instala la versión 2024.12.0 y superior d
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-enabling_ESPHome_Add-on.png" style={{width:1000, height:'auto'}}/></div>
 
-Al reunir los componentes necesarios y configurar Home Assistant con el complemento ESPHome, estarás listo para proceder con la integración del Sensor MR60BHA2 mmWave.
+Al reunir los componentes necesarios y configurar Home Assistant con el complemento ESPHome, estarás listo para proceder con la integración del Sensor mmWave MR60BHA2.
 
 :::tip instalar Home Assistant
-También hemos escrito cómo instalar Home Assistant para algunos de los productos de Seeed Studio, por favor consúltalos.
+También hemos escrito cómo instalar Home Assistant para algunos productos de Seeed Studio, por favor consúltalos.
 
 - [Comenzando con Home Assistant en ODYSSEY-X86](/es/ODYSSEY-X86-Home-Assistant)
 - [Comenzando con Home Assistant en reTerminal](/es/reTerminal_Home_Assistant)
 - [Comenzando con Home Assistant en LinkStar H68K/reRouter CM4](/es/h68k-ha-esphome)
 :::
 
-### Paso 2: Preparando el Kit
+### Paso 2: Preparar el Kit
 
 Por defecto, tu dispositivo (XIAO ESP32C6) viene pre-cargado con firmware para detección de respiración y frecuencia cardíaca. Sin embargo, hay dos escenarios donde podrías necesitar actualizar el firmware:
 
-1. **Re-flashear el Firmware**: Si el firmware existente está corrupto o necesitas empezar de nuevo.
+1. **Re-cargar el Firmware**: Si el firmware existente está corrupto o necesitas empezar de nuevo.
 2. **Actualizar el Firmware**: Si hay una versión más nueva del firmware con funcionalidad mejorada.
 
-Hay dos métodos simples para flashear el firmware:
+Hay dos métodos simples para cargar el firmware:
 
 :::caution
-Firefox no soporta el flasheo de firmware en dispositivos ESP. Por favor usa Google Chrome o Microsoft Edge en su lugar.
+Firefox no soporta cargar firmware en dispositivos ESP. Por favor usa Google Chrome o Microsoft Edge en su lugar.
 :::
 
 <Tabs>
-<TabItem value='Web Tool'>
+<TabItem value='Herramienta Web'>
 
-Puedes usar esta [Herramienta Web](https://limengdu.github.io/MR60BHA2_ESPHome_external_components/) para un método fácil y directo de flashear tu firmware. Simplemente sigue las instrucciones en pantalla.
+Puedes usar esta [Herramienta Web](https://limengdu.github.io/MR60BHA2_ESPHome_external_components/) para un método fácil y directo de cargar tu firmware. Simplemente sigue las instrucciones en pantalla.
 
-- Haz clic en el botón `CONNECT` para iniciar la conexión. La herramienta actualizará automáticamente el firmware.
+- Haz clic en el botón `CONECTAR` para iniciar la conexión. La herramienta actualizará automáticamente el firmware.
 
 Si algo sale mal, sigue los pasos de solución de problemas en pantalla o cambia al método `ESPHome Web` para completar el proceso.
 
@@ -129,22 +129,22 @@ Si algo sale mal, sigue los pasos de solución de problemas en pantalla o cambia
 
 Para este método, necesitarás descargar el archivo de firmware `bin` desde [aquí](https://github.com/limengdu/MR60BHA2_ESPHome_external_components/releases)(necesitarás descomprimir el archivo descargado).
 
-1. Conecta el kit del sensor a tu PC.
+1. Conecta el kit sensor a tu PC.
 2. Visita la página [ESPHome Web](https://web.esphome.io/).
 3. Selecciona el archivo de firmware con el sufijo `*.factory.bin`.
 
-Mira el siguiente video para un recorrido detallado del flasheo del firmware vía ESPHome Web:
+Mira el siguiente video para un recorrido detallado de cargar el firmware vía ESPHome Web:
 
-<iframe class="youtube-video-r" src="https://www.youtube.com/embed/J3AVeZCoLK8?si=1AeNTsdmbTvMl0Nq" title="Install firmware via ESPHome Web" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe class="youtube-video-r" src="https://www.youtube.com/embed/J3AVeZCoLK8?si=1AeNTsdmbTvMl0Nq" title="Instalar firmware vía ESPHome Web" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 </TabItem>
 </Tabs>
 
-Con cualquiera de los métodos, tendrás tu firmware actualizado y listo para la integración con Home Assistant.
+Con cualquiera de los métodos, tendrás tu firmware actualizado y listo para integración con Home Assistant.
 
 #### Conectar al punto de acceso del kit
 
-Con el firmware, podrías encender el kit del sensor, y aparecerá un punto de acceso Wi-Fi: `seeedstudio-mr60bha2`.
+Con el firmware, podrías encender el kit sensor, y aparecerá un punto de acceso Wi-Fi: `seeedstudio-mr60bha2`.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/hotspot-name.png" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
 
@@ -154,37 +154,38 @@ Navega a `192.168.4.1` para configurar los ajustes de red local de tu servidor H
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-enter-psw.JPEG" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
 
-### Paso 3: Descubrir y Agregar el Dispositivo en Home Assistant {#discovering-and-adding-the-device-in-home-assistant}
+### Paso 3: Descubrir y Añadir el Dispositivo en Home Assistant {#descubrir-y-añadir-el-dispositivo-en-home-assistant}
 
-En esta sección, revisaremos el proceso usando la aplicación de Home Assistant, donde la lógica es la misma que en la web.
+En esta sección, repasaremos el proceso usando la aplicación Home Assistant, donde la lógica es la misma que en la web.
 
-1. **Abrir la Aplicación**: Una vez que inicies la aplicación, selecciona tu servidor de Home Assistant. La aplicación encontrará automáticamente tu servidor.
+1. **Abrir la Aplicación**: Una vez que inicies la aplicación, selecciona tu servidor Home Assistant. La aplicación encontrará automáticamente tu servidor.
 
   <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-server-option.JPG" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
 2. **Crear una Cuenta**: Si no has creado una cuenta, necesitarás hacerlo. Después de eso, inicia sesión con tus credenciales.
   <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-login.JPG" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
-3. **Navegar a la Página de Integraciones**: Una vez que hayas iniciado sesión, ve a la página de "Integraciones" en Home Assistant. Si has instalado el complemento de ESPHome y tanto el XIAO ESP32C6 como tu servidor de Home Assistant están en la misma red, deberías ver el dispositivo `Seeed Studio MR60BHA2 Kit {device-mac-address}` aparecer bajo dispositivos descubiertos.
-4. **Agregar el Dispositivo**: Haz clic para agregar el dispositivo a tu configuración de Home Assistant.
+3. **Navegar a la Página de Integración**: Una vez que hayas iniciado sesión, ve a la página "Integraciones" en Home Assistant. Si has instalado el complemento ESPHome y tanto el XIAO ESP32C6 como tu servidor Home Assistant están en la misma red, deberías ver el dispositivo `Seeed Studio MR60BHA2 Kit {device-mac-address}` aparecer bajo dispositivos descubiertos.
+4. **Añadir el Dispositivo**: Haz clic para añadir el dispositivo a tu configuración de Home Assistant.
+
   <div class="img-container" align="center">
     <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-find.JPG" alt="find device"/>
     <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-submit.JPG" alt="submit a device"/>
     <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-add.JPG" alt="area"/>
     <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-addon-device.JPG" alt="addon"/>
   </div>
-  
-  Haz clic en el botón `CONFIGURE`, confirma presionando el botón `SUBMIT`, y asigna el dispositivo a tu área preferida (por ejemplo, Dormitorio). Después de esto, el dispositivo será gestionado a través de tu integración de ESPHome, habilitando control y monitoreo completo en Home Assistant.
 
-## Monitoreo y Control {#monitoring-and-control}
+  Haz clic en el botón `CONFIGURE`, confirma presionando el botón `SUBMIT`, y asigna el dispositivo a tu área preferida (por ejemplo, Dormitorio). Después de esto, el dispositivo será gestionado a través de tu integración ESPHome, habilitando control y monitoreo completo en Home Assistant.
+
+## Monitoreo y Control {#monitoreo-y-control}
 
 Siguiendo los pasos anteriores, habrás descubierto y agregado exitosamente el Sensor MR60BHA2 a tu Home Assistant, habilitando monitoreo y control en tiempo real.
 
-### Monitoreo de Datos del Sensor
+### Monitoreo de datos del Sensor
 
-Ahora que el sensor está agregado al "Dormitorio", navega a la pestaña "Resumen". Verás la tarjeta mmWave mostrada en la sección del Dormitorio.
+Ahora que el sensor está agregado al "Dormitorio", navega a la pestaña "Overview". Verás la tarjeta mmWave mostrada en la sección del Dormitorio.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-sensor-data-with-person-detection.png" style={{width:680, height:'auto', "border-radius": '15px'}}/></div>
 
-### Control de Luz RGB
+### Control de luz RGB
 
 En esta sección, exploraremos cómo controlar una luz RGB.
 
@@ -199,22 +200,22 @@ Haz clic en la caja correspondiente para controlar directamente la luz RGB:
 
 <iframe class="video-mp4" src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-control-light.mp4" title="Home Assistant Control RGB Light" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture;" allowfullscreen></iframe>
 
-### Próximos Pasos {#next-steps}
+### Próximos Pasos {#próximos-pasos}
 
 Ahora que has integrado exitosamente el Sensor mmWave MR60BHA2 con el XIAO ESP32C6 y Home Assistant, puedes explorar mejoras adicionales para aprovechar al máximo tu configuración. Aquí hay dos vías esenciales a considerar:
 
-#### Implementar Automatización en Home Assistant
+#### Implementando Automatización en Home Assistant
 
 Las poderosas características de automatización de Home Assistant te permiten crear un entorno de hogar inteligente más receptivo basado en los datos recopilados de tu Sensor MR60BHA2. Esto significa que puedes configurar acciones que ocurran automáticamente basadas en disparadores específicos relacionados con la detección de movimiento o latidos del corazón.
 
 Aquí te mostramos cómo implementar automatizaciones paso a paso:
 
-1. **Navegar a la Sección de Automatizaciones**: En tu panel de Home Assistant, encuentra y haz clic en la pestaña "Automatizaciones". Esta área está dedicada a crear y gestionar acciones automatizadas dentro de tu hogar.
-2. **Crear una Nueva Automatización**: Haz clic en el botón "Agregar Automatización". Home Assistant ofrece un asistente fácil de usar que te guía a través del proceso de configurar una automatización.
-3. **Definir el Disparador**: Elige un disparador basado en los datos del Sensor MR60BHA2. Por ejemplo, puedes configurar la automatización para que se active cuando el sensor detecte movimiento o un patrón específico de latidos del corazón. Esto significa que tu automatización puede responder inmediatamente a las lecturas del sensor.
-4. **Establecer Condiciones (Opcional)**: Las condiciones te permiten refinar cuándo debe ejecutarse la automatización. Por ejemplo, podrías querer que las luces se enciendan solo cuando esté oscuro afuera o si un usuario específico está en casa.
-5. **Determinar la Acción**: Especifica qué acción debe ocurrir cuando se cumplan las condiciones del disparador. Las acciones pueden incluir encender luces, enviar notificaciones, o incluso ajustar la configuración del termostato. Por ejemplo, podrías crear una acción que encienda una luz RGB cuando se detecte movimiento, mejorando tanto la seguridad como la comodidad.
-6. **Guardar y Probar**: Después de configurar tu automatización, guárdala y prueba su funcionalidad. Camina frente al sensor para ver si las luces se encienden como se esperaba. Si surgen problemas, puedes regresar a la configuración de automatización para solucionar problemas y ajustar.
+1. **Navega a la Sección de Automatizaciones**: En tu panel de Home Assistant, encuentra y haz clic en la pestaña "Automations". Esta área está dedicada a crear y gestionar acciones automatizadas dentro de tu hogar.
+2. **Crea una Nueva Automatización**: Haz clic en el botón "Add Automation". Home Assistant ofrece un asistente fácil de usar que te guía a través del proceso de configurar una automatización.
+3. **Define el Disparador**: Elige un disparador basado en los datos del Sensor MR60BHA2. Por ejemplo, puedes configurar la automatización para que se dispare cuando el sensor detecte movimiento o un patrón específico de latidos del corazón. Esto significa que tu automatización puede responder inmediatamente a las lecturas del sensor.
+4. **Establece Condiciones (Opcional)**: Las condiciones te permiten refinar cuándo debe ejecutarse la automatización. Por ejemplo, podrías querer que las luces se enciendan solo cuando esté oscuro afuera o si un usuario específico está en casa.
+5. **Determina la Acción**: Especifica qué acción debe ocurrir cuando se cumplan las condiciones del disparador. Las acciones pueden incluir encender luces, enviar notificaciones, o incluso ajustar configuraciones del termostato. Por ejemplo, podrías crear una acción que encienda una luz RGB cuando se detecte movimiento, mejorando tanto la seguridad como la comodidad.
+6. **Guarda y Prueba**: Después de configurar tu automatización, guárdala y prueba su funcionalidad. Camina frente al sensor para ver si las luces se encienden como se espera. Si surgen problemas, puedes regresar a la configuración de automatización para solucionar problemas y ajustar.
 
 Al aprovechar las capacidades de automatización de Home Assistant, puedes crear un entorno verdaderamente inteligente que responda a tus movimientos y métricas de salud, asegurando que tu espacio de vida se adapte a tu estilo de vida sin problemas.
 
@@ -224,42 +225,36 @@ Una de las ventajas significativas de usar el XIAO ESP32C6 es su compatibilidad 
 
 Para comenzar con ESPHome, sigue estos pasos:
 
-1. **Accede al Panel de ESPHome**: En Home Assistant, navega al complemento de ESPHome. Deberías ver tu XIAO ESP32C6 listado entre los dispositivos.
+1. **Accede al Panel de ESPHome**: En Home Assistant, navega al complemento ESPHome. Deberías ver tu XIAO ESP32C6 listado entre los dispositivos.
 
 2. **Crea una Nueva Configuración**: Haz clic en el dispositivo para abrir su configuración. Aquí, puedes ajustar configuraciones como la sensibilidad del sensor, intervalos de reporte y formatos de salida. ESPHome usa un formato de configuración YAML, que es fácil de usar y te permite definir varios parámetros. Puedes usar el siguiente archivo YAML de plantilla como punto de partida para tu configuración, que está diseñado específicamente para el Sensor MR60BHA2:
 
   ```yaml showLineNumbers title=example/mr60bha2.yaml
   # template from https://github.com/limengdu/MR60BHA2_ESPHome_external_components
 
-  substitutions:
-    name: "seeedstudio-mr60bha2-kit"
-    friendly_name: "Seeed Studio MR60BHA2 Kit"
+  # substitutions:
+  #   name: "seeedstudio-mr60bha2-kit"
+  #   friendly_name: "Seeed Studio MR60BHA2 Kit"
 
   esphome:
-    name: "${name}"
-    friendly_name: "${friendly_name}"
-    name_add_mac_suffix: true
-    project:
-      name: "seeedstudio.mr60bha2_kit"
-      version: "2.0"
-    platformio_options:
-      board_upload.maximum_size: 4194304
-    min_version: "2024.3.2" # Fix logger compile error on ESP32-C6 esphome#6323
+    name: seeed-mr60bha2
+    friendly_name: seeed-mr60bha2
 
   esp32:
     board: esp32-c6-devkitc-1
-    variant: esp32c6
-    flash_size: 4MB # upload.flash_size
+    # variant: esp32c6
+    # flash_size: 4MB # upload.flash_size
     framework:
       type: esp-idf
 
-  external_components:
-    - source:
-        type: git
-        url: https://github.com/limengdu/MR60BHA2_ESPHome_external_components
-        ref: main
-      components: [ seeed_mr60bha2 ]
-      refresh: 0s
+  # If it is indicated that this library does not exist, you can choose to remove this comment.
+  # external_components:
+  #   - source:
+  #       type: git
+  #       url: https://github.com/limengdu/MR60BHA2_ESPHome_external_components
+  #       ref: main
+  #     components: [ seeed_mr60bha2 ]
+  #     refresh: 0s
 
   # Enable logging
   logger:
@@ -268,22 +263,22 @@ Para comenzar con ESPHome, sigue estos pasos:
 
   # Enable Home Assistant API
   api:
+    encryption:
+      key: "ThVm4U+W/dxSbk9yHbeWuDnkGZJ5R2Bsb62hSaNuc2w=" # The content in "Show API key"
 
   ota:
     - platform: esphome
+      password: "84fd31bc8c1ba852d687e90ef654c232"  # Your own password as specified by ESPhome
 
   wifi:
-    # Enable fallback hotspot (captive portal) in case wifi connection fails
+    ssid: "Maker_HA_2.4G"
+    password: "maker2025"
+
     ap:
-      ssid: "seeedstudio-mr60bha2"
+      ssid: "seeed-mr60bha2 Fallback Hotspot"
+      password: "rKa7nM3Pe4vX"
 
   captive_portal:
-
-  # For XIAO ESP32C6 Onboard LED
-  # light:
-  #   - platform: status_led
-  #     name: "Switch state"
-  #     pin: GPIO15
 
   light:
     - platform: esp32_rmt_led_strip
@@ -291,7 +286,6 @@ Para comenzar con ESPHome, sigue estos pasos:
       name: "Seeed MR60BHA2 RGB Light"
       pin: GPIO1
       num_leds: 1
-      rmt_channel: 0
       rgb_order: GRB
       chipset: ws2812
 
@@ -314,8 +308,9 @@ Para comenzar con ESPHome, sigue estos pasos:
 
   binary_sensor:
     - platform: seeed_mr60bha2
-      people_exist:
+      has_target:
         name: "Person Information"
+
 
   sensor:
     - platform: bh1750
@@ -329,19 +324,19 @@ Para comenzar con ESPHome, sigue estos pasos:
         name: "Real-time heart rate"
       distance:
         name: "Distance to detection object"
-      target_num:
-        name: "Target Number"
+      num_targets:
+        name: "Target number"
   ```
 
-3. **Personalizar Funcionalidad**: Puedes mejorar las capacidades del sensor explorando varias características disponibles en ESPHome, permitiendo ajustes flexibles para adaptarse a tus necesidades específicas.
+3. **Personaliza la Funcionalidad**: Puedes mejorar las capacidades del sensor explorando varias características disponibles en ESPHome, permitiendo ajustes flexibles para adaptarse a tus necesidades específicas.
 
-4. **Subir el Firmware Actualizado**: Después de hacer tus modificaciones, guarda la configuración. El panel de ESPHome te permite subir el firmware directamente por aire. Simplemente haz clic en el botón `Upload`, y sigue las indicaciones para completar el proceso. Este método simplificado hace que sea fácil mantener tu firmware actualizado.
+4. **Sube el Firmware Actualizado**: Después de hacer tus modificaciones, guarda la configuración. El panel de ESPHome te permite subir el firmware directamente por aire. Simplemente haz clic en el botón `Upload`, y sigue las indicaciones para completar el proceso. Este método simplificado hace que sea fácil mantener tu firmware actualizado.
 
-5. **Probar e Iterar**: Una vez que la subida esté completa, prueba tus cambios en tiempo real. Monitorea el rendimiento del sensor para asegurar que opere como se espera. Si encuentras algún problema, vuelve al panel de ESPHome para refinar tus configuraciones. Este enfoque iterativo te permite mejorar continuamente tu firmware, asegurando que cumpla con tus requisitos de manera efectiva.
+5. **Prueba e Itera**: Una vez que la subida esté completa, prueba tus cambios en tiempo real. Monitorea el rendimiento del sensor para asegurar que opere como se espera. Si encuentras algún problema, vuelve al panel de ESPHome para refinar tus configuraciones. Este enfoque iterativo te permite mejorar continuamente tu firmware, asegurando que cumpla con tus requisitos de manera efectiva.
 
 Al utilizar ESPHome, te empoderas para hacer mejoras continuas a tu configuración de sensor, adaptándola para satisfacer tus necesidades en evolución. Esta capacidad no solo mejora la funcionalidad de tu proyecto sino que también proporciona una plataforma para aprender y experimentar con el desarrollo de IoT.
 
-A través de estos pasos, puedes maximizar la funcionalidad de tu configuración del Sensor mmWave MR60BHA2 y XIAO ESP32C6, transformándola en un sistema de hogar inteligente altamente personalizado y responsivo adaptado a tus preferencias y necesidades.
+A través de estos pasos, puedes maximizar la funcionalidad de tu configuración del Sensor mmWave MR60BHA2 y XIAO ESP32C6, transformándola en un sistema de hogar inteligente altamente personalizado y receptivo adaptado a tus preferencias y necesidades.
 
 ## Recursos
 
@@ -349,7 +344,7 @@ A través de estos pasos, puedes maximizar la funcionalidad de tu configuración
 - [Installation - Home Assistant](https://www.home-assistant.io/installation/)
 - [limengdu/MR60BHA2_ESPHome_external_components](https://github.com/limengdu/MR60BHA2_ESPHome_external_components)
 
-## Soporte Técnico y Discusión de Productos
+## Soporte Técnico y Discusión del Producto
 
 ¡Gracias por elegir nuestros productos! Estamos aquí para brindarte diferentes tipos de soporte para asegurar que tu experiencia con nuestros productos sea lo más fluida posible. Ofrecemos varios canales de comunicación para atender diferentes preferencias y necesidades.
 
@@ -361,6 +356,7 @@ A través de estos pasos, puedes maximizar la funcionalidad de tu configuración
 
   <div class="button_tech_support_container">
   <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+
   <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
   </div>
 </div>

--- a/docs/ja/Sensor/mmWave_radar_sensor/mr60bha2-mmwave-kit/ja_ha_with_mr60bha2.md
+++ b/docs/ja/Sensor/mmWave_radar_sensor/mr60bha2-mmwave-kit/ja_ha_with_mr60bha2.md
@@ -1,31 +1,31 @@
 ---
-title: MR60BHA2 呼吸・心拍センサーと Home Assistant の統合
+title: MR60BHA2 呼吸・心拍センサーとHome Assistant
 description: | 
-  MR60BHA2 心拍 mmWave センサーと Home Assistant
+  MR60BHA2 心拍mmWaveセンサーとHome Assistant
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /ja/ha_with_mr60bha2
 keywords:
   - ESPHome
 sidebar_position: 1
 last_update:
-  date: 05/15/2025
+  date: 09/23/2024
   author: Spencer
 ---
-:::note
-この文書は AI によって翻訳されています。内容に不正確な点や改善すべき点がございましたら、文書下部のコメント欄または以下の Issue ページにてご報告ください。  
-https://github.com/Seeed-Studio/wiki-documents/issues
-:::
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::danger Home AssistantでのRADAR使用範囲について
+RADARファームウェアの更新とESPHome YAMLの更新は2つの異なるソフトウェアです。ESPHome YAMLはOTAで更新できますが、RADARボードはケース内でUSB経由でのみ更新でき、SEEEDが提供する専用ソフトウェアが必要です。ESPHomeソフトウェアはカスタマイズできますが、[RADARファームウェアはカスタマイズできません](https://wiki.seeedstudio.com/ja/getting_started_with_mr60bha2_mmwave_kit/#module-firmware-upgrade)。Seeed StudioはビジネスアプリケーションでのみRADARのカスタマイズを許可しています。
+:::
+
 ## はじめに {#introduction}
 
-MR60BHA2 は、XIAO ESP32C6 マイクロコントローラーとの統合を目的として設計された 60GHz mmWave 呼吸・心拍検出センサー モジュールです。この高度なセンサーはミリ波技術を利用して、非侵襲的なバイタルサインの監視と存在検出を提供します。
+MR60BHA2は、XIAO ESP32C6マイクロコントローラーとの統合用に設計された60GHz mmWave呼吸・心拍検出センサーモジュールです。この先進的なセンサーは、ミリ波技術を利用してバイタルサインの非侵襲的監視と存在検出を提供します。
 
-このガイドでは、XIAO ESP32C6 マイクロコントローラーを使用して MR60BHA2 mmWave センサーを Home Assistant に統合するための明確で包括的な手順を提供します。このガイドに従うことで、ユーザーは心拍検出用のセンサーを設定し、Home Assistant 環境に接続し、ESPHome を使用してデバイスを効果的に管理および監視する方法を学ぶことができます。
+このガイドは、XIAO ESP32C6マイクロコントローラーを使用してMR60BHA2 mmWaveセンサーをHome Assistantと統合するための明確で包括的なウォークスルーを提供することを目的としています。このガイドに従うことで、ユーザーは心拍検出用のセンサーの設定、Home Assistant環境への接続、ESPHomeを使用したデバイスの効果的な管理と監視の方法を学ぶことができます。
 
-この統合により、ユーザーはスマートホームシステムを高度なセンシング機能で強化し、さまざまな用途における自動応答やリアルタイム監視を可能にします。
+この統合により、ユーザーは高度なセンシング機能でスマートホームシステムを強化し、さまざまなアプリケーションでの自動応答とリアルタイム監視を可能にします。
 
 <div><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-sensor-light-on.png" style={{"border-radius": '6px'}}/></div>
 
@@ -34,7 +34,7 @@ MR60BHA2 は、XIAO ESP32C6 マイクロコントローラーとの統合を目�
 <div class="table-center">
    <table align="center">
       <tr>
-         <th>MR60BHA2 mmWave センサー</th>
+         <th>MR60BHA2 mmWaveセンサー</th>
       </tr>
       <tr>
          <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/22-114993387-mr60bha2-60ghz-mmwave-45font.jpg" style={{width:360, height:'auto', "border-radius": '6px'}}/></div></td>
@@ -49,42 +49,42 @@ MR60BHA2 は、XIAO ESP32C6 マイクロコントローラーとの統合を目�
    </table>
 </div>
 
-### MR60BHA2 mmWave センサーと XIAO ESP32C6
+### MR60BHA2 mmWaveセンサーとXIAO ESP32C6
 
-MR60BHA2 mmWave センサーを XIAO ESP32C6 を使用して Home Assistant に効果的に統合するためには、以下の重要な手順を実行してください：
+XIAO ESP32C6を使用してMR60BHA2 mmWaveセンサーをHome Assistantと効果的に統合するには、以下の重要なステップに従ってください：
 
 :::caution
-MR60BHA2 モジュールの[ファームウェアを最新バージョンにアップグレード](/ja/getting_started_with_mr60bha2_mmwave_kit#module-firmware-upgrade)してください。  
-最新のファームウェアでは、人の存在検出および人員検出機能が追加されています。
+MR60BHA2モジュールの[ファームウェアを最新バージョンにアップグレード](/ja/getting_started_with_mr60bha2_mmwave_kit#module-firmware-upgrade)していることを確認してください。  
+最新のファームウェアには人の存在検出と人員検出機能が追加されています。
 :::
 
-1. **[Home Assistant のセットアップ](#setting-up-home-assistant)**: Home Assistant をインストールしてスマートホームデバイスを管理し、センサーとのシームレスな接続を確保します。
-2. **[MR60BHA2 センサーの接続](#discovering-and-adding-the-device-in-home-assistant)**: MR60BHA2 センサーを Home Assistant に追加してリアルタイムでバイタルサインを監視する方法を学びます。
-3. **[センサーデータの監視](#sensor-data-monitoring)**: 統合後、センサーデータを効果的に監視し、心拍数や呼吸パターンの洞察を得ることができます。
-4. **[Home Assistant での自動化の実装](#implementing-automation-in-home-assistant)**: Home Assistant の強力な自動化機能を活用して、センサーデータに基づいた応答アクションを作成し、スマートホーム環境を強化します。
-5. **[ESPHome を使用したファームウェアの変更](#modifying-the-firmware-with-esphome)**: ESPHome を利用してセンサーの機能をカスタマイズし、特定のニーズに合わせて柔軟性と制御性を向上させます。
+1. **[Home Assistantのセットアップ](#setting-up-home-assistant)**：スマートホームデバイスを管理するためにHome Assistantをインストールして設定し、センサーとのシームレスな接続を確保します。
+2. **[MR60BHA2センサーの接続](#discovering-and-adding-the-device-in-home-assistant)**：MR60BHA2センサーを発見してHome Assistantセットアップに追加し、バイタルサインのリアルタイム監視を可能にする方法を学びます。
+3. **[センサーデータの監視](#sensor-data-monitoring)**：統合後、センサーデータを効果的に監視し、心拍数と呼吸パターンの洞察を得ることができます。
+4. **[自動化の実装](#implementing-automation-in-home-assistant)**：Home Assistantの強力な自動化機能を探索して、センサーデータに基づく応答アクションを作成し、スマートホーム環境を強化します。
+5. **[ESPHomeでのファームウェア変更](#modifying-the-firmware-with-esphome)**：ESPHomeを利用してセンサーの機能をカスタマイズし、特定のニーズに合わせて調整して、より大きな柔軟性と制御を実現します。
 
-これらの手順に従うことで、MR60BHA2 mmWave センサーと XIAO ESP32C6 のセットアップを最大限に活用する方法を学ぶことができます。
+これらのステップは統合プロセスをガイドし、MR60BHA2 mmWaveセンサーとXIAO ESP32C6セットアップを最大限に活用するのに役立ちます。
 
 ## はじめに {#getting-started}
 
 :::note 注意
-ファームウェアの更新や変更について言及する場合、XIAO ESP32C6のファームウェアを特に指していることに注意してください。
+ファームウェアの更新や変更について言及する場合、XIAO ESP32C6上のファームウェアを特に指していることにご注意ください。
 :::
 
-MR60BHA2 mmWaveセンサーをHome Assistantと統合するには、以下のコンポーネントが必要です：
+MR60BHA2 mmWaveセンサーをHome Assistantと正常に統合するには、以下のコンポーネントが必要です：
 
-- **Home Assistant**: センサーのデータを管理するスマートホームプラットフォーム。
-- **ESPHomeアドオン**: ESP32デバイスの簡単な設定と管理を可能にするファームウェア。
+- **Home Assistant**：センサーデータを管理するスマートホームプラットフォーム。
+- **ESPHome Add-on**：ESP32デバイスの簡単な設定と管理を可能にするファームウェア。
 
-### ステップ1: Home Assistantのセットアップ {#setting-up-home-assistant}
+### ステップ1：Home Assistantのセットアップ {#setting-up-home-assistant}
 
-1. **インストール**: 最適なパフォーマンスを得るために、[Home Assistant OS](https://www.home-assistant.io/installation/)を仮想マシンやRaspberry Piにインストールすることを推奨します。公式のインストールガイドに従ってください。
-2. **ESPHomeアドオンの有効化**:
-   - Home Assistantのダッシュボードにアクセスします。
-   - 「アドオン」セクションに移動し、ESPHomeアドオンを検索します。
-   - 「インストール」をクリックし、その後「開始」をクリックして有効化します。
-   - インストール後、XIAO ESP32C6との適切な通信を確保するためにアドオンを設定します。
+1. **インストール**：最適なパフォーマンスのために、仮想マシンまたはRaspberry Piに[Home Assistant OS](https://www.home-assistant.io/installation/)をインストールすることをお勧めします。Home Assistantウェブサイトのオフィシャルインストールガイドに従ってください。
+2. **ESPHome Add-onの有効化**：
+   - Home Assistantダッシュボードにアクセスします。
+   - 「Add-ons」セクションに移動し、ESPHome add-onを検索します。
+   - 「Install」をクリックし、次に「Start」をクリックして有効にします。
+   - インストール後、XIAO ESP32C6との適切な通信を確保するためにadd-onを設定します。
 
 :::caution 注意
 新しいアイコンのため、ESPHomeプラグインバージョン2024.12.0以上をインストールしてください。
@@ -92,59 +92,59 @@ MR60BHA2 mmWaveセンサーをHome Assistantと統合するには、以下のコ
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-enabling_ESPHome_Add-on.png" style={{width:1000, height:'auto'}}/></div>
 
-必要なコンポーネントを収集し、ESPHomeアドオンを使用してHome Assistantをセットアップすることで、MR60BHA2 mmWaveセンサーの統合を進める準備が整います。
+必要なコンポーネントを収集し、ESPHome add-onでHome Assistantをセットアップすることで、MR60BHA2 mmWaveセンサーの統合を進める準備が整います。
 
 :::tip Home Assistantのインストール
-Seeed Studio製品向けにHome Assistantのインストール方法も記載していますので、参考にしてください。
+Seeed Studio製品の一部についてHome Assistantのインストール方法も書いていますので、参考にしてください。
 
-- [ODYSSEY-X86でのHome Assistantの始め方](/ja/ODYSSEY-X86-Home-Assistant)
-- [reTerminalでのHome Assistantの始め方](/ja/reTerminal_Home_Assistant)
-- [LinkStar H68K/reRouter CM4でのHome Assistantの始め方](/ja/h68k-ha-esphome)
+- [ODYSSEY-X86でのHome Assistant入門](/ja/ODYSSEY-X86-Home-Assistant)
+- [reTerminalでのHome Assistant入門](/ja/reTerminal_Home_Assistant)
+- [LinkStar H68K/reRouter CM4でのHome Assistant入門](/ja/h68k-ha-esphome)
 :::
 
-### ステップ2: キットの準備
+### ステップ2：キットの準備
 
-デフォルトでは、XIAO ESP32C6デバイスには呼吸と心拍数検出用のファームウェアがプリインストールされています。ただし、以下の2つのシナリオではファームウェアを更新する必要があります：
+デフォルトでは、デバイス（XIAO ESP32C6）には呼吸と心拍検出用のファームウェアが事前にフラッシュされています。ただし、ファームウェアを更新する必要がある2つのシナリオがあります：
 
-1. **ファームウェアの再フラッシュ**: 既存のファームウェアが破損している場合や、新しい状態から始めたい場合。
-2. **ファームウェアのアップグレード**: 機能が改善された新しいバージョンのファームウェアがある場合。
+1. **ファームウェアの再フラッシュ**：既存のファームウェアが破損している場合や、新しく開始する必要がある場合。
+2. **ファームウェアのアップグレード**：機能が改善された新しいバージョンのファームウェアがある場合。
 
-ファームウェアをフラッシュする方法は以下の2つです：
+ファームウェアをフラッシュする2つの簡単な方法があります：
 
 :::caution
-FirefoxはESPデバイスのファームウェアフラッシュをサポートしていません。Google ChromeまたはMicrosoft Edgeを使用してください。
+FirefoxはESPデバイスでのファームウェアフラッシュをサポートしていません。代わりにGoogle ChromeまたはMicrosoft Edgeを使用してください。
 :::
 
 <Tabs>
 <TabItem value='Web Tool'>
 
-この[Web Tool](https://limengdu.github.io/MR60BHA2_ESPHome_external_components/)を使用すると、簡単かつ直接的にファームウェアをフラッシュできます。画面上の指示に従ってください。
+この[Webツール](https://limengdu.github.io/MR60BHA2_ESPHome_external_components/)を使用して、簡単で直接的な方法でファームウェアをフラッシュできます。画面の指示に従ってください。
 
-- `CONNECT`ボタンをクリックして接続を開始します。このツールは自動的にファームウェアを更新します。
+- `CONNECT`ボタンをクリックして接続を開始します。ツールが自動的にファームウェアを更新します。
 
-問題が発生した場合は、画面上のトラブルシューティング手順に従うか、`ESPHome Web`メソッドに切り替えてプロセスを完了してください。
+何か問題が発生した場合は、画面のトラブルシューティング手順に従うか、`ESPHome Web`方法に切り替えてプロセスを完了してください。
 
 </TabItem>
 <TabItem value='ESPHome Web'>
 
-この方法では、[こちら](https://github.com/limengdu/MR60BHA2_ESPHome_external_components/releases)から`bin`ファームウェアファイルをダウンロードする必要があります（ダウンロードしたファイルを解凍してください）。
+この方法では、[こちら](https://github.com/limengdu/MR60BHA2_ESPHome_external_components/releases)から`bin`ファームウェアファイルをダウンロードする必要があります（ダウンロードしたファイルを解凍する必要があります）。
 
 1. センサーキットをPCに接続します。
 2. [ESPHome Web](https://web.esphome.io/)ページにアクセスします。
-3. `*.factory.bin`という接尾辞のファームウェアファイルを選択します。
+3. `*.factory.bin`サフィックスのファームウェアファイルを選択します。
 
-以下の動画で、ESPHome Webを使用したファームウェアフラッシュの詳細な手順をご覧ください：
+ESPHome Web経由でファームウェアをフラッシュする詳細なウォークスルーについては、以下のビデオをご覧ください：
 
-<iframe class="youtube-video-r" src="https://www.youtube.com/embed/J3AVeZCoLK8?si=1AeNTsdmbTvMl0Nq" title="ESPHome Webでのファームウェアインストール" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe class="youtube-video-r" src="https://www.youtube.com/embed/J3AVeZCoLK8?si=1AeNTsdmbTvMl0Nq" title="Install firmware via ESPHome Web" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 </TabItem>
 </Tabs>
 
-どちらの方法でも、ファームウェアを更新し、Home Assistantとの統合の準備が整います。
+どちらの方法でも、ファームウェアが更新され、Home Assistantとの統合の準備が整います。
 
-#### キットのホットスポットに接続する
+#### キットのホットスポットに接続
 
-ファームウェアを使用してセンサーキットの電源を入れると、Wi-Fiアクセスポイント`seeedstudio-mr60bha2`が表示されます。
+ファームウェアを使用して、センサーキットの電源を入れると、Wi-Fiアクセスポイントが表示されます：`seeedstudio-mr60bha2`。
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/hotspot-name.png" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
 
@@ -154,33 +154,34 @@ FirefoxはESPデバイスのファームウェアフラッシュをサポート�
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-enter-psw.JPEG" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
 
-### ステップ3: Home Assistantでデバイスを検出して追加する {#discovering-and-adding-the-device-in-home-assistant}
+### ステップ3：Home Assistantでのデバイスの発見と追加 {#discovering-and-adding-the-device-in-home-assistant}
 
-このセクションでは、Home Assistantアプリを使用したプロセスを説明します。ロジックはウェブ版と同じです。
+このセクションでは、Home Assistantアプリを使用したプロセスを説明します。ロジックはWebと同じです。
 
-1. **アプリを開く**: アプリを起動したら、Home Assistantサーバーを選択します。アプリは自動的にサーバーを検出します。
+1. **アプリを開く**：アプリを起動したら、Home Assistantサーバーを選択します。アプリが自動的にサーバーを見つけます。
 
   <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-server-option.JPG" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
-2. **アカウントを作成する**: アカウントを作成していない場合は作成する必要があります。その後、資格情報でログインします。
+2. **アカウントの作成**：アカウントを作成していない場合は、作成する必要があります。その後、認証情報でログインします。
   <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-login.JPG" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
-3. **統合ページに移動する**: ログイン後、Home Assistantの「統合」ページに移動します。ESPHomeアドオンをインストールしており、XIAO ESP32C6とHome Assistantサーバーが同じネットワーク上にある場合、`Seeed Studio MR60BHA2 Kit {device-mac-address}`というデバイスが検出されたデバイスの下に表示されるはずです。
-4. **デバイスを追加する**: デバイスをHome Assistantのセットアップに追加するにはクリックします。
+3. **統合ページに移動**：ログイン後、Home Assistantの「Integrations」ページに移動します。ESPHome add-onをインストールし、XIAO ESP32C6とHome Assistantサーバーの両方が同じネットワーク上にある場合、発見されたデバイスの下に`Seeed Studio MR60BHA2 Kit {device-mac-address}`デバイスが表示されるはずです。
+4. **デバイスの追加**：クリックしてデバイスをHome Assistantセットアップに追加します。
+
   <div class="img-container" align="center">
-    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-find.JPG" alt="デバイスを検出"/>
-    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-submit.JPG" alt="デバイスを送信"/>
-    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-add.JPG" alt="エリア"/>
-    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-addon-device.JPG" alt="アドオン"/>
+    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-find.JPG" alt="find device"/>
+    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-submit.JPG" alt="submit a device"/>
+    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-add.JPG" alt="area"/>
+    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-addon-device.JPG" alt="addon"/>
   </div>
 
-`CONFIGURE`ボタンをクリックし、`SUBMIT`ボタンを押して確認した後、デバイスを希望するエリア（例：寝室）に割り当てます。この操作が完了すると、デバイスはESPHome統合を通じて管理され、Home Assistantで完全な制御と監視が可能になります。
+  `CONFIGURE`ボタンをクリックし、`SUBMIT`ボタンを押して確認し、デバイスを希望するエリア（例：寝室）に割り当てます。この後、デバイスはESPHome統合を通じて管理され、Home Assistantでの完全な制御と監視が可能になります。
 
-## 監視と制御 {#monitoring-and-control}
+## 監視と制御 {#監視と制御}
 
-上記の手順を完了することで、MR60BHA2センサーをHome Assistantに追加し、リアルタイムの監視と制御が可能になります。
+上記の手順に従うことで、MR60BHA2センサーをHome Assistantに正常に発見・追加し、リアルタイムでの監視と制御が可能になります。
 
-### センサーのデータ監視
+### センサーデータの監視
 
-センサーが「寝室」に追加されたら、「概要」タブに移動します。寝室セクションにmmWaveカードが表示されます。
+センサーが「寝室」に追加されたので、「概要」タブに移動します。寝室セクションにmmWaveカードが表示されます。
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-sensor-data-with-person-detection.png" style={{width:680, height:'auto', "border-radius": '15px'}}/></div>
 
@@ -193,97 +194,91 @@ FirefoxはESPデバイスのファームウェアフラッシュをサポート�
    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/light-on.jpg" style={{"border-radius": '6px'}}/>
 </div>
 
-対応するボックスをクリックしてRGBライトを直接制御します：
+対応するボックスをクリックして、RGBライトを直接制御します：
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-light-panel.png" style={{width:680, height:'auto', "border-radius": '15px'}}/></div>
 
 <iframe class="video-mp4" src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-control-light.mp4" title="Home Assistant Control RGB Light" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture;" allowfullscreen></iframe>
 
-### 次のステップ {#next-steps}
+### 次のステップ {#次のステップ}
 
-MR60BHA2 mmWaveセンサーをXIAO ESP32C6およびHome Assistantと統合したので、セットアップを最大限に活用するためのさらなる拡張を探求できます。以下の2つの重要な方向性を検討してください：
+MR60BHA2 mmWaveセンサーとXIAO ESP32C6、Home Assistantの統合が正常に完了したので、セットアップを最大限に活用するためのさらなる機能強化を探求できます。考慮すべき2つの重要な方向性をご紹介します：
 
 #### Home Assistantでの自動化の実装
 
-Home Assistantの強力な自動化機能を活用することで、MR60BHA2センサーから収集したデータに基づいて、より応答性の高いスマートホーム環境を構築できます。これにより、動作や心拍検出に関連する特定のトリガーに基づいて自動的にアクションを設定できます。
+Home Assistantの強力な自動化機能により、MR60BHA2センサーから収集されたデータに基づいて、より応答性の高いスマートホーム環境を作成できます。これは、動作や心拍検出に関連する特定のトリガーに基づいて自動的に実行されるアクションを設定できることを意味します。
 
-以下は、自動化を実装する手順です：
+自動化を段階的に実装する方法は次のとおりです：
 
-1. **自動化セクションに移動**: Home Assistantのダッシュボードで「Automations」タブを見つけてクリックします。このエリアは、家庭内の自動化アクションを作成および管理するための専用セクションです。
-2. **新しい自動化を作成**: 「Add Automation」ボタンをクリックします。Home Assistantは、ユーザーが自動化を設定するプロセスをガイドする使いやすいウィザードを提供します。
-3. **トリガーを定義**: MR60BHA2センサーのデータに基づいてトリガーを選択します。例えば、センサーが動作や特定の心拍パターンを検出したときに自動化をトリガーするよう設定できます。これにより、センサーの読み取りに即座に応答する自動化が可能になります。
-4. **条件を設定（オプション）**: 条件を設定することで、自動化が実行されるタイミングを絞り込むことができます。例えば、外が暗い場合や特定のユーザーが家にいる場合にのみライトをオンにするよう設定できます。
-5. **アクションを決定**: トリガー条件が満たされた場合に実行されるアクションを指定します。アクションには、ライトのオン/オフ、通知の送信、またはサーモスタット設定の調整などが含まれます。例えば、動作が検出されたときにRGBライトをオンにするアクションを作成し、セキュリティと快適性を向上させることができます。
-6. **保存とテスト**: 自動化を設定したら保存し、その機能をテストします。センサーの前を通り過ぎて、ライトが期待通りにオンになるか確認してください。問題が発生した場合は、自動化設定に戻ってトラブルシューティングと調整を行うことができます。
+1. **自動化セクションに移動**：Home Assistantダッシュボードで「自動化」タブを見つけてクリックします。このエリアは、ホーム内での自動化されたアクションの作成と管理に専用されています。
+2. **新しい自動化を作成**：「自動化を追加」ボタンをクリックします。Home Assistantは、自動化の設定プロセスをガイドするユーザーフレンドリーなウィザードを提供します。
+3. **トリガーを定義**：MR60BHA2センサーのデータに基づいてトリガーを選択します。例えば、センサーが動作や特定の心拍パターンを検出したときに自動化がトリガーされるように設定できます。これにより、自動化がセンサーの読み取り値に即座に応答できます。
+4. **条件を設定（オプション）**：条件により、自動化が実行されるタイミングを細かく調整できます。例えば、外が暗いときや特定のユーザーが在宅のときにのみライトを点灯させたい場合があります。
+5. **アクションを決定**：トリガー条件が満たされたときに実行されるアクションを指定します。アクションには、ライトの点灯、通知の送信、サーモスタット設定の調整などが含まれます。例えば、動作が検出されたときにRGBライトを点灯させるアクションを作成し、セキュリティと快適性の両方を向上させることができます。
+6. **保存とテスト**：自動化を設定した後、保存して機能をテストします。センサーの前を歩いて、期待通りにライトが点灯するかを確認します。問題が発生した場合は、自動化設定に戻ってトラブルシューティングと調整を行うことができます。
 
-Home Assistantの自動化機能を活用することで、動作や健康指標に応じて生活空間がシームレスに適応する、真にスマートな環境を構築できます。
+Home Assistantの自動化機能を活用することで、あなたの動きや健康指標に応答する真にスマートな環境を作成し、生活空間があなたのライフスタイルにシームレスに適応することを確実にできます。
 
-## ESPHome を使用したファームウェアの変更
+## ESPHomeでのファームウェアの変更
 
-XIAO ESP32C6 を使用する大きな利点の一つは、強力なツールである ESPHome と互換性があることです。ESPHome を使用すると、マイクロコントローラーのファームウェアを直接変更し、MR60BHA2 mmWave センサーの機能を特定のニーズに合わせてカスタマイズすることができます。
+XIAO ESP32C6を使用する大きな利点の一つは、マイクロコントローラーファームウェアの管理とカスタマイズのための強力なツールであるESPHomeとの互換性です。ESPHomeを使用すると、ファームウェアを直接変更して、MR60BHA2 mmWaveセンサーの機能を特定のニーズに合わせて調整できます。
 
-ESPHome を使用するには、以下の手順に従ってください：
+ESPHomeを開始するには、次の手順に従ってください：
 
-1. **ESPHome ダッシュボード にアクセス**: Home Assistant 内で ESPHome アドオンに移動します。XIAO ESP32C6 がデバイス一覧に表示されているはずです。
+1. **ESPHomeダッシュボードにアクセス**：Home AssistantでESPHomeアドオンに移動します。デバイス一覧にXIAO ESP32C6が表示されているはずです。
 
-2. **新しい設定を作成**: デバイスをクリックして設定を開きます。ここでは、センサーの感度、報告間隔、出力形式などの設定を調整できます。ESPHome は YAML 設定形式を使用しており、ユーザーフレンドリーでさまざまなパラメータを定義できます。以下のテンプレート YAML ファイルを使用して、MR60BHA2 センサー用の設定を開始できます：
+2. **新しい設定を作成**：デバイスをクリックして設定を開きます。ここで、センサーの感度、レポート間隔、出力形式などの設定を調整できます。ESPHomeはユーザーフレンドリーなYAML設定形式を使用し、さまざまなパラメータを定義できます。MR60BHA2センサー専用に設計された以下のテンプレートYAMLファイルを設定の出発点として使用できます：
 
   ```yaml showLineNumbers title=example/mr60bha2.yaml
-  # https://github.com/limengdu/MR60BHA2_ESPHome_external_components からのテンプレート
+  # template from https://github.com/limengdu/MR60BHA2_ESPHome_external_components
 
-  substitutions:
-    name: "seeedstudio-mr60bha2-kit"
-    friendly_name: "Seeed Studio MR60BHA2 Kit"
+  # substitutions:
+  #   name: "seeedstudio-mr60bha2-kit"
+  #   friendly_name: "Seeed Studio MR60BHA2 Kit"
 
   esphome:
-    name: "${name}"
-    friendly_name: "${friendly_name}"
-    name_add_mac_suffix: true
-    project:
-      name: "seeedstudio.mr60bha2_kit"
-      version: "2.0"
-    platformio_options:
-      board_upload.maximum_size: 4194304
-    min_version: "2024.3.2" # ESP32-C6 のロガーコンパイルエラー修正 esphome#6323
+    name: seeed-mr60bha2
+    friendly_name: seeed-mr60bha2
 
   esp32:
     board: esp32-c6-devkitc-1
-    variant: esp32c6
-    flash_size: 4MB # upload.flash_size
+    # variant: esp32c6
+    # flash_size: 4MB # upload.flash_size
     framework:
       type: esp-idf
 
-  external_components:
-    - source:
-        type: git
-        url: https://github.com/limengdu/MR60BHA2_ESPHome_external_components
-        ref: main
-      components: [ seeed_mr60bha2 ]
-      refresh: 0s
+  # If it is indicated that this library does not exist, you can choose to remove this comment.
+  # external_components:
+  #   - source:
+  #       type: git
+  #       url: https://github.com/limengdu/MR60BHA2_ESPHome_external_components
+  #       ref: main
+  #     components: [ seeed_mr60bha2 ]
+  #     refresh: 0s
 
-  # ロギングを有効化
+  # Enable logging
   logger:
     hardware_uart: USB_SERIAL_JTAG
     level: DEBUG
 
-  # Home Assistant API を有効化
+  # Enable Home Assistant API
   api:
+    encryption:
+      key: "ThVm4U+W/dxSbk9yHbeWuDnkGZJ5R2Bsb62hSaNuc2w=" # The content in "Show API key"
 
   ota:
     - platform: esphome
+      password: "84fd31bc8c1ba852d687e90ef654c232"  # Your own password as specified by ESPhome
 
   wifi:
-    # Wi-Fi 接続が失敗した場合のフォールバックホットスポット (キャプティブポータル) を有効化
+    ssid: "Maker_HA_2.4G"
+    password: "maker2025"
+
     ap:
-      ssid: "seeedstudio-mr60bha2"
+      ssid: "seeed-mr60bha2 Fallback Hotspot"
+      password: "rKa7nM3Pe4vX"
 
   captive_portal:
-
-  # XIAO ESP32C6 のオンボード LED 用
-  # light:
-  #   - platform: status_led
-  #     name: "Switch state"
-  #     pin: GPIO15
 
   light:
     - platform: esp32_rmt_led_strip
@@ -291,7 +286,6 @@ ESPHome を使用するには、以下の手順に従ってください：
       name: "Seeed MR60BHA2 RGB Light"
       pin: GPIO1
       num_leds: 1
-      rmt_channel: 0
       rgb_order: GRB
       chipset: ws2812
 
@@ -314,8 +308,9 @@ ESPHome を使用するには、以下の手順に従ってください：
 
   binary_sensor:
     - platform: seeed_mr60bha2
-      people_exist:
+      has_target:
         name: "Person Information"
+
 
   sensor:
     - platform: bh1750
@@ -329,29 +324,29 @@ ESPHome を使用するには、以下の手順に従ってください：
         name: "Real-time heart rate"
       distance:
         name: "Distance to detection object"
-      target_num:
-        name: "Target Number"
+      num_targets:
+        name: "Target number"
   ```
 
-3. **機能をカスタマイズ**: ESPHome のさまざまな機能を探索することで、センサーの能力を向上させ、特定のニーズに合わせて柔軟に調整できます。
+3. **機能をカスタマイズ**：ESPHomeで利用可能なさまざまな機能を探求することで、センサーの機能を強化し、特定のニーズに合わせて柔軟に調整できます。
 
-4. **更新されたファームウェアをアップロード**: 変更を加えた後、設定を保存します。ESPHome ダッシュボードでは、ファームウェアを直接 OTA (Over-The-Air) でアップロードできます。「Upload」ボタンをクリックし、プロンプトに従ってプロセスを完了してください。この簡素化された方法により、ファームウェアを簡単に最新の状態に保つことができます。
+4. **更新されたファームウェアをアップロード**：変更を行った後、設定を保存します。ESPHomeダッシュボードでは、ファームウェアを無線で直接アップロードできます。`Upload`ボタンをクリックし、プロンプトに従ってプロセスを完了します。この合理化された方法により、ファームウェアを最新の状態に保つことが簡単になります。
 
-5. **テストと反復**: アップロードが完了したら、リアルタイムで変更をテストします。センサーの性能を監視し、期待通りに動作していることを確認してください。問題が発生した場合は、ESPHome ダッシュボードに戻り、設定を調整してください。この反復的なアプローチにより、ファームウェアを継続的に改善し、効果的にニーズを満たすことができます。
+5. **テストと反復**：アップロードが完了したら、変更をリアルタイムでテストします。センサーのパフォーマンスを監視して、期待通りに動作することを確認します。問題が発生した場合は、ESPHomeダッシュボードに戻って設定を調整します。この反復的なアプローチにより、ファームウェアを継続的に改善し、要件を効果的に満たすことができます。
 
-ESPHome を活用することで、センサー設定を継続的に改善し、進化するニーズに合わせて適応させることができます。この機能は、プロジェクトの機能を向上させるだけでなく、IoT 開発における学習と実験のプラットフォームを提供します。
+ESPHomeを活用することで、センサーセットアップの継続的な改善を行い、進化するニーズに適応させることができます。この機能は、プロジェクトの機能性を向上させるだけでなく、IoT開発での学習と実験のプラットフォームも提供します。
 
-これらの手順を通じて、MR60BHA2 mmWave センサーと XIAO ESP32C6 のセットアップの機能を最大化し、個々の好みやニーズに合わせた高度にカスタマイズされた応答性の高いスマートホームシステムに変えることができます。
+これらの手順を通じて、MR60BHA2 mmWaveセンサーとXIAO ESP32C6セットアップの機能を最大化し、あなたの好みとニーズに合わせて高度にカスタマイズされた応答性の高いスマートホームシステムに変換できます。
 
 ## リソース
 
 - [ESPHome — ESPHome](https://esphome.io/)
-- [インストール - Home Assistant](https://www.home-assistant.io/installation/)
+- [Installation - Home Assistant](https://www.home-assistant.io/installation/)
 - [limengdu/MR60BHA2_ESPHome_external_components](https://github.com/limengdu/MR60BHA2_ESPHome_external_components)
 
-## 技術サポートと製品に関する議論
+## 技術サポートと製品ディスカッション
 
-弊社製品をお選びいただきありがとうございます！製品をご利用いただく際にスムーズな体験を提供するため、さまざまなサポートを提供しております。異なる好みやニーズに対応するため、複数のコミュニケーションチャネルをご用意しています。
+弊社製品をお選びいただき、ありがとうございます！弊社製品での体験が可能な限りスムーズになるよう、さまざまなサポートを提供しています。さまざまな好みやニーズに対応するため、複数のコミュニケーションチャネルを提供しています。
 
 <div class="table-center">
   <div class="button_tech_support_container">
@@ -361,6 +356,7 @@ ESPHome を活用することで、センサー設定を継続的に改善し、
 
   <div class="button_tech_support_container">
   <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+
   <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
   </div>
 </div>

--- a/docs/zh-CN/Sensor/mmWave_radar_sensor/mr60bha2-mmwave-kit/cn_ha_with_mr60bha2.md
+++ b/docs/zh-CN/Sensor/mmWave_radar_sensor/mr60bha2-mmwave-kit/cn_ha_with_mr60bha2.md
@@ -15,13 +15,17 @@ last_update:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::danger 关于雷达在 Home Assistant 中的使用范围
+雷达固件更新和 ESPHome YAML 更新是两个不同的软件。ESPHome YAML 可以通过 OTA 更新，而雷达板只能通过外壳内的 USB 使用 SEEED 提供的专用软件进行更新。您可以自定义 ESPHome 软件，但[不能自定义雷达固件](https://wiki.seeedstudio.com/cn/getting_started_with_mr60bha2_mmwave_kit/#module-firmware-upgrade)。Seeed Studio 只有在您进行商业应用时才允许雷达定制。
+:::
+
 ## 介绍 {#introduction}
 
-MR60BHA2 是一款 60GHz 毫米波呼吸和心跳检测传感器模块，专为与 XIAO ESP32C6 微控制器集成而设计。这款先进的传感器利用毫米波技术提供非侵入式的生命体征监测和存在检测。
+MR60BHA2 是一个 60GHz 毫米波呼吸和心跳检测传感器模块，专为与 XIAO ESP32C6 微控制器集成而设计。这个先进的传感器利用毫米波技术提供非侵入式的生命体征监测和存在检测。
 
 本指南旨在为使用 XIAO ESP32C6 微控制器将 MR60BHA2 毫米波传感器与 Home Assistant 集成提供清晰而全面的演练。通过遵循本指南，用户将学习如何设置传感器进行心跳检测，将其连接到 Home Assistant 环境，并利用 ESPHome 有效地管理和监控设备。
 
-这种集成使用户能够通过先进的传感功能增强其智能家居系统，实现自动响应和实时监控，适用于各种应用场景。
+这种集成使用户能够通过先进的传感功能增强其智能家居系统，实现自动响应和各种应用的实时监控。
 
 <div><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-sensor-light-on.png" style={{"border-radius": '6px'}}/></div>
 
@@ -38,7 +42,7 @@ MR60BHA2 是一款 60GHz 毫米波呼吸和心跳检测传感器模块，专为�
       <tr>
          <td>
             <div class="get_one_now_container" style={{textAlign: 'center'}}>
-               <a class="get_one_now_item" href="https://www.seeedstudio.com/MR60BHA2-60GHz-mmWave-Sensor-Breathing-and-Heartbeat-Module-p-5945.html?utm_source=wiki" target="_blank"><strong><span><font color={'FFFFFF'} size={"4"}> 立即购买 🖱️</font></span></strong></a>
+               <a class="get_one_now_item" href="https://www.seeedstudio.com/MR60BHA2-60GHz-mmWave-Sensor-Breathing-and-Heartbeat-Module-p-5945.html?utm_source=wiki" target="_blank"><strong><span><font color={'FFFFFF'} size={"4"}> 立即获取 🖱️</font></span></strong></a>
             </div>
          </td>
       </tr>
@@ -55,14 +59,14 @@ MR60BHA2 是一款 60GHz 毫米波呼吸和心跳检测传感器模块，专为�
 :::
 
 1. **[设置 Home Assistant](#setting-up-home-assistant)**：首先安装和配置 Home Assistant 来管理您的智能家居设备，确保与传感器的无缝连接。
-2. **[连接 MR60BHA2 传感器](#discovering-and-adding-the-device-in-home-assistant)**：学习如何在 Home Assistant 设置中发现和添加 MR60BHA2 传感器，实现生命体征的实时监控。
-3. **[监控传感器数据](#sensor-data-monitoring)**：一旦集成完成，您可以有效地监控传感器数据，从而深入了解心率和呼吸模式。
+2. **[连接 MR60BHA2 传感器](#discovering-and-adding-the-device-in-home-assistant)**：学习如何发现并将 MR60BHA2 传感器添加到您的 Home Assistant 设置中，实现生命体征的实时监控。
+3. **[监控传感器数据](#sensor-data-monitoring)**：一旦集成，您可以有效地监控传感器数据，从而深入了解心率和呼吸模式。
 4. **[实施自动化](#implementing-automation-in-home-assistant)**：探索 Home Assistant 强大的自动化功能，根据传感器数据创建响应式操作，增强您的智能家居环境。
 5. **[使用 ESPHome 修改固件](#modifying-the-firmware-with-esphome)**：利用 ESPHome 自定义传感器的功能，根据您的特定需求进行定制，以获得更大的灵活性和控制力。
 
 这些步骤将指导您完成集成过程，帮助您充分利用 MR60BHA2 毫米波传感器和 XIAO ESP32C6 设置。
 
-## 开始使用 {#getting-started}
+## 入门指南 {#getting-started}
 
 :::note 注意
 请注意，当我们提到固件更新或修改时，我们特指 XIAO ESP32C6 上的固件。
@@ -75,12 +79,12 @@ MR60BHA2 是一款 60GHz 毫米波呼吸和心跳检测传感器模块，专为�
 
 ### 步骤 1：设置 Home Assistant {#setting-up-home-assistant}
 
-1. **安装**：为了获得最佳性能，建议在虚拟机或树莓派上安装 [Home Assistant OS](https://www.home-assistant.io/installation/)。请按照 Home Assistant 官网上的官方安装指南进行操作。
+1. **安装**：为了获得最佳性能，建议在虚拟机或 Raspberry Pi 上安装 [Home Assistant OS](https://www.home-assistant.io/installation/)。请遵循 Home Assistant 网站上的官方安装指南。
 2. **启用 ESPHome 插件**：
    - 访问 Home Assistant 仪表板。
    - 导航到"插件"部分并搜索 ESPHome 插件。
-   - 点击"安装"然后点击"启动"来启用它。
-   - 安装完成后，配置插件以确保与 XIAO ESP32C6 的正常通信。
+   - 点击"安装"然后"启动"来启用它。
+   - 安装完成后，配置插件以确保与 XIAO ESP32C6 的正确通信。
 
 :::caution 注意
 由于新图标的原因，请安装 ESPHome 插件版本 2024.12.0 及以上。
@@ -88,10 +92,10 @@ MR60BHA2 是一款 60GHz 毫米波呼吸和心跳检测传感器模块，专为�
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-enabling_ESPHome_Add-on.png" style={{width:1000, height:'auto'}}/></div>
 
-通过收集必要的组件并设置带有 ESPHome 插件的 Home Assistant，您就可以准备进行 MR60BHA2 毫米波传感器的集成了。
+通过收集必要的组件并使用 ESPHome 插件设置 Home Assistant，您将准备好继续进行 MR60BHA2 毫米波传感器的集成。
 
 :::tip 安装 Home Assistant
-我们还为一些 Seeed Studio 产品编写了如何安装 Home Assistant 的教程，请参考它们。
+我们还为一些 Seeed Studio 产品编写了如何安装 Home Assistant 的指南，请参考它们。
 
 - [在 ODYSSEY-X86 上开始使用 Home Assistant](/cn/ODYSSEY-X86-Home-Assistant)
 - [在 reTerminal 上开始使用 Home Assistant](/cn/reTerminal_Home_Assistant)
@@ -105,20 +109,20 @@ MR60BHA2 是一款 60GHz 毫米波呼吸和心跳检测传感器模块，专为�
 1. **重新刷写固件**：如果现有固件损坏或您需要重新开始。
 2. **升级固件**：如果有具有改进功能的新版本固件。
 
-有两种简单的刷写固件方法：
+有两种简单的固件刷写方法：
 
 :::caution
-Firefox 不支持在 ESP 设备上刷写固件。请使用 Google Chrome 或 Microsoft Edge。
+Firefox 不支持在 ESP 设备上刷写固件。请改用 Google Chrome 或 Microsoft Edge。
 :::
 
 <Tabs>
 <TabItem value='Web Tool'>
 
-您可以使用这个 [Web Tool](https://limengdu.github.io/MR60BHA2_ESPHome_external_components/) 来获得简单直接的固件刷写方法。只需按照屏幕上的说明操作即可。
+您可以使用这个[网页工具](https://limengdu.github.io/MR60BHA2_ESPHome_external_components/)来简单直接地刷写固件。只需按照屏幕上的说明操作。
 
-- 点击 `CONNECT` 按钮启动连接。该工具将自动更新固件。
+- 点击 `CONNECT` 按钮开始连接。工具将自动更新固件。
 
-如果出现问题，请按照屏幕上的故障排除步骤操作，或切换到 `ESPHome Web` 方法来完成该过程。
+如果出现问题，请按照屏幕上的故障排除步骤操作，或切换到 `ESPHome Web` 方法来完成过程。
 
 </TabItem>
 <TabItem value='ESPHome Web'>
@@ -129,7 +133,7 @@ Firefox 不支持在 ESP 设备上刷写固件。请使用 Google Chrome 或 Mic
 2. 访问 [ESPHome Web](https://web.esphome.io/) 页面。
 3. 选择带有 `*.factory.bin` 后缀的固件文件。
 
-观看以下视频，了解通过 ESPHome Web 刷写固件的详细演示：
+观看以下视频，了解通过 ESPHome Web 刷写固件的详细演练：
 
 <iframe class="youtube-video-r" src="https://www.youtube.com/embed/J3AVeZCoLK8?si=1AeNTsdmbTvMl0Nq" title="Install firmware via ESPHome Web" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -140,7 +144,7 @@ Firefox 不支持在 ESP 设备上刷写固件。请使用 Google Chrome 或 Mic
 
 #### 连接到套件的热点
 
-使用固件，您可以为传感器套件供电，将出现一个 Wi-Fi 接入点：`seeedstudio-mr60bha2`。
+使用固件，您可以打开传感器套件的电源，将出现一个 Wi-Fi 接入点：`seeedstudio-mr60bha2`。
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/hotspot-name.png" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
 
@@ -152,7 +156,7 @@ Firefox 不支持在 ESP 设备上刷写固件。请使用 Google Chrome 或 Mic
 
 ### 步骤 3：在 Home Assistant 中发现和添加设备 {#discovering-and-adding-the-device-in-home-assistant}
 
-在本节中，我们将使用 Home Assistant 应用程序来演示该过程，其逻辑与网页版相同。
+在本节中，我们将使用 Home Assistant 应用程序进行演示，其逻辑与网页版相同。
 
 1. **打开应用程序**：启动应用程序后，选择您的 Home Assistant 服务器。应用程序将自动找到您的服务器。
 
@@ -161,6 +165,7 @@ Firefox 不支持在 ESP 设备上刷写固件。请使用 Google Chrome 或 Mic
   <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-login.JPG" style={{width:360, height:'auto', "border-radius": '15px'}}/></div>
 3. **导航到集成页面**：登录后，转到 Home Assistant 中的"集成"页面。如果您已安装 ESPHome 插件，并且 XIAO ESP32C6 和您的 Home Assistant 服务器都在同一网络上，您应该会看到设备 `Seeed Studio MR60BHA2 Kit {device-mac-address}` 出现在已发现的设备下。
 4. **添加设备**：点击将设备添加到您的 Home Assistant 设置中。
+
   <div class="img-container" align="center">
     <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-find.JPG" alt="find device"/>
     <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-device-submit.JPG" alt="submit a device"/>
@@ -168,11 +173,11 @@ Firefox 不支持在 ESP 设备上刷写固件。请使用 Google Chrome 或 Mic
     <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-addon-device.JPG" alt="addon"/>
   </div>
 
-点击 `CONFIGURE` 按钮，按 `SUBMIT` 按钮确认，并将设备分配到您首选的区域（例如，卧室）。之后，设备将通过您的 ESPHome 集成进行管理，在 Home Assistant 中实现完全控制和监控。
+  点击 `CONFIGURE` 按钮，按下 `SUBMIT` 按钮确认，并将设备分配到您首选的区域（例如，卧室）。之后，设备将通过您的 ESPHome 集成进行管理，在 Home Assistant 中实现完全控制和监控。
 
-## 监控和控制 {#monitoring-and-control}
+## 监控和控制 {#监控和控制}
 
-按照上述步骤，您将成功发现并将 MR60BHA2 传感器添加到您的 Home Assistant，实现实时监控和控制。
+通过遵循上述步骤，您将成功发现并将 MR60BHA2 传感器添加到您的 Home Assistant 中，实现实时监控和控制。
 
 ### 传感器数据监控
 
@@ -189,15 +194,15 @@ Firefox 不支持在 ESP 设备上刷写固件。请使用 Google Chrome 或 Mic
    <img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/light-on.jpg" style={{"border-radius": '6px'}}/>
 </div>
 
-点击相应的框来直接控制 RGB 灯光：
+点击相应的框直接控制 RGB 灯光：
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-light-panel.png" style={{width:680, height:'auto', "border-radius": '15px'}}/></div>
 
-<iframe class="video-mp4" src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-control-light.mp4" title="Home Assistant 控制 RGB 灯光" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture;" allowfullscreen></iframe>
+<iframe class="video-mp4" src="https://files.seeedstudio.com/wiki/mmwave-for-xiao/mr60/mr60bha2/ha-control-light.mp4" title="Home Assistant Control RGB Light" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture;" allowfullscreen></iframe>
 
-### 下一步 {#next-steps}
+### 下一步 {#下一步}
 
-现在您已经成功将 MR60BHA2 毫米波传感器与 XIAO ESP32C6 和 Home Assistant 集成，您可以探索进一步的增强功能，以充分利用您的设置。以下是两个需要考虑的重要方向：
+现在您已成功将 MR60BHA2 毫米波传感器与 XIAO ESP32C6 和 Home Assistant 集成，您可以探索进一步的增强功能，以充分利用您的设置。以下是两个需要考虑的重要方向：
 
 #### 在 Home Assistant 中实现自动化
 
@@ -208,54 +213,48 @@ Home Assistant 强大的自动化功能允许您基于从 MR60BHA2 传感器收�
 1. **导航到自动化部分**：在您的 Home Assistant 仪表板中，找到并点击"自动化"选项卡。此区域专门用于在您的家中创建和管理自动化操作。
 2. **创建新的自动化**：点击"添加自动化"按钮。Home Assistant 提供了一个用户友好的向导，指导您完成设置自动化的过程。
 3. **定义触发器**：基于 MR60BHA2 传感器的数据选择触发器。例如，您可以设置自动化在传感器检测到运动或特定心跳模式时触发。这意味着您的自动化可以立即响应传感器的读数。
-4. **设置条件（可选）**：条件允许您细化自动化应该执行的时机。例如，您可能希望灯光仅在外面天黑时或特定用户在家时才打开。
-5. **确定操作**：指定当满足触发条件时应该发生什么操作。操作可以包括打开灯光、发送通知，甚至调整恒温器设置。例如，您可以创建一个在检测到运动时打开 RGB 灯光的操作，增强安全性和舒适性。
+4. **设置条件（可选）**：条件允许您细化自动化应何时执行。例如，您可能希望灯光仅在外面天黑时或特定用户在家时才打开。
+5. **确定操作**：指定当满足触发条件时应发生什么操作。操作可以包括打开灯光、发送通知，甚至调整恒温器设置。例如，您可以创建一个在检测到运动时打开 RGB 灯光的操作，增强安全性和舒适性。
 6. **保存和测试**：配置自动化后，保存它并测试其功能。走过传感器看看灯光是否按预期打开。如果出现任何问题，您可以返回自动化设置进行故障排除和调整。
 
 通过利用 Home Assistant 的自动化功能，您可以创建一个真正智能的环境，响应您的运动和健康指标，确保您的生活空间无缝适应您的生活方式。
 
 ## 使用 ESPHome 修改固件
 
-使用 XIAO ESP32C6 的一个重要优势是它与 ESPHome 的兼容性，ESPHome 是一个用于管理和自定义微控制器固件的强大工具。通过 ESPHome，您可以直接修改固件，以根据您的特定需求定制 MR60BHA2 毫米波传感器的功能。
+使用 XIAO ESP32C6 的一个重要优势是它与 ESPHome 的兼容性，ESPHome 是一个用于管理和自定义微控制器固件的强大工具。使用 ESPHome，您可以直接修改固件，将 MR60BHA2 毫米波传感器的功能定制为您的特定需求。
 
 要开始使用 ESPHome，请按照以下步骤操作：
 
-1. **访问 ESPHome 仪表板**：在 Home Assistant 中，导航到 ESPHome 插件。您应该会看到您的 XIAO ESP32C6 列在设备中。
+1. **访问 ESPHome 仪表板**：在 Home Assistant 中，导航到 ESPHome 插件。您应该在设备中看到您的 XIAO ESP32C6 列出。
 
-2. **创建新配置**：点击设备以打开其配置。在这里，您可以调整传感器的灵敏度、报告间隔和输出格式等设置。ESPHome 使用 YAML 配置格式，这种格式用户友好，允许您定义各种参数。您可以使用以下模板 YAML 文件作为配置的起点，该文件专为 MR60BHA2 传感器设计：
+2. **创建新配置**：点击设备打开其配置。在这里，您可以调整传感器的灵敏度、报告间隔和输出格式等设置。ESPHome 使用 YAML 配置格式，这是用户友好的，允许您定义各种参数。您可以使用以下模板 YAML 文件作为配置的起点，该文件专门为 MR60BHA2 传感器设计：
 
   ```yaml showLineNumbers title=example/mr60bha2.yaml
   # template from https://github.com/limengdu/MR60BHA2_ESPHome_external_components
 
-  substitutions:
-    name: "seeedstudio-mr60bha2-kit"
-    friendly_name: "Seeed Studio MR60BHA2 Kit"
+  # substitutions:
+  #   name: "seeedstudio-mr60bha2-kit"
+  #   friendly_name: "Seeed Studio MR60BHA2 Kit"
 
   esphome:
-    name: "${name}"
-    friendly_name: "${friendly_name}"
-    name_add_mac_suffix: true
-    project:
-      name: "seeedstudio.mr60bha2_kit"
-      version: "2.0"
-    platformio_options:
-      board_upload.maximum_size: 4194304
-    min_version: "2024.3.2" # Fix logger compile error on ESP32-C6 esphome#6323
+    name: seeed-mr60bha2
+    friendly_name: seeed-mr60bha2
 
   esp32:
     board: esp32-c6-devkitc-1
-    variant: esp32c6
-    flash_size: 4MB # upload.flash_size
+    # variant: esp32c6
+    # flash_size: 4MB # upload.flash_size
     framework:
       type: esp-idf
 
-  external_components:
-    - source:
-        type: git
-        url: https://github.com/limengdu/MR60BHA2_ESPHome_external_components
-        ref: main
-      components: [ seeed_mr60bha2 ]
-      refresh: 0s
+  # If it is indicated that this library does not exist, you can choose to remove this comment.
+  # external_components:
+  #   - source:
+  #       type: git
+  #       url: https://github.com/limengdu/MR60BHA2_ESPHome_external_components
+  #       ref: main
+  #     components: [ seeed_mr60bha2 ]
+  #     refresh: 0s
 
   # Enable logging
   logger:
@@ -264,22 +263,22 @@ Home Assistant 强大的自动化功能允许您基于从 MR60BHA2 传感器收�
 
   # Enable Home Assistant API
   api:
+    encryption:
+      key: "ThVm4U+W/dxSbk9yHbeWuDnkGZJ5R2Bsb62hSaNuc2w=" # The content in "Show API key"
 
   ota:
     - platform: esphome
+      password: "84fd31bc8c1ba852d687e90ef654c232"  # Your own password as specified by ESPhome
 
   wifi:
-    # Enable fallback hotspot (captive portal) in case wifi connection fails
+    ssid: "Maker_HA_2.4G"
+    password: "maker2025"
+
     ap:
-      ssid: "seeedstudio-mr60bha2"
+      ssid: "seeed-mr60bha2 Fallback Hotspot"
+      password: "rKa7nM3Pe4vX"
 
   captive_portal:
-
-  # For XIAO ESP32C6 Onboard LED
-  # light:
-  #   - platform: status_led
-  #     name: "Switch state"
-  #     pin: GPIO15
 
   light:
     - platform: esp32_rmt_led_strip
@@ -287,7 +286,6 @@ Home Assistant 强大的自动化功能允许您基于从 MR60BHA2 传感器收�
       name: "Seeed MR60BHA2 RGB Light"
       pin: GPIO1
       num_leds: 1
-      rmt_channel: 0
       rgb_order: GRB
       chipset: ws2812
 
@@ -310,8 +308,9 @@ Home Assistant 强大的自动化功能允许您基于从 MR60BHA2 传感器收�
 
   binary_sensor:
     - platform: seeed_mr60bha2
-      people_exist:
+      has_target:
         name: "Person Information"
+
 
   sensor:
     - platform: bh1750
@@ -325,19 +324,19 @@ Home Assistant 强大的自动化功能允许您基于从 MR60BHA2 传感器收�
         name: "Real-time heart rate"
       distance:
         name: "Distance to detection object"
-      target_num:
-        name: "Target Number"
+      num_targets:
+        name: "Target number"
   ```
 
-3. **自定义功能**：您可以通过探索 ESPHome 中提供的各种功能来增强传感器的能力，允许灵活调整以满足您的特定需求。
+3. **自定义功能**：您可以通过探索 ESPHome 中可用的各种功能来增强传感器的能力，允许灵活调整以适应您的特定需求。
 
-4. **上传更新的固件**：进行修改后，保存配置。ESPHome 仪表板允许您直接通过无线方式上传固件。只需点击 `Upload` 按钮，并按照提示完成该过程。这种简化的方法使保持固件最新变得容易。
+4. **上传更新的固件**：进行修改后，保存配置。ESPHome 仪表板允许您直接通过无线方式上传固件。只需点击 `Upload` 按钮，并按照提示完成过程。这种简化的方法使保持固件最新变得容易。
 
-5. **测试和迭代**：上传完成后，实时测试您的更改。监控传感器的性能以确保其按预期运行。如果遇到任何问题，请重新访问 ESPHome 仪表板以完善您的设置。这种迭代方法使您能够持续改进固件，确保其有效满足您的要求。
+5. **测试和迭代**：上传完成后，实时测试您的更改。监控传感器的性能以确保其按预期运行。如果遇到任何问题，请重新访问 ESPHome 仪表板以完善您的设置。这种迭代方法使您能够持续改进固件，确保它有效满足您的要求。
 
-通过使用 ESPHome，您可以对传感器设置进行持续改进，使其适应您不断变化的需求。这种能力不仅增强了项目的功能性，还为学习和实验 IoT 开发提供了平台。
+通过利用 ESPHome，您可以对传感器设置进行持续改进，使其适应您不断变化的需求。这种能力不仅增强了项目的功能，还为学习和实验 IoT 开发提供了平台。
 
-通过这些步骤，您可以最大化 MR60BHA2 毫米波传感器和 XIAO ESP32C6 设置的功能，将其转变为根据您的偏好和需求量身定制的高度自定义和响应式智能家居系统。
+通过这些步骤，您可以最大化 MR60BHA2 毫米波传感器和 XIAO ESP32C6 设置的功能，将其转变为根据您的偏好和需求定制的高度自定义和响应式智能家居系统。
 
 ## 资源
 
@@ -357,6 +356,7 @@ Home Assistant 强大的自动化功能允许您基于从 MR60BHA2 传感器收�
 
   <div class="button_tech_support_container">
   <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+
   <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
   </div>
 </div>


### PR DESCRIPTION
1. Removed the content that would lead to failure.
2. Added some contents related to Wi-Fi and OTA to avoid Wi-Fi connection failure.
3. Added some contents related to API.
4. Added some comments to aid understanding.
5. Removed the "rmt_channel" content from the light section, as it is not present in the library.
6. Used the recommended content from the ESPhome documentation for binary_sensor and sensor sections, excluding "fall_detect".