### PR TITLE
fix: Escape tilde to avoid rendering as strike-through text

### DIFF
--- a/docs/Edge/Raspberry_Pi_Devices/Edge_Controller/reComputer_R1000/recomputer_r.md
+++ b/docs/Edge/Raspberry_Pi_Devices/Edge_Controller/reComputer_R1000/recomputer_r.md
@@ -136,7 +136,7 @@ With robust IoT network communication capabilities, the R1000 series supports mu
     </tr>
     <tr data-style="height: 18px;" style={{height: 18}}>
       <td data-style="height: 18px; width: 35.4622%;" colSpan={1} style={{height: 18, width: '35.4622%'}}>Supply Voltage(AC/DC)</td>
-      <td data-style="height: 18px; width: 63.1933%;" colSpan={2} style={{height: 18, width: '63.1933%'}}>12~24V AC/9~36V DC</td>
+      <td data-style="height: 18px; width: 63.1933%;" colSpan={2} style={{height: 18, width: '63.1933%'}}>12\~24V AC/9\~36V DC</td>
     </tr>
     <tr data-style="height: 18px;" style={{height: 18}}>
       <td data-style="height: 18px; width: 35.4622%;" colSpan={1} style={{height: 18, width: '35.4622%'}}>Overvoltage Protection</td>


### PR DESCRIPTION
The tilde in the docs render as strikethrough, this is a small fix

Illustration of problem:
<img width="834" height="66" alt="image" src="https://github.com/user-attachments/assets/dd7a752f-470a-46c2-9927-7f5229662567" />

Link to page:
- https://wiki.seeedstudio.com/recomputer_r/#:~:text=Supply%20Voltage%28AC%2FDC