### PR TITLE
modify xiao nrf54l15 imu driver

### DIFF
--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54L15-Sense/XIAO_nRF54L15-Sense_Built-in-Sensor.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54L15-Sense/XIAO_nRF54L15-Sense_Built-in-Sensor.md
@@ -49,24 +49,16 @@ Based on VS Code, if you want to use the following case on the nRF Connect SDK, 
 
 To simplify your development experience and ensure a quick start with this IMU program, we've leveraged the PlatformIO platform for writing the necessary driver code. PlatformIO offers a comprehensive and efficient environment for embedded development, making it an ideal choice for the XIAO nRF54L15 Sense.
 
-Before proceeding, please ensure that your development environment is correctly set up. If you haven't yet added the Seeed Studio XIAO nRF54L15 development board to your PlatformIO configuration, kindly refer to this [link](http://localhost:3000/xiao_nrf54l15_with_platform_io/) for detailed instructions on how to configure it. This crucial step will enable PlatformIO to properly recognize and compile code for your board.
+Before proceeding, please ensure that your development environment is correctly set up. If you haven't yet added the Seeed Studio XIAO nRF54L15 development board to your PlatformIO configuration, kindly refer to this [link](https://wiki.seeedstudio.com/xiao_nrf54l15_with_platform_io/) for detailed instructions on how to configure it. This crucial step will enable PlatformIO to properly recognize and compile code for your board.
 
-- Once your environment is ready, the IMU driver will allow you to read raw sensor data from the LSM6DS3TR-C. This data includes:
+Once your environment is ready, the IMU driver will allow you to read raw sensor data from the LSM6DS3TR-C. This data includes:
 
 - Accelerometer raw values (accel raw): Representing the acceleration along the X, Y, and Z axes.
 
 - Gyroscope raw values (gyro raw): Indicating the angular velocity around the X, Y, and Z axes.
 
-Trigger count (trig_cnt): A counter that increments with each new data sample.
+- Trigger count (trig_cnt): A counter that increments with each new data sample.
 
-Below is an example of the serial output you can expect to see from the IMU, as displayed in the PlatformIO Device Monitor. This output provides real-time readings of the accelerometer and gyroscope data, which are fundamental for understanding the motion and orientation of your device.
-
-<div style={{textAlign:'center'}}>
-    <img src="https://files.seeedstudio.com/wiki/XIAO_nRF54L15/Getting_Start/imu_display.png" alt="XIAO nRF54L15 BLE Advertising Power Consumption" style={{width:1000, height:'auto', border:'1px solid #ccc', borderRadius:5, boxShadow:'2px 2px 8px rgba(0,0,0,0.2)'}}/>
-    <p style={{fontSize:'0.9em', color:'#555', marginTop:10}}><em> Real-time IMU Data Output from PlatformIO Device Monitor, displaying raw accelerometer and gyroscope readings.</em></p>
-</div>
-
-This raw data forms the basis for various applications, from simple motion detection to complex orientation tracking, by applying appropriate algorithms (e.g., filtering, sensor fusion).
 
 ---
 
@@ -76,196 +68,146 @@ This raw data forms the basis for various applications, from simple motion detec
     </a>
 </div><br />
 
