### PR TITLE
Change ESP32 framework type from Arduino to ESP-IDF

### DIFF
--- a/docs/Edge/reTerminal_E10xx/Applications/reterminal_e10xx_with_esphome_advance.md
+++ b/docs/Edge/reTerminal_E10xx/Applications/reterminal_e10xx_with_esphome_advance.md
@@ -192,7 +192,7 @@ esphome:
 esp32:
   board: esp32-s3-devkitc-1
   framework:
-    type: arduino
+    type: esp-idf
 
 # Enable logging
 logger:
@@ -630,7 +630,7 @@ esphome:
 esp32:
   board: esp32-s3-devkitc-1
   framework:
-    type: arduino
+    type: esp-idf
 
 # Enable logging
 logger:
@@ -952,7 +952,7 @@ esphome:
 esp32:
   board: esp32-s3-devkitc-1
   framework:
-    type: arduino
+    type: esp-idf
 
 # Enable logging
 logger:


### PR DESCRIPTION
esp-idf is the [default framework](https://github.com/esphome/esphome/pull/12746) for ESP32 in esphome 2026.1. There is no need to use the arduino framework specifically.