### PR TITLE
docs(XIAO_ESP32S3): add USB peripheral disabled warning to sleep modes

### DIFF
--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Sense_Consumption.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3/XIAO_ESP32S3_Sense_Consumption.md
@@ -52,6 +52,10 @@ In Deep-Sleep mode, the ESP32 powers off the CPUs, most of the RAM, and all digi
 - RTC FAST memory
 - RTC SLOW memory
 
+:::warning
+**USB Peripheral Disabled During Deep Sleep:** All digital peripherals including the internal USB peripheral (USB-Serial-JTAG) will be powered off during Deep Sleep. **Serial output over USB will not be available** while the device is in Deep Sleep. If you need to debug, use an external USB-UART chip connected to the hardware UART pins.
+:::
+
 ### Wake-up Methods
 
 - **Timer Wake-up：**The ESP32 can wake up automatically after a specified time by setting a timer.
@@ -731,6 +735,10 @@ To re-burn the program after entering deep sleep mode, hold down the boot button
 Light Sleep mode is another low-power mode in the ESP32 that allows the device to conserve energy while still maintaining a quick response time. In this mode, the CPU cores are halted, but the RAM and some peripherals remain powered on, allowing the device to wake up quickly in response to certain events.
 
 Light Sleep is ideal for applications that require low power consumption but still need to maintain a connection to WiFi or Bluetooth, as it allows the wireless communication modules to remain active.
+
+:::warning
+**USB Peripheral Disabled During Light Sleep:** The internal USB peripheral (USB-Serial-JTAG) will be disabled during Light Sleep for power saving. This means **Serial output over USB will not be available** while the device is in Light Sleep. If you are using the USB port to view Serial logs, you will not see any output during the sleep period. To debug, consider using an external USB-UART chip connected to the hardware UART pins, or use GPIO wake-up to monitor output after the device wakes up.
+:::
 
 ### Wake-up Methods
 


### PR DESCRIPTION
## Summary

Add warning notes to both **Light-Sleep** and **Deep-Sleep** sections of the XIAO ESP32S3 Sense Sleep Modes wiki page, informing users that the internal USB peripheral (USB-Serial-JTAG) is disabled during sleep modes for power saving.

## Changes

- Added `:::warning` block after the Light-Sleep Introduction section
- Added `:::warning` block after the Deep-Sleep Introduction section

## Motivation

A customer reported confusion when Serial log output was not visible while the XIAO ESP32S3 was in sleep mode. The ESP-IDF light_sleep example documentation includes a similar warning:

> "If you're using the USB-Serial-JTAG port to view logs from this example, note that the internal USB peripheral will be disabled during light_sleep for power saving."

This change brings the Seeed Wiki in line with the upstream ESP-IDF documentation.

## Reference

- [ESP-IDF light_sleep example](https://github.com/espressif/esp-idf/tree/v6.0.1/examples/system/light_sleep)
- [ESP-IDF Sleep Modes documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-reference/system/sleep_modes.html)