+Download the repository and open the folder in VS Code. Then click on main.c, and you will see the following code:
+
 ```cpp
 #include <stdio.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-#include <zephyr/drivers/i2c.h>
-#include <zephyr/logging/log.h>
-#include <zephyr/devicetree.h>
+#include <zephyr/drivers/sensor.h>
 
-LOG_MODULE_REGISTER(lsm6dso_i2c_example, LOG_LEVEL_INF);
-
-// --- LSM6DSO I2C address and register definitions ---
-#define LSM6DSO_I2C_ADDR    0x6A // LSM6DSO I2C device address
-
-#define LSM6DSO_REG_WHO_AM_I 0x0F // Identification register
-#define LSM6DSO_WHO_AM_I_VAL 0x6A // Expected WHO_AM_I value
-
-#define LSM6DSO_REG_CTRL1_XL 0x10 // Accelerometer control register
-#define LSM6DSO_REG_CTRL2_G  0x11 // Gyroscope control register
-// Accelerometer/gyroscope data output registers (low byte first)
-#define LSM6DSO_REG_OUTX_L_XL 0x28 // Accelerometer X axis low byte
-#define LSM6DSO_REG_OUTX_L_G  0x22 // Gyroscope X axis low byte
-
-// --- Data structure definitions ---
-// Structure for storing raw sensor data
-struct lsm6dso_raw_data {
-    int16_t accel_x;
-    int16_t accel_y;
-    int16_t accel_z;
-    int16_t gyro_x;
-    int16_t gyro_y;
-    int16_t gyro_z;
-};
-
-// --- Helper functions ---
-
-/**
- * @brief Write a single byte to an LSM6DSO register via I2C.
- */
-static int lsm6dso_i2c_reg_write_byte(const struct device *i2c_dev, uint8_t reg_addr, uint8_t value)
+static inline float out_ev(struct sensor_value *val)
 {
-    uint8_t tx_buf[2] = {reg_addr, value};
-    return i2c_write(i2c_dev, tx_buf, sizeof(tx_buf), LSM6DSO_I2C_ADDR);
+	return (val->val1 + (float)val->val2 / 1000000);
 }
 
-/**
- * @brief Read a single byte from an LSM6DSO register via I2C.
- */
-static int lsm6dso_i2c_reg_read_byte(const struct device *i2c_dev, uint8_t reg_addr, uint8_t *value)
+static void fetch_and_display(const struct device *dev)
 {
-    return i2c_reg_read_byte(i2c_dev, LSM6DSO_I2C_ADDR, reg_addr, value);
+	struct sensor_value x, y, z;
+	static int trig_cnt;
+
+	trig_cnt++;
+
+	/* lsm6dsl accel */
+	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
+	sensor_channel_get(dev, SENSOR_CHAN_ACCEL_X, &x);
+	sensor_channel_get(dev, SENSOR_CHAN_ACCEL_Y, &y);
+	sensor_channel_get(dev, SENSOR_CHAN_ACCEL_Z, &z);
+
+	printf("accel x:%f ms/2 y:%f ms/2 z:%f ms/2\n",
+			(double)out_ev(&x), (double)out_ev(&y), (double)out_ev(&z));
+
+	/* lsm6dsl gyro */
+	sensor_sample_fetch_chan(dev, SENSOR_CHAN_GYRO_XYZ);
+	sensor_channel_get(dev, SENSOR_CHAN_GYRO_X, &x);
+	sensor_channel_get(dev, SENSOR_CHAN_GYRO_Y, &y);
+	sensor_channel_get(dev, SENSOR_CHAN_GYRO_Z, &z);
+
+	printf("gyro x:%f rad/s y:%f rad/s z:%f rad/s\n",
+			(double)out_ev(&x), (double)out_ev(&y), (double)out_ev(&z));
+
+	printf("trig_cnt:%d\n\n", trig_cnt);
 }
 
-/**
- * @brief Read multiple consecutive bytes from LSM6DSO register via I2C.
- */
-static int lsm6dso_i2c_reg_read_bytes(const struct device *i2c_dev, uint8_t reg_addr, uint8_t *data, uint8_t len)
+static int set_sampling_freq(const struct device *dev)
 {
-    return i2c_burst_read(i2c_dev, LSM6DSO_I2C_ADDR, reg_addr, data, len);
+	int ret = 0;
+	struct sensor_value odr_attr;
+
+	/* set accel/gyro sampling frequency to 12.5 Hz */
+	odr_attr.val1 = 12.5;
+	odr_attr.val2 = 0;
+
+	ret = sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ,
+			SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr);
+	if (ret != 0) {
+		printf("Cannot set sampling frequency for accelerometer.\n");
+		return ret;
+	}
+
+	ret = sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ,
+			SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr);
+	if (ret != 0) {
+		printf("Cannot set sampling frequency for gyro.\n");
+		return ret;
+	}
+
+	return 0;
 }
 
-// --- LSM6DSO driver core functionality ---
-
-/**
- * @brief Initialize the LSM6DSO sensor.
- * Check WHO_AM_I and set ODR for accelerometer and gyroscope.
- */
-static int lsm6dso_init(const struct device *i2c_dev)
+#ifdef CONFIG_LSM6DSL_TRIGGER
+static void trigger_handler(const struct device *dev,
+			    const struct sensor_trigger *trig)
 {
-    uint8_t who_am_i = 0;
-    int ret;
-
-    // Verify device ID
-    ret = lsm6dso_i2c_reg_read_byte(i2c_dev, LSM6DSO_REG_WHO_AM_I, &who_am_i);
-    if (ret != 0) {
-        LOG_ERR("Failed to read WHO_AM_I register (err: %d)", ret);
-        return ret;
-    }
-    if (who_am_i != LSM6DSO_WHO_AM_I_VAL) {
-        LOG_ERR("Invalid WHO_AM_I: 0x%02x, expected 0x%02x", who_am_i, LSM6DSO_WHO_AM_I_VAL);
-        return -ENODEV;
-    }
-    LOG_INF("LSM6DSO WHO_AM_I check passed. ID: 0x%02x", who_am_i);
-
-    // Set accelerometer ODR (12.5 Hz) and 2g range (0x20)
-    ret = lsm6dso_i2c_reg_write_byte(i2c_dev, LSM6DSO_REG_CTRL1_XL, 0x20);
-    if (ret != 0) {
-        LOG_ERR("Failed to set CTRL1_XL register (err: %d)", ret);
-        return ret;
-    }
-
-    // Set gyroscope ODR (12.5 Hz) and 250dps range (0x20)
-    ret = lsm6dso_i2c_reg_write_byte(i2c_dev, LSM6DSO_REG_CTRL2_G, 0x20);
-    if (ret != 0) {
-        LOG_ERR("Failed to set CTRL2_G register (err: %d)", ret);
-        return ret;
-    }
-
-    LOG_INF("LSM6DSO initialized successfully.");
-    return 0;
+	fetch_and_display(dev);
 }
 
-/**
- * @brief Fetch raw accelerometer and gyroscope data from LSM6DSO sensor.
- * @param i2c_dev Pointer to I2C device structure.
- * @param raw_data_out Pointer to structure for storing raw data.
- * @return 0 on success, negative value on failure.
- */
-static int lsm6dso_fetch_raw_data(const struct device *i2c_dev, struct lsm6dso_raw_data *raw_data_out)
+static void test_trigger_mode(const struct device *dev)
 {
-    uint8_t accel_data[6];
-    uint8_t gyro_data[6];
-    int ret;
+	struct sensor_trigger trig;
 
-    // Read accelerometer data (6 bytes)
-    ret = lsm6dso_i2c_reg_read_bytes(i2c_dev, LSM6DSO_REG_OUTX_L_XL, accel_data, 6);
-    if (ret != 0) {
-        LOG_ERR("Failed to read accelerometer data (err: %d).", ret);
-        return ret;
-    }
-    // Raw data is 16-bit signed integer, low byte first
-    raw_data_out->accel_x = (int16_t)(accel_data[0] | (accel_data[1] << 8));
-    raw_data_out->accel_y = (int16_t)(accel_data[2] | (accel_data[3] << 8));
-    raw_data_out->accel_z = (int16_t)(accel_data[4] | (accel_data[5] << 8));
+	if (set_sampling_freq(dev) != 0) {
+		return;
+	}
 
-    // Read gyroscope data (6 bytes)
-    ret = lsm6dso_i2c_reg_read_bytes(i2c_dev, LSM6DSO_REG_OUTX_L_G, gyro_data, 6);
-    if (ret != 0) {
-        LOG_ERR("Failed to read gyroscope data (err: %d).", ret);
-        return ret;
-    }
-    // Raw data is 16-bit signed integer, low byte first
-    raw_data_out->gyro_x = (int16_t)(gyro_data[0] | (gyro_data[1] << 8));
-    raw_data_out->gyro_y = (int16_t)(gyro_data[2] | (gyro_data[3] << 8));
-    raw_data_out->gyro_z = (int16_t)(gyro_data[4] | (gyro_data[5] << 8));
+	trig.type = SENSOR_TRIG_DATA_READY;
+	trig.chan = SENSOR_CHAN_ACCEL_XYZ;
 
-    return 0;
+	if (sensor_trigger_set(dev, &trig, trigger_handler) != 0) {
+		printf("Could not set sensor type and channel\n");
+		return;
+	}
 }
 
-/**
- * @brief Display raw accelerometer and gyroscope data.
- * @param raw_data Pointer to structure containing raw data.
- * @param count Polling counter.
- */
-static void lsm6dso_display_raw_data(const struct lsm6dso_raw_data *raw_data, int count)
+#else
+static void test_polling_mode(const struct device *dev)
 {
-    printf("accel raw: X:%d Y:%d Z:%d (LSB)\n",
-           raw_data->accel_x, raw_data->accel_y, raw_data->accel_z);
-    printf("gyro raw: X:%d Y:%d Z:%d (LSB)\n",
-           raw_data->gyro_x, raw_data->gyro_y, raw_data->gyro_z);
-    printf("trig_cnt:%d\n\n", count);
-}
+	if (set_sampling_freq(dev) != 0) {
+		return;
+	}
 
-// --- Main function ---
+	while (1) {
+		fetch_and_display(dev);
+		k_sleep(K_MSEC(1000));
+	}
+}
+#endif
 
 int main(void)
 {
-    const struct device *i2c_dev = DEVICE_DT_GET(DT_NODELABEL(i2c30));
-    struct lsm6dso_raw_data sensor_data;
-    static int trig_cnt = 0; // Ensure only initialized once in main scope
+	const struct device *const dev = DEVICE_DT_GET(DT_ALIAS(imu0));
 
-    if (!device_is_ready(i2c_dev)) {
-        LOG_ERR("I2C device %s is not ready!", i2c_dev->name);
-        return 0;
-    }
-    LOG_INF("I2C device %s is ready.", i2c_dev->name);
+	if (!device_is_ready(dev)) {
+		printk("%s: device not ready.\n", dev->name);
+		return 0;
+	}
 
-    if (lsm6dso_init(i2c_dev) != 0) {
-        LOG_ERR("Failed to initialize LSM6DSO sensor.");
-        return 0;
-    }
-
-    printf("Testing LSM6DSO sensor in polling mode (custom I2C driver) - Raw Data Output.\n\n");
-
-    while (1) {
-        trig_cnt++; // Increment counter at the start of each loop
-
-        // Fetch raw data
-        if (lsm6dso_fetch_raw_data(i2c_dev, &sensor_data) == 0) {
-            // Display raw data
-            lsm6dso_display_raw_data(&sensor_data, trig_cnt);
-        } else {
-            LOG_ERR("Failed to fetch data.");
-        }
-
-        k_sleep(K_MSEC(1000)); // Read once every second
-    }
-
-    return 0;
+#ifdef CONFIG_LSM6DSL_TRIGGER
+	printf("Testing LSM6DSL sensor in trigger mode.\n\n");
+	test_trigger_mode(dev);
+#else
+	printf("Testing LSM6DSL sensor in polling mode.\n\n");
+	test_polling_mode(dev);
+#endif
+	return 0;
 }
 ```
