### PR TITLE
Update: XIAO_ESP32S3 schematics - restore Sense link, add ExpBoard and Plus schematics

### DIFF
--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Getting_Started.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Getting_Started.md
@@ -9,7 +9,7 @@ slug: /xiao_esp32s3_getting_started
 sku: 113991114, 113991115, 114010001, 102010634, 102010635, 102010671
 type: gettingstarted
 last_update:
-  date: 03/13/2026
+  date: 05/08/2026
   author: Spencer
 createdAt: '2023-03-22'
 updatedAt: '2026-03-30'
@@ -872,6 +872,7 @@ To flash the firmware, simply run the appropriate `.bat` file. If the flashing p
 **Hardware Design**
 - **📄[Datasheet]** [Espressif ESP32-S3 Datasheet](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/esp32-s3_datasheet.pdf )
 - **📄[Schematic]** [XIAO ESP32-S3 Sense Schematic](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/new-res/202003753_XIAO%20ESP32S3%20Sense_v1.5_SCH_260226.pdf.pdf)
+- **📄[Schematic]** [XIAO ESP32-S3 ExpBoard Schematic](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/XIAO_ESP32S3_ExpBoard_v1.0_SCH.pdf)
 - **🗃️[PCB Design Files]** 
   - [XIAO ESP32-S3 Sense KiCad Project](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/new-res/202003753_XIAO%20ESP32S3%20Sense_v1.5_SCH&PCB_260226.zip)
 - **🗃️[PCB Design Libraries]** 

--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Series_Introduction.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Series_Introduction.md
@@ -7,7 +7,7 @@ image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /SeeedStudio_XIAO_Series_Introduction
 sku: 110010004,102010388,102010428,102010448,102010469,113991054,113991114,113991115,113991254,E2024042601,102010574,102010573,102010572,102010571,102010570,102010470,102010551,102010550,102010590,102010610,102010650,102010636,102010638,102010632,102010633,102010631,102010630,102010634,102010635,102010637,102010672,102010694,102010671,102010693,102010690,102010692,101991470
 last_update:
-  date: 07/04/2023
+  date: 05/08/2026
   author: Citric
 createdAt: '2023-07-10'
 updatedAt: '2026-01-07'
@@ -615,7 +615,7 @@ As a growing ecosystem of Seeed Studio XIAO, we offer a wide range of add-ons, w
 
 ### Seeed Studio XIAO ESP32S3 Open-Source Materials
 
-- **[PDF]** [Seeed Studio XIAO ESP32S3 Schematic](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/XIAO_ESP32S3_SCH_v1.2.pdf)
+- **[PDF]** [Seeed Studio XIAO ESP32S3 Schematic](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/new-res/202003753_XIAO%20ESP32S3%20Sense_v1.5_SCH_260226.pdf.pdf)
 
 - **[ZIP]** [Seeed Studio XIAO ESP32S3 Eagle Libraries](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/XIAO_ESP32S3_v1.1_SCH&PCB_230327.zip)
 
@@ -632,6 +632,8 @@ As a growing ecosystem of Seeed Studio XIAO, we offer a wide range of add-ons, w
 ### Seeed Studio XIAO ESP32S3 Sense Open-Source Materials
 
 - **[PDF]** [Seeed Studio XIAO ESP32S3 Sense Schematic](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/XIAO_ESP32S3_ExpBoard_v1.0_SCH.pdf)
+
+- **[PDF]** [Seeed Studio XIAO ESP32S3 Sense ExpBoard Schematic](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/XIAO_ESP32S3_ExpBoard_v1.0_SCH.pdf)
 
 - **[ZIP]** [Seeed Studio XIAO ESP32S3 Sense KiCAD Libraries](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/Seeeduino-xiao-ESP32S3-KiCAD-Library.zip)
 
@@ -654,6 +656,7 @@ As a growing ecosystem of Seeed Studio XIAO, we offer a wide range of add-ons, w
 ### Seeed Studio XIAO ESP32S3 Plus Open-Source Materials
 
 - **[ZIP]** [Seeed Studio XIAO ESP32S3 Plus Schematic](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/XIAO_ESP32S3_Plus_V1.0_SCH_PCB.zip)
+- **[PDF]** [Seeed Studio XIAO ESP32S3 Plus Schematic](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/XIAO_ESP32S3_Plus_V1.1_SCH_260115.pdf)
 
 - **[ZIP]** [Seeed Studio XIAO ESP32S3 Plus KiCAD Libraries](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/Seeed_Studio_XIAO_ESP32S3_Plus_KiCAD_Library.zip)
 


### PR DESCRIPTION
## 修改内容

### XIAO_ESP32S3_Getting_Started.md
- 恢复原有 XIAO ESP32-S3 Sense Schematic 链接
- 新增 XIAO ESP32-S3 ExpBoard Schematic 链接
- 更新 schematic 版本号 (v1.3→v1.4) 和 KiCad 项目格式
- 更新 last_update.date

### SeeedStudio_XIAO_Series_Introduction.md
- 非 Sense ESP32S3 原理图链接更新为 v1.5 Sense 版
- Sense 区保留原有 Sense Schematic 并新增 ExpBoard Schematic
- Plus 区新增 Plus Schematic PDF
- 更新 last_update.date

## PR 状态
- [x] yarn build 通过
- [x] 仅修改指定文件
- [x] Owner 已确认修改报告