### PR TITLE
docs: add XIAO ESP32S3 B2B pin diagram

### DIFF
--- a/sites/en/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/Get_Started_meshtastic.md
+++ b/sites/en/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/Get_Started_meshtastic.md
@@ -101,6 +101,12 @@ The last four digits of nodenum are the device number ID discovered by the mesht
 ### Connected to SX-1262
 
 The SX-1262 can be connected to the Xiao ESP32-S3 via the B2B interface. The SX-1262 uses SPI to  communicate with Xiao ESP32-S3.
+
+The following diagram shows the B2B pin mapping between XIAO ESP32S3 and Wio-SX1262.
+
+<div style={{textAlign:'center'}}>
+  <img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/img/ESP32-S3B2B%E5%BA%A7%E5%AD%90%E5%BC%95%E8%84%9A%E5%9B%BE.png" style={{width:700, height:'auto'}} alt="B2B pin mapping between XIAO ESP32S3 and Wio-SX1262"/>
+</div>
 :::warning
 The compatible SX-1262 can only be bought within the kit.
 :::


### PR DESCRIPTION
## Summary\n- add the B2B pin mapping diagram for XIAO ESP32S3 and Wio-SX1262\n- place the diagram in the Connected to SX-1262 section of the getting started guide\n\n## Testing\n- yarn start:en\n- verified the page locally at http://localhost:3000/xiao_esp32s3_%26_wio_SX1262_kit_for_meshtastic/\n