### PR TITLE
Document PSRAM support for ESP32 configuration

### DIFF
--- a/docs/Sensor/SeeedStudio_XIAO_Gadgets/trmnl_7inch5_diy_kit/works_with_esphome.md
+++ b/docs/Sensor/SeeedStudio_XIAO_Gadgets/trmnl_7inch5_diy_kit/works_with_esphome.md
@@ -667,6 +667,15 @@ You can take a look the effect of the screenshot by input this link in your brow
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/xiao_075inch_epaper_panel/92.jpg" style={{width:800, height:'auto'}}/></div>
 
+Copy the code below and paste it after `esp32`:
+
+```yaml
+# Enable PSRAM support since online_image requires more than the available RAM capacity
+psram:
+  mode: octal
+  speed: 80MHz
+```
+
 You can copy the code below and paste it after `captive_portal` as shown below.
 
 ```yaml
@@ -808,7 +817,12 @@ esp32:
   board: esp32-s3-devkitc-1
   framework:
     type: arduino
-    
+
+# Enable PSRAM support since online_image requires more than the available RAM capacity
+psram:
+  mode: octal
+  speed: 80MHz
+
 # Enable logging
 logger:
 


### PR DESCRIPTION
Without this, the online_image fails with anything that's not a BMP (and even with bitmap rendering, as you add pixels on the screen or pages, it starts to fail too).