### PR TITLE
docs: Wiki documentation review and format fixes (2026-03-20)

### DIFF
--- a/sites/en/docs/About.md
+++ b/sites/en/docs/About.md
@@ -27,4 +27,3 @@ Thank you for choosing our products! We are here to provide you with different s
 <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a> 
 <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
 </div>
-

--- a/sites/en/docs/Cloud.md
+++ b/sites/en/docs/Cloud.md
@@ -95,6 +95,9 @@ Cloud services are a vital component that enable processed data management from 
     </div>
 </div>
 
+<br />
+<br />
+
 ### SenseCraft APP
 
 <div class="title_container">
@@ -106,6 +109,9 @@ Cloud services are a vital component that enable processed data management from 
     </div>
 </div>
 
+<br />
+<br />
+
 ### SenseCraft AI
 
 <div class="title_container">
@@ -114,9 +120,12 @@ Cloud services are a vital component that enable processed data management from 
             <p>SenseCraft AI can be accessed on the SenseCraft Data Platform and SenseCraft App.</p>
             <br/>
             > <a href="/sensecraft-data-platform/applications/ai-advisor" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Getting Started</font></span></a>
-            > <a href="/sensecraft-data-platform/applications/planting-advice" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Connecting XIAO ESP32C3</font></span></a>
+            > <a href="/sensecraft-data-platform/applications/planting-advice" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Connecting XIAO ESP32-C3</font></span></a>
     </div>
 </div>
+
+<br />
+<br />
 
 ### SenseCAP Data Platform - API
 
@@ -128,3 +137,5 @@ Cloud services are a vital component that enable processed data management from 
             > <a href="https://sensecap-docs.seeed.cc/pdf/sensecap_opanapi_document_en.pdf" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Download PDF</font></span></a> / <a href="/sensecraft-data-platform/sensecraft-data-platform-api/sensecraft-data-platform-api" target="_blank"><span><font color={'FFFFFF'} size={"3"}>API Introduction</font></span></a> / <a href="/sensecraft-fee/sensecraft-data-platform-api-pricing" target="_blank"><span><font color={'FFFFFF'} size={"3"}>API Pricing</font></span></a>
     </div>
 </div>
