### PR TITLE
fix the content for XIAO ESP32-C5 and Others

### DIFF
--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_Getting_Started.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_Getting_Started.md
@@ -454,7 +454,7 @@ After entering deep sleep mode, the XIAO's port will disappear and you'll need t
 In the program, we are using a **D1** low level to wake up. This means that we can connect a button to pin D1 and the XIAO will wake up when we press the button.
 
 :::caution
-The XIAO ESP32-C3 supports GPIO wake-up and timer wake-up. To prevent the loss of hardware debugging capabilities and increased difficulty in firmware flashing during low-power development, it is strongly recommended that the JTAG (MTMS, MTDI, MTCK, MTDO) pins be reserved for dedicated use and not employed as wake-up sources for deep sleep mode.
+The XIAO ESP32-C3 supports GPIO wake-up and timer wake-up, and the pins that support wake-up are D0~D3.
 :::
 
 ## Troubleshooting

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_Getting_Started.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C3/XIAO_ESP32C3_Getting_Started.md
@@ -454,7 +454,7 @@ After entering deep sleep mode, the XIAO's port will disappear and you'll need t
 In the program, we are using a **D1** low level to wake up. This means that we can connect a button to pin D1 and the XIAO will wake up when we press the button.
 
 :::caution
-Currently the XIAO ESP32C3 only supports GPIO wake-up, and the only pins that support wake-up are D0~D3. This program may not work on other pins.
+The XIAO ESP32-C3 supports GPIO wake-up and timer wake-up. To prevent the loss of hardware debugging capabilities and increased difficulty in firmware flashing during low-power development, it is strongly recommended that the JTAG (MTMS, MTDI, MTCK, MTDO) pins be reserved for dedicated use and not employed as wake-up sources for deep sleep mode.
 :::
 
 ## Troubleshooting

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C5/XIAO_ESP32C5_Getting_Started.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32C5/XIAO_ESP32C5_Getting_Started.md
@@ -141,8 +141,8 @@ last_update:
 | 5V                     | VBUS       |           |                          | Power Input/Output           |
 | GND                    |            |           |                          |                              |
 | 3V3                    | 3V3_OUT    |           |                          | Power Output                 |
-| D0                     | Analog     | GPIO1     | LP_UART_DSRN,LP_GPIO1    | GPIO, ADC                    |
-| D1                     |            | GPIO0     | LP_UART_DTRN,LP_GPIO0    | GPIO                         |
+| D0                     | Analog     | GPIO1     | LP_UART_DSRN, LP_GPIO1   | GPIO, ADC                    |
+| D1                     |            | GPIO0     | LP_UART_DTRN, LP_GPIO0   | GPIO                         |
 | D2                     |            | GPIO25    |                          | GPIO                         |
 | D3                     |            | GPIO7     | SDIO_DATA1               | GPIO                         |
 | D4                     | SDA        | GPIO23    |                          | GPIO, I2C Data               |
@@ -152,10 +152,10 @@ last_update:
 | D8                     | SCK        | GPIO8     | TOUCH7                   | GPIO, SPI Clock              |
 | D9                     | MISO       | GPIO9     | TOUCH8                   | GPIO, SPI Data               |
 | D10                    | MOSI       | GPIO10    | TOUCH9                   | GPIO, SPI Data               |
-| MTDO                   |            | GPIO5     |                          | JTAG                         |
-| MTDI                   |            | GPIO3     |                          | JTAG, ADC                    |
-| MTCK                   |            | GPIO4     |                          | JTAG, ADC                    |
-| MTMS                   |            | GPIO2     |                          | JTAG, ADC                    |
+| MTDO                   |            | GPIO5     | LP_UART_TXD, LP_GPIO5    | JTAG                         |
+| MTDI                   |            | GPIO3     | LP_I2C_SCL, LP_GPIO3     | JTAG, ADC                    |
+| MTCK                   |            | GPIO4     | LP_UART_RXD, LP_GPIO4    | JTAG, ADC                    |
+| MTMS                   |            | GPIO2     | LP_I2C_SDA, LP_GPIO2     | JTAG, ADC                    |
 | ADC_BAT                |            | GPIO6    |                          | Read the BAT voltage value   |
 | ADC_CRL                |            | GPIO26    |                          | Controls (enables/disables) the measurement circuit to save power.   |
 | Reset                  |            | CHIP_EN   |                          | EN                           |
@@ -319,7 +319,7 @@ After entering deep sleep mode, the XIAO's port will disappear and you'll need t
 :::
 
 :::caution