+
+Now, connect your XIAO nRF54L15 to your computer via USB. In VS Code:
+
+- Build: Click the "Build" icon (checkmark) in the PlatformIO toolbar at the bottom of VS Code, or use the PlatformIO sidebar: PROJECT TASKS -> your_project_name -> General -> Build.
+
+- Upload: After a successful build, click the "Upload" icon (right arrow) in the PlatformIO toolbar, or use the PlatformIO sidebar: PROJECT TASKS -> your_project_name -> General -> Upload.
+
+After a successful upload, you should see output similar to the example below in the PlatformIO Device Monitor. This serial output shows real-time accelerometer and gyroscope readings, providing key insights into the motion and orientation of your device.
+
+<div style={{textAlign:'center'}}>
+    <img src="https://files.seeedstudio.com/wiki/XIAO_nRF54L15/Getting_Start/imu_display.png" alt="XIAO nRF54L15 BLE Advertising Power Consumption" style={{width:1000, height:'auto', border:'1px solid #ccc', borderRadius:5, boxShadow:'2px 2px 8px rgba(0,0,0,0.2)'}}/>
+    <p style={{fontSize:'0.9em', color:'#555', marginTop:10}}><em> Real-time IMU Data Output from PlatformIO Device Monitor, displaying raw accelerometer and gyroscope readings.</em></p>
+</div>
+
+This raw data forms the basis for various applications, from simple motion detection to complex orientation tracking, by applying appropriate algorithms (e.g., filtering, sensor fusion).
+
 
 ## XIAO nRF54L15 Sense MIC
 


### PR DESCRIPTION
Switch to the Nordic official IMU driver for better SDK compatibility, stability, and reduced upgrade risk. And correct the IMU device to LSM6DS3TR-C (previously misidentified as LSM6DSO).