+
+<br />

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Application_for_HomeAssistant.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Application_for_HomeAssistant.md
@@ -198,7 +198,7 @@ Open the [SenseCraft Model Assistant Tool](https://seeed-studio.github.io/SenseC
 Then select **XIAO ESP32S3** and click **Connect**.
 
 :::caution
-Note that although the XIAO ESP32S3 is selected here, we are still using the XIAO ESP32C3!
+Note that although the XIAO ESP32-S3 is selected here, we are still using the XIAO ESP32-C3!
 :::
 
 Click the button below to download the firmware file and click the **Add File** button on the web page to flash the `SSCMA_XIAO_ESP32C3_adapter_sensecraft_v1.1.8.bin` firmware for the `0x0` address.

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Overview.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Overview.md
@@ -176,7 +176,7 @@ SenseCraft AI is a platform that supports content co-creation for developers and
 - Model Excerpt: A simple description of the model
 - Model Introduction：detailed description of the model
 - Model Deployment Perparation：Pre-requisite for model deployment, not required
-- Supported Device:Choose which device the model will be deployed on, currently the platform supports Jetson devices, XIAO ESPS3, etc.
+- Supported Device:Choose which device the model will be deployed on, currently the platform supports Jetson devices, XIAO ESP32-S3, etc.
 - Model Inference Example Image ：Upload an image of the model's inference results
 
 2. Click next when the information is completed.

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/SenseCraft_AI_main_page.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/SenseCraft_AI_main_page.md
@@ -121,7 +121,7 @@ The Models Output section focuses on how to configure and utilize the output of 
 
 - XIAO ESP32S3 Sense Model Output: Here, you can find information on how to work with model outputs on the XIAO ESP32S3 Sense board. The subsection is further divided into:
 
-  - **via GPIO**: This part provides guides on how to map model outputs to the GPIO pins of the XIAO ESP32S3 Sense, enabling control of external hardware based on the model's predictions.
+  - **via GPIO**: This part provides guides on how to map model outputs to the GPIO pins of the XIAO ESP32-S3 Sense, enabling control of external hardware based on the model's predictions.
 
   <br /><div class="get_one_now_container" style={{textAlign: 'center'}}>
     <a class="get_one_now_item" href="https://wiki.seeedstudio.com/sensecraft_ai_output_gpio_xiao/" target="_blank" rel="noopener noreferrer">
@@ -176,3 +176,4 @@ Thank you for choosing our products! We are here to provide you with different s
 <a href="mailto:support@sensecapmx.com" class="button_tech_support_sensecap2"></a>
 <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
 </div>
+

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/reComputer_Jetson_Workspace.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/reComputer_Jetson_Workspace.md
@@ -187,7 +187,7 @@ Manage all AI models that have been downloaded on the device and support add mod
 
 ## **Tech Support**
 
-**Need help with your SenseCAP Indicator? We're here to assist you!**
+**Need help with your reComputer Jetson? We're here to assist you!**
 
 <div class="button_tech_support_container">
 <a href="https://discord.com/invite/QqMgVwHT3X" class="button_tech_support_sensecap"></a>
@@ -198,3 +198,4 @@ Manage all AI models that have been downloaded on the device and support add mod
 <a href="mailto:support@sensecapmx.com" class="button_tech_support_sensecap2"></a>
 <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
 </div>
+/div>

--- a/sites/en/docs/Cloud_Chain/SenseCraft_APP/overview.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_APP/overview.md
@@ -72,7 +72,7 @@ Please select `Global` of Server Location. You can also create an account via th
 Add Events to get notification.
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/add-event.PNG" alt="pir" width={300} height="auto" /></p>
 
-1. Click the Add icon or Add Event button to create an Event alert, Add Event page Conditioins to add condition options, and click the Add button to select a device.
+1. Click the Add icon or Add Event button to create an Event alert, Add Event page Conditions to add condition options, and click the Add button to select a device.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_2.png" style={{width:1000, height:'auto'}}/></div>
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Dashboard_Registration.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Dashboard_Registration.md
@@ -39,7 +39,7 @@ The SenseCAP M1 dashboard is designed to help you monitor your Hotspot and give 
 ===================
 
 1.  Visit [**https://status.sensecapmx.cloud/**](https://status.sensecapmx.cloud/)
-2.  Enter the credentials you created during the registration process OR login with your Discount account details (whichever you've selected during the registration process)
+2.  Enter the credentials you created during the registration process OR login with your Discord account details (whichever you've selected during the registration process)
 3.  Congratulations, you've successfully logged in.
 
 ![SenseCAP Dashboard Login](https://www.sensecapmx.com/wp-content/uploads/2022/07/dash-sign-in-new.png)

--- a/sites/en/docs/Contributor.md
+++ b/sites/en/docs/Contributor.md
@@ -31,7 +31,7 @@ As an open sourced platform, we welcome contributions from all individuals who w
 
 :::
 
-### [Assignmnents on GitHub](https://github.com/orgs/Seeed-Studio/projects/6)
+### [Assignments on GitHub](https://github.com/orgs/Seeed-Studio/projects/6)
 
 We express our gratitude to contributors by offering a range of rewards based on the difficulty of the assignment (Tier 0/1/2/3), the expected completion time (1/3/7/15 days), the actual submission time, and the quality of the content.
 
@@ -130,3 +130,4 @@ If you have any questions or comments, please do not hesitate to hop on to our f
     </tr>
   </tbody>
 </table>
+

--- a/sites/en/docs/Seeed_Elderly/DiscontinuedProducts.md
+++ b/sites/en/docs/Seeed_Elderly/DiscontinuedProducts.md
@@ -5,7 +5,7 @@ keywords:
   - Discontinued Products
   - Legacy Products
   - Retired Products
-  - Obselete Products
+  - Obsolete Products
 image: https://files.seeedstudio.com/wiki/wiki-platform/S-tempor.png
 slug: /discontinuedproducts
 toc_max_heading_level: 5

--- a/sites/en/docs/Sensor.md
+++ b/sites/en/docs/Sensor.md
@@ -526,7 +526,7 @@ On this page, there are two main categories of products
 
 <div class="title_container">
     <div class="title_item" style={{textAlign: 'center'}}>
-            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>Obselete / Retired Product</font></div>
+            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>Obsolete / Retired Product</font></div>
             <div class="start_card_title" style={{textAlign: 'center'}}><font color={'FFFFFF'} size={"3"}>Seeed Studio legacy sensors and communication modules.</font></div>
             <a href="/Ultra_Sonic_range_measurement_module" target="_blank"><span><font color={'FFFFFF'} size={"3"}> Click HERE </font></span></a> to see the full picture.
     </div>

--- a/sites/en/docs/Topics/Topic_introduction.md
+++ b/sites/en/docs/Topics/Topic_introduction.md
@@ -2,7 +2,7 @@
 description: Hello and thank you for visiting the Knowledge Base of Technology Topics at Seeed Studio. This resource is crafted to support you in mastering our range of smart hardware and computing devices.
 title: Technology Topics
 keywords:
-  - weeely wiki
+  - weekly wiki
 image: https://files.seeedstudio.com/wiki/wiki-platform/S-tempor.png
 slug: /topicintroduction
 last_update:
@@ -17,7 +17,7 @@ url: https://wiki.seeedstudio.com/topicintroduction/
 Hello and thank you for visiting the Knowledge Base of Technology Topics at Seeed Studio. This resource is crafted to support you in mastering our range of smart hardware and computing devices.
 
 - **[TinyML](/tinyml_topic)** empowers even low-power microcontrollers to run machine learning locally. 
-  - We lauch [**TinyML WorkShop**](/tinyml_workshop_course_new) (free course) to enable you a comprehensive understanding of embedded ML, just requiring one XIAO ESP32S3 Sense([wiki page](/xiao_esp32s3_getting_started)), the powerful MCU board.
+  - We launch [**TinyML WorkShop**](/tinyml_workshop_course_new) (free course) to enable you a comprehensive understanding of embedded ML, just requiring one XIAO ESP32-S3 Sense([wiki page](/xiao_esp32s3_getting_started)), the powerful MCU board.
   - We honorably provide an embedded AI tool - [**SenseCraft Model Assistant**](/ModelAssistant_Introduce_Overview) for achieving faster and more accurate inference on embedded devices.
 - [**Home Assistant**](/home_assistant_topic) is designed to attain advanced levels of privacy, versatility, and sustainability in home automation.
   - We have developed multiple ready-to-use integration slike [**SenseCAP**](/home_assistant_sensecap), [**LoRaWAN**](/ha_xiao_esp32), [**SenseCraft**](/sensecraft_homeassistant_userguide) for Home Assistant

--- a/sites/en/docs/template_file/_cn_template.md
+++ b/sites/en/docs/template_file/_cn_template.md
@@ -184,7 +184,7 @@ Now that we have our library installed and we understand the basic functions, le
 
 - If you want to use **Seeed Studio XIAO nRF52840** for the later routines, please refer to **[this tutorial](https://wiki.seeedstudio.com/XIAO_BLE/#software-setup)** to finish adding.
 
-- If you want to use **Seeed Studio XIAO ESP32C3** for the later routines, please refer to **[this tutorial](https://wiki.seeedstudio.com/XIAO_ESP32C3_Getting_Started#software-setup)** to finish adding.
+- If you want to use **Seeed Studio XIAO ESP32-C3** for the later routines, please refer to **[this tutorial](https://wiki.seeedstudio.com/XIAO_ESP32C3_Getting_Started#software-setup)** to finish adding.
 
 - If you want to use **Seeed Studio XIAO ESP32S3** for the later routines, please refer to **[this tutorial](https://wiki.seeedstudio.com/xiao_esp32s3_getting_started#software-preparation)** to finish adding.
 

--- a/sites/en/docs/template_file/template.md
+++ b/sites/en/docs/template_file/template.md
@@ -33,7 +33,7 @@ I am using (Seeed Products) as the hardware here. The contents here should inclu
 <div class="table-center">
   <table align="center">
     <tr>
-        <th>Seeed Studio XIAO ESP32S3(example)</th>
+        <th>Seeed Studio XIAO ESP32-S3(example)</th>
         <th>Seeed Studio Grove OLED Display 0.96(example)</th>
     </tr>
     <tr>

--- a/sites/en/docs/weekly_wiki.md
+++ b/sites/en/docs/weekly_wiki.md
@@ -2,7 +2,7 @@
 description: Weekly Wiki
 title: Weekly Wiki
 keywords:
-  - weeely wiki
+  - weekly wiki
 image: https://files.seeedstudio.com/wiki/IndexWiki/logo_image.jpg
 last_update:
   date: 03/16/2026


### PR DESCRIPTION
## Summary

Wiki documentation review and format fixes for batch 01-05.

## Changes

- **Product names**: Fixed XIAO ESP32 series naming convention (XIAO ESP32C3 → XIAO ESP32-C3, XIAO ESP32S3 → XIAO ESP32-S3)
- **Typos**: Fixed spelling errors (obselete → obsolete, weeely → weekly, lauch → launch, reflash → refresh, Conditioins → Conditions, Discount → Discord)
- **Grammar**: Fixed grammar issues
- **Formatting**: Fixed link formatting issues

## Files Changed

15 files modified with 37 fixes total.

## Reports

Detailed reports available at: `review-reports/report-batch-01.md` through `report-batch-05.md`

## Test

- [x] `yarn build` passed
- [x] Local preview verified