### PR TITLE
docs: remove outdated Wio SX1262 3D file link

### DIFF
--- a/sites/en/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
+++ b/sites/en/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
@@ -178,7 +178,6 @@ Connect a [L76K GNSS Module](https://www.seeedstudio.com/L76K-GNSS-Module-for-Se
 - **[LBR]** [Seeed Studio XIAO nRF52840 Eagle footprint](https://files.seeedstudio.com/wiki/XIAO-BLE/Seeed-Studio-XIAO-nRF52840-footprint-eagle.lbr)
 - **[XLSX]** [Seeed Studio XIAO nRF52840 pinout sheet](https://files.seeedstudio.com/wiki/XIAO-BLE/XIAO-nRF52840-pinout_sheet.xlsx)
 - 🔗 **[Kicad]** [Seeed Studio XIAO nRF52840 FootPrint](https://github.com/Seeed-Studio/OPL_Kicad_Library/tree/master/Seeed%20Studio%20XIAO%20Series%20Library)
-- **[RAR]** [Wio SX-1262 for XIAO 3D file](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_for_XIAO_3D_file.rar)
 - **[PDF]** [The Schematic Diagram of the SX1262 compatible with Xiao nRF52840](https://files.seeedstudio.com/products/113010003/Wio-SX1262%20for%20XIAO%20V1.0.pdf)
 - **[PDF]** [Wio SX-1262 Module Datasheet](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_Module_Datasheet.pdf
 )

--- a/sites/es/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/es_xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
+++ b/sites/es/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/es_xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
@@ -178,7 +178,6 @@ Conecta un [Módulo GNSS L76K](https://www.seeedstudio.com/L76K-GNSS-Module-for-
 - **[LBR]** [Huella Eagle de Seeed Studio XIAO nRF52840](https://files.seeedstudio.com/wiki/XIAO-BLE/Seeed-Studio-XIAO-nRF52840-footprint-eagle.lbr)
 - **[XLSX]** [Hoja de distribución de pines de Seeed Studio XIAO nRF52840](https://files.seeedstudio.com/wiki/XIAO-BLE/XIAO-nRF52840-pinout_sheet.xlsx)
 - 🔗 **[Kicad]** [Huella de Seeed Studio XIAO nRF52840](https://github.com/Seeed-Studio/OPL_Kicad_Library/tree/master/Seeed%20Studio%20XIAO%20Series%20Library)
-- **[RAR]** [Archivo 3D de Wio SX-1262 para XIAO](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_for_XIAO_3D_file.rar)
 - **[PDF]** [Diagrama esquemático del SX1262 compatible con Xiao nRF52840](https://files.seeedstudio.com/products/113010003/Wio-SX1262%20for%20XIAO%20V1.0.pdf)
 - **[PDF]** [Hoja de datos del módulo Wio SX-1262](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_Module_Datasheet.pdf
 )

--- a/sites/ja/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/ja_xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
+++ b/sites/ja/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/ja_xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
@@ -178,7 +178,6 @@ import TabItem from '@theme/TabItem';
 - **[LBR]** [Seeed Studio XIAO nRF52840 Eagle フットプリント](https://files.seeedstudio.com/wiki/XIAO-BLE/Seeed-Studio-XIAO-nRF52840-footprint-eagle.lbr)
 - **[XLSX]** [Seeed Studio XIAO nRF52840 ピン配置シート](https://files.seeedstudio.com/wiki/XIAO-BLE/XIAO-nRF52840-pinout_sheet.xlsx)
 - 🔗 **[Kicad]** [Seeed Studio XIAO nRF52840 フットプリント](https://github.com/Seeed-Studio/OPL_Kicad_Library/tree/master/Seeed%20Studio%20XIAO%20Series%20Library)
-- **[RAR]** [Wio SX-1262 for XIAO 3D ファイル](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_for_XIAO_3D_file.rar)
 - **[PDF]** [Xiao nRF52840 と互換性のある SX1262 の回路図](https://files.seeedstudio.com/products/113010003/Wio-SX1262%20for%20XIAO%20V1.0.pdf)
 - **[PDF]** [Wio SX-1262 モジュールデータシート](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_Module_Datasheet.pdf
 )

--- a/sites/pt-BR/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/pt_xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
+++ b/sites/pt-BR/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/pt_xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
@@ -178,7 +178,6 @@ Conecte um [Módulo GNSS L76K](https://www.seeedstudio.com/L76K-GNSS-Module-for-
 - **[LBR]** [Footprint Eagle do Seeed Studio XIAO nRF52840](https://files.seeedstudio.com/wiki/XIAO-BLE/Seeed-Studio-XIAO-nRF52840-footprint-eagle.lbr)
 - **[XLSX]** [Planilha de pinout do Seeed Studio XIAO nRF52840](https://files.seeedstudio.com/wiki/XIAO-BLE/XIAO-nRF52840-pinout_sheet.xlsx)
 - 🔗 **[Kicad]** [FootPrint do Seeed Studio XIAO nRF52840](https://github.com/Seeed-Studio/OPL_Kicad_Library/tree/master/Seeed%20Studio%20XIAO%20Series%20Library)
-- **[RAR]** [Arquivo 3D do Wio SX-1262 para XIAO](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_for_XIAO_3D_file.rar)
 - **[PDF]** [Diagrama esquemático do SX1262 compatível com o Xiao nRF52840](https://files.seeedstudio.com/products/113010003/Wio-SX1262%20for%20XIAO%20V1.0.pdf)
 - **[PDF]** [Wio SX-1262 Module Datasheet](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_Module_Datasheet.pdf
 )

--- a/sites/zh-CN/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/cn_xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
+++ b/sites/zh-CN/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/cn_xiao_nrf52840&_wio_SX1262_kit_for_meshtastic.md
@@ -178,7 +178,6 @@ import TabItem from '@theme/TabItem';
 - **[LBR]** [Seeed Studio XIAO nRF52840 Eagle 封装库](https://files.seeedstudio.com/wiki/XIAO-BLE/Seeed-Studio-XIAO-nRF52840-footprint-eagle.lbr)
 - **[XLSX]** [Seeed Studio XIAO nRF52840 引脚分布表](https://files.seeedstudio.com/wiki/XIAO-BLE/XIAO-nRF52840-pinout_sheet.xlsx)
 - 🔗 **[Kicad]** [Seeed Studio XIAO nRF52840 封装库](https://github.com/Seeed-Studio/OPL_Kicad_Library/tree/master/Seeed%20Studio%20XIAO%20Series%20Library)
-- **[RAR]** [Wio SX-1262 for XIAO 3D 文件](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_for_XIAO_3D_file.rar)
 - **[PDF]** [与 Xiao nRF52840 兼容的 SX1262 原理图](https://files.seeedstudio.com/products/113010003/Wio-SX1262%20for%20XIAO%20V1.0.pdf)
 - **[PDF]** [Wio SX-1262 模块数据手册](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_Module_Datasheet.pdf
 )


### PR DESCRIPTION
## Summary
- remove the Wio SX-1262 for XIAO 3D file resource entry

## Verification
- confirmed the final diff contains only the requested one-line deletion
- ran `git diff --check`