### PR TITLE
Update: LED Driver Board - Add FAQ section

### DIFF
--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Expansion_board/gpio_expander_for_xiao.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Expansion_board/gpio_expander_for_xiao.md
@@ -5,7 +5,7 @@ image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /io_expander_for_xiao
 sku: 103030415
 last_update:
-  date: 09/18/2023
+  date: 04/29/2026
   author: Stephen Lo
 createdAt: '2023-09-19'
 updatedAt: '2026-01-07'
@@ -36,7 +36,7 @@ The IO Expander for XIAO is a state-of-the-art expansion board designed to enhan
 - Communication Protocol: I2C
 - Default I2C Address: 0x21 (Configurable to 0x20)
 - Operating Voltage: 3.3V
-- Dimensions: 21mm x 17mm
+- Dimensions: 21mm x 17.8mm
 
 ## Applications
 


### PR DESCRIPTION
## Summary

Added a FAQ section to the LED Driver Board for XIAO documentation page.

### Changes

- Added a new **FAQ** section before the Tech Support section
- Updated  to 04/28/2026

### FAQ Content

**Q: What screw size is used for the LED driver board enclosure? Are threaded inserts needed?**

A: The enclosure uses M2.5 × 10 mm screws. The 3D-printed holes are slightly undersized to allow the screws to fit tightly, which eliminates the need for threaded inserts. The enclosure design is available on [Printables](https://www.printables.com/model/1332077-enclosure-for-led-driver-board-for-seeed-studio-xi).

### Source

Based on a real community Q&A from Discord.