-Currently the XIAO ESP32-C5 only supports GPIO wake-up, and the only pins that support wake-up are D0~D1. This program may not work on other pins.
+The XIAO ESP32-C5 supports GPIO wake-up and timer wake-up. To prevent the loss of hardware debugging capabilities and increased difficulty in firmware flashing during low-power development, it is strongly recommended that the JTAG (MTMS, MTDI, MTCK, MTDO) pins be reserved for dedicated use and not employed as wake-up sources for deep sleep mode.
 :::
 
 ## Battery Usage
@@ -382,8 +382,16 @@ According to the datasheet, the effective measurement range of the ESP32-C5 cove
 ## Resource
 
 - **[PDF]** [ESP32-C5 datasheet](https://files.seeedstudio.com/wiki/XIAO_ESP32C5/res/esp32-c5_datasheet_en.pdf)
+
 - **[PCB Design Files]** [XIAO ESP32-C5 KiCad Project](https://files.seeedstudio.com/wiki/XIAO_ESP32C5/res/Seeed_Studio_XIAO_ESP32C5.zip)
+
 - **[Schematic]** [XIAO ESP32-C5 Schematic](https://files.seeedstudio.com/wiki/XIAO_ESP32C5/res/Seeed_Studio_XIAO_ESP32C5.pdf)
+
+- **[XLSX]** [XIAO ESP32-C5 pinout sheet](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32C6/res/XIAO_ESP32C6_Pinout.xlsx)
+
+- **[Kicad]** [XIAO ESP32-C5 FootPrint](https://github.com/Seeed-Studio/OPL_Kicad_Library/tree/master/Seeed%20Studio%20XIAO%20Series%20Library)
+
+- **[STEP]** [XIAO ESP32-C5 Step file](https://grabcad.com/library/seeed-studio-xiao-esp32-c5-1)
 
 ## Tech Support & Product Discussion
 

--- a/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_SAMD21/Seeeduino-XIAO.md
+++ b/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_SAMD21/Seeeduino-XIAO.md
@@ -107,7 +107,7 @@ Please pay attention to use, do not lift the shield cover.
 |Reset          |                 |  RES	                                |	RESET                  |
 |TX_LED         |                 |   PA19	                              |	TX_LED                 |
 |RX_LED         |                 | PA18	                                |	RX_LED                 |
-|CHARGE_LED     |          |        VBUS	                                |       	CHG-LED_Red      |
+|Power_LED     |          |        VBUS	                                |       	CHG-LED_Red      |
 |USER_LED       |                 |   PA17	                              |	User Light_Yellow      |
 
 ### **Enter Bootloader Mode**

--- a/docs/Sensor/SeeedStudio_XIAO_Gadgets/xiao_w5500_ethernet_adapter/esphome_with_xiao_w5500_ethernet_adapter.md
+++ b/docs/Sensor/SeeedStudio_XIAO_Gadgets/xiao_w5500_ethernet_adapter/esphome_with_xiao_w5500_ethernet_adapter.md
@@ -122,10 +122,11 @@ If you have not set up Home Assistant, you can click this link and follow the of
 <summary>Click here to copy the yaml file</summary>
 
 ```yaml
+# Only boards produced after November 1, 2025 are supported
 esphome:
-  name: seeed-esp32-s3
+  name: seeed-esp32-poe
   friendly_name: Bluetooth Proxy
-  min_version: 2025.8.0
+  min_version: 2025.11.0
   name_add_mac_suffix: true
 
 esp32:
@@ -135,10 +136,11 @@ esp32:
 
 ethernet:
   type: W5500
-  cs_pin: GPIO2
   clk_pin: GPIO7
   mosi_pin: GPIO9
   miso_pin: GPIO8
+  cs_pin: GPIO2
+  interrupt_pin: GPIO10
 
 api:
 logger:
@@ -147,14 +149,14 @@ ota:
   - platform: esphome
     id: ota_esphome
 
+esp32_ble:
+  max_connections: 4
+
 esp32_ble_tracker:
-  scan_parameters:
-    interval: 1100ms
-    window: 1100ms
-    active: true
 
 bluetooth_proxy:
   active: true
+  connection_slots: 4
 
 button:
   - platform: safe_mode


### PR DESCRIPTION
- Add the missing contents of XIAO ESP320C5 PinMap
- Fix the descriptions regarding low power consumption for ESP32-C5 and ESP32-C3
- Fix the content of PinMap in SAMD21
- Add the missing resource links for the ESP32-C5