### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chalk": "^5.4.1",
     "cli-progress": "^3.12.0",
     "clsx": "^1.2.1",
+    "docusaurus-plugin-copy-page-button": "^0.6.2",
     "docusaurus-plugin-image-zoom": "^0.1.4",
     "docusaurus-plugin-sass": "^0.2.2",
     "docusaurus-theme-search-typesense": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "chalk": "^5.4.1",
     "cli-progress": "^3.12.0",
     "clsx": "^1.2.1",
-    "docusaurus-plugin-copy-page-button": "^0.6.2",
+    "docusaurus-plugin-copy-page-button": "^0.7.0",
     "docusaurus-plugin-image-zoom": "^0.1.4",
     "docusaurus-plugin-sass": "^0.2.2",
     "docusaurus-theme-search-typesense": "^0.25.0",

--- a/sites/en/docusaurus.config.js
+++ b/sites/en/docusaurus.config.js
@@ -362,7 +362,12 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
-      'docusaurus-plugin-copy-page-button',
+      [
+        'docusaurus-plugin-copy-page-button',
+        {
+          enabledActions: ['copy', 'view', 'chatgpt', 'claude', 'gemini'],
+        },
+      ],
     ],
 
     themeConfig:

--- a/sites/en/docusaurus.config.js
+++ b/sites/en/docusaurus.config.js
@@ -362,6 +362,7 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
+      'docusaurus-plugin-copy-page-button',
     ],
 
     themeConfig:

--- a/sites/es/docusaurus.config.js
+++ b/sites/es/docusaurus.config.js
@@ -369,6 +369,7 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
+      'docusaurus-plugin-copy-page-button',
     ],
 
     themeConfig:

--- a/sites/es/docusaurus.config.js
+++ b/sites/es/docusaurus.config.js
@@ -369,7 +369,37 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
-      'docusaurus-plugin-copy-page-button',
+      [
+        'docusaurus-plugin-copy-page-button',
+        {
+          enabledActions: ['copy', 'view', 'chatgpt', 'claude', 'gemini'],
+          labels: {
+            button: {
+              label: 'Copiar página',
+            },
+            copy: {
+              title: 'Copiar como Markdown',
+              description: 'Copia el contenido de esta página como Markdown',
+            },
+            view: {
+              title: 'Ver como Markdown',
+              description: 'Ver el contenido de esta página en formato Markdown',
+            },
+            chatgpt: {
+              title: 'Abrir en ChatGPT',
+              description: 'Abrir el contenido de esta página como contexto en ChatGPT',
+            },
+            claude: {
+              title: 'Abrir en Claude',
+              description: 'Abrir el contenido de esta página como contexto en Claude',
+            },
+            gemini: {
+              title: 'Abrir en Gemini',
+              description: 'Abrir el contenido de esta página como contexto en Gemini',
+            },
+          },
+        },
+      ],
     ],
 
     themeConfig:

--- a/sites/ja/docusaurus.config.js
+++ b/sites/ja/docusaurus.config.js
@@ -369,6 +369,7 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
+      'docusaurus-plugin-copy-page-button',
     ],
 
     themeConfig:

--- a/sites/ja/docusaurus.config.js
+++ b/sites/ja/docusaurus.config.js
@@ -369,7 +369,37 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
-      'docusaurus-plugin-copy-page-button',
+      [
+        'docusaurus-plugin-copy-page-button',
+        {
+          enabledActions: ['copy', 'view', 'chatgpt', 'claude', 'gemini'],
+          labels: {
+            button: {
+              label: 'ページをコピー',
+            },
+            copy: {
+              title: 'Markdown としてコピー',
+              description: 'このページの内容を Markdown としてコピーします',
+            },
+            view: {
+              title: 'Markdown で表示',
+              description: 'このページの内容を Markdown 形式で表示します',
+            },
+            chatgpt: {
+              title: 'ChatGPT で開く',
+              description: 'このページの内容をコンテキストとして ChatGPT で開きます',
+            },
+            claude: {
+              title: 'Claude で開く',
+              description: 'このページの内容をコンテキストとして Claude で開きます',
+            },
+            gemini: {
+              title: 'Gemini で開く',
+              description: 'このページの内容をコンテキストとして Gemini で開きます',
+            },
+          },
+        },
+      ],
     ],
 
     themeConfig:

--- a/sites/pt-BR/docusaurus.config.js
+++ b/sites/pt-BR/docusaurus.config.js
@@ -369,6 +369,7 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
+      'docusaurus-plugin-copy-page-button',
     ],
 
     themeConfig:

