### PR TITLE
fix: update Grove Shield XIAO charging current from 400mA to 500mA

### DIFF
--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Expansion_board/Grove-Shield-for-Seeeduino-XIAO-embedded-battery-management-chip.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Expansion_board/Grove-Shield-for-Seeeduino-XIAO-embedded-battery-management-chip.md
@@ -62,7 +62,7 @@ This product does not include a Seeed Studio XIAO board, please click [here](ht
 |---|---|
 |Operating voltage|3.3V / 3.7V Lithium Battery|
 |Load Capacity|800mA|
-|Charging current| 400mA (Max)|
+|Charging current| 500mA (Max)|
 |Operating Temperature|- 40°C to 85°C|
 |Storage Temperature|-55°C to 150°C|
 |Grove Interface|I2C *2 / UART* 1|


### PR DESCRIPTION
Update the charging current spec from 400mA to 500mA. Based on BQ24070 schematic V1.2: ICHG = 2.5*425/2100 = 506mA, Imax=500mA. Requested by Nickeyjoy.