--- a/sites/pt-BR/docusaurus.config.js
+++ b/sites/pt-BR/docusaurus.config.js
@@ -369,7 +369,37 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
-      'docusaurus-plugin-copy-page-button',
+      [
+        'docusaurus-plugin-copy-page-button',
+        {
+          enabledActions: ['copy', 'view', 'chatgpt', 'claude', 'gemini'],
+          labels: {
+            button: {
+              label: 'Copiar página',
+            },
+            copy: {
+              title: 'Copiar como Markdown',
+              description: 'Copiar o conteúdo desta página como Markdown',
+            },
+            view: {
+              title: 'Visualizar como Markdown',
+              description: 'Visualizar o conteúdo desta página em formato Markdown',
+            },
+            chatgpt: {
+              title: 'Abrir no ChatGPT',
+              description: 'Abrir o conteúdo desta página como contexto no ChatGPT',
+            },
+            claude: {
+              title: 'Abrir no Claude',
+              description: 'Abrir o conteúdo desta página como contexto no Claude',
+            },
+            gemini: {
+              title: 'Abrir no Gemini',
+              description: 'Abrir o conteúdo desta página como contexto no Gemini',
+            },
+          },
+        },
+      ],
     ],
 
     themeConfig:

--- a/sites/zh-CN/docusaurus.config.js
+++ b/sites/zh-CN/docusaurus.config.js
@@ -369,6 +369,7 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
+      'docusaurus-plugin-copy-page-button',
     ],
 
     themeConfig:

--- a/sites/zh-CN/docusaurus.config.js
+++ b/sites/zh-CN/docusaurus.config.js
@@ -369,7 +369,37 @@ module.exports = (async () => {
       
       'docusaurus-plugin-image-zoom',
       'docusaurus-plugin-sass',
-      'docusaurus-plugin-copy-page-button',
+      [
+        'docusaurus-plugin-copy-page-button',
+        {
+          enabledActions: ['copy', 'view', 'chatgpt', 'claude', 'gemini'],
+          labels: {
+            button: {
+              label: '复制页面',
+            },
+            copy: {
+              title: '复制为 Markdown',
+              description: '将本页内容复制为 Markdown',
+            },
+            view: {
+              title: '以 Markdown 查看',
+              description: '以 Markdown 格式查看本页内容',
+            },
+            chatgpt: {
+              title: '在 ChatGPT 中打开',
+              description: '将本页内容作为上下文发送到 ChatGPT',
+            },
+            claude: {
+              title: '在 Claude 中打开',
+              description: '将本页内容作为上下文发送到 Claude',
+            },
+            gemini: {
+              title: '在 Gemini 中打开',
+              description: '将本页内容作为上下文发送到 Gemini',
+            },
+          },
+        },
+      ],
     ],
 
     themeConfig:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4940,6 +4940,11 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+docusaurus-plugin-copy-page-button@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.6.2.tgz#fee47fa75f77ab634d90694c47e832ce9dadcc6c"
+  integrity sha512-RbldmCJ6FEYx515ptp1Ei9WwQAQyK6ty5UaHVaSlOyBfh/Nm+wu+6y3g/V7sVejBrMCxpGLnAuIJn3h8nqdjcQ==
+
 docusaurus-plugin-image-zoom@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-0.1.4.tgz#9b5fd06e3a79d84979265b7e74881a65bb3e1872"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4940,10 +4940,10 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-docusaurus-plugin-copy-page-button@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.6.2.tgz#fee47fa75f77ab634d90694c47e832ce9dadcc6c"
-  integrity sha512-RbldmCJ6FEYx515ptp1Ei9WwQAQyK6ty5UaHVaSlOyBfh/Nm+wu+6y3g/V7sVejBrMCxpGLnAuIJn3h8nqdjcQ==
+docusaurus-plugin-copy-page-button@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.7.0.tgz#7c6c2b5e342ad705c879e04979540dfc5fdfea68"
+  integrity sha512-2YGcDHlgGjTuemVVqSBV7C7myT3aKo7PiNIPJH1zwy0ltE41qgS+wFHmEH8202SrQaszu9DYiAFEJ/TAGAL0WQ==
 
 docusaurus-plugin-image-zoom@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
## Summary

Adds [`docusaurus-plugin-copy-page-button`](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) across all five language sites so readers can copy any wiki page as clean markdown — useful when piping hardware setup or firmware troubleshooting context into ChatGPT, Claude, Perplexity, or Gemini.

The plugin auto-injects a small "Copy page" button + dropdown into the doc page's table-of-contents area. The dropdown offers:

- Copy as markdown
- View as markdown
- Open in ChatGPT / Claude / Perplexity / Gemini

Live preview of the UI: https://portdeveloper.github.io/copy-page-button-showcase/

## Adoption

The plugin currently ships on the docs sites for React Native (just merged via facebook/react-native-website#5085), Puppeteer, Arbitrum, Cardano, Sui, Ethereum execution-apis, and several others — full list in the [project README](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button#used-by).

## Changes

- Added `'docusaurus-plugin-copy-page-button'` to the `plugins` array in each language config (`sites/en`, `sites/zh-CN`, `sites/ja`, `sites/es`, `sites/pt-BR`)
- Added `docusaurus-plugin-copy-page-button@^0.6.2` to root `dependencies`
- Resulting `yarn.lock` updates

`yarn build` of the English site passes locally; the other four configs use the identical plugin entry.