### PR TITLE
docs: expand reTerminal E10xx ESPHome cookbooks

### DIFF
--- a/sites/en/docs/Sensor/ePaper_Displays/Application/work_with_esphome.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/Application/work_with_esphome.md
@@ -48,7 +48,7 @@ Every Seeed ePaper product on the [main hub page](/seeed_epaper_displays) that h
     <tr>
       <td><strong>reTerminal E1001 / E1002 / E1003 / E1004</strong></td>
       <td>XIAO ESP32-S3</td>
-      <td><a href="/reterminal_e10xx_with_esphome">Basic</a> · <a href="/reterminal_e10xx_with_esphome_advanced">Advanced (peripherals)</a></td>
+      <td><a href="/reterminal_e10xx_with_esphome">Display</a> · <a href="/reterminal_e10xx_with_esphome_advanced">I/O & power</a> · <a href="/reterminal_e10xx_with_esphome_rtc_sd_microphone">RTC, SD & mic</a></td>
     </tr>
     <tr>
       <td><strong>EE04 driver board</strong></td>
@@ -193,8 +193,9 @@ You can now drag the entities into a Lovelace dashboard, or — much more intere
 
 This page intentionally stops at the boilerplate. The product-specific YAML, peripheral examples, and end-to-end recipes live in each product's cookbook:
 
-- **[reTerminal E Series — Basic ESPHome](/reterminal_e10xx_with_esphome)** — first dashboard, Wi-Fi setup, pre-built firmware ZIP for E1001/E1002/E1003/E1004.
-- **[reTerminal E Series — Advanced ESPHome](/reterminal_e10xx_with_esphome_advanced)** — buttons, buzzer, battery monitoring, SHT4x sensor, deep sleep, multi-page dashboards.
+- **[reTerminal E Series — ESPHome Display](/reterminal_e10xx_with_esphome)** — first dashboard, Wi-Fi setup, pre-built firmware ZIP, and ePaper drawing examples for E1001/E1002/E1003/E1004.
+- **[reTerminal E Series — ESPHome I/O, Battery & Power](/reterminal_e10xx_with_esphome_advanced)** — buttons, buzzer, onboard LED, battery monitoring, SHT4x sensor, deep sleep, and multi-page dashboards.
+- **[reTerminal E1001 / E1002 — ESPHome RTC, SD & Microphone](/reterminal_e10xx_with_esphome_rtc_sd_microphone)** — PCF8563 RTC time sync, microSD card power/detect pins, and onboard PDM microphone setup.
 - **[EE04 driver board — ESPHome](/EE04_with_esphome_advanced)** — full Home Assistant integration on the XIAO ESP32-S3 + EE04 + your choice of ePaper screen.
 - **[XIAO 7.5" ePaper Panel — ESPHome](/xiao_075inch_epaper_panel_esphome)** — minimal ESP32-C3 dashboard.
 - **[TRMNL 7.5" DIY Kit — ESPHome](/ogdiy_kit_works_with_esphome)** — using the kit hardware with ESPHome instead of the TRMNL cloud platform.
@@ -217,7 +218,7 @@ When new ePaper products ship, the corresponding cookbook is added under each pr
 
 ### Battery drains faster than expected
 
-ePaper only saves power when the rest of the SoC is also asleep. Add a `deep_sleep` block (see the Advanced cookbook for your product) and lower the `update_interval`.
+ePaper only saves power when the rest of the SoC is also asleep. Add a `deep_sleep` block (see the I/O, battery, and low-power cookbook for your product) and lower the `update_interval`.
 
 For deeper troubleshooting on a specific product, check the cookbook for that hardware.
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome.md
@@ -1,13 +1,13 @@
 ---
-description: ESPHome cookbook for reTerminal E1001 / E1002 / E1003 / E1004 - Basic Home Assistant integration, first dashboard, Wi-Fi setup, pre-built firmware ZIP.
-title: ESPHome Cookbook - Basic (reTerminal E Series)
+description: ESPHome display cookbook for reTerminal E1001 / E1002 / E1003 / E1004 - Home Assistant integration, first dashboard, Wi-Fi setup, pre-built firmware ZIP, and ePaper drawing examples.
+title: ESPHome Cookbook - Display Basics (reTerminal E Series)
 image: https://files.seeedstudio.com/wiki/reterminal_e10xx/img/44.webp
 slug: /reterminal_e10xx_with_esphome
 aliases:
   - /reterminal_e10xx_esphome
 sku: 100017057,100073581
 sidebar_position: 3
-sidebar_label: ESPHome (Basic)
+sidebar_label: ESPHome - Display
 last_update:
   date: 04/28/2026
   author: Citric
@@ -19,10 +19,10 @@ url: https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome/
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# ESPHome Cookbook - Basic: reTerminal E Series
+# ESPHome Cookbook - Display Basics: reTerminal E Series
 
 :::tip Read the main ESPHome guide first
-This page is the **reTerminal E Series-specific ESPHome cookbook (basic)**. The shared boilerplate — picking a flashing path, the generic YAML skeleton, connecting to Home Assistant — lives in **[Work with ESPHome](/epaper_work_with_esphome)**. Skim that first if you're new to ESPHome on Seeed ePaper. For onboard-peripheral examples (buttons, buzzer, battery, SHT4x, deep sleep), see the [Advanced cookbook](/reterminal_e10xx_with_esphome_advanced).
+This page is the **reTerminal E Series-specific ESPHome display cookbook**. The shared boilerplate — picking a flashing path, the generic YAML skeleton, connecting to Home Assistant — lives in **[Work with ESPHome](/epaper_work_with_esphome)**. Skim that first if you're new to ESPHome on Seeed ePaper. For buttons, buzzer, LED, battery, SHT4x, and deep sleep, see the [I/O, battery, and low-power cookbook](/reterminal_e10xx_with_esphome_advanced). For RTC, microSD card detect, and microphone setup, see the [RTC, SD card, and microphone cookbook](/reterminal_e10xx_with_esphome_rtc_sd_microphone).
 :::
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/44.jpg" style={{width:700, height:'auto'}}/></div><br />
@@ -969,7 +969,10 @@ By combining images with text and other display elements covered in previous exa
 
 ## Continue Reading
 
-Due to space constraints, this article only covers some basic use cases and drawing examples of the device. We will cover the use of reTerminal's hardware on ESPHome in more detail in the [Advanced ESPHome Usage of reTerminal E Series ePaper Display in Home Assistant](https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced)'s Wiki, which you can read on.
+This article focuses on connecting the display and drawing content on the ePaper screen. Continue with these ESPHome cookbooks when you want to use the rest of the onboard hardware:
+
+- **[ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power](/reterminal_e10xx_with_esphome_advanced)** - user buttons, buzzer feedback, onboard LED, battery monitoring, SHT4x sensor, deep sleep, and multi-page dashboards.
+- **[ESPHome Cookbook: RTC, SD Card & Microphone](/reterminal_e10xx_with_esphome_rtc_sd_microphone)** - PCF8563 RTC time sync, microSD card power/detect pins, and onboard PDM microphone initialization.
 
 ## FAQ
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome.md
@@ -994,6 +994,15 @@ In this case, you should go to Settings -> Devices & Services -> Integrations to
 
 Try unplugging and replugging it several times, or just install the driver according to the prompts.
 
+### Q4: Why is there no serial log over USB?
+
+The reTerminal E Series uses a CH340K USB-to-UART bridge on UART0. Keep this logger setting in your YAML:
+
+```yaml
+logger:
+  hardware_uart: UART0
+```
+
 ## Tech Support & Product Discussion
 
 Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_advanced.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_advanced.md
@@ -1316,6 +1316,15 @@ Step 4. Finally, replug the cable and upload a new program. -->
 
 In this case, your device is either offline or in deep sleep mode. Please ensure it's connected to your network or wake it up from sleep mode before attempting to upload.
 
+### Q4: Why is there no serial log over USB?
+
+The reTerminal E Series uses a CH340K USB-to-UART bridge on UART0. Keep this logger setting in your YAML:
+
+```yaml
+logger:
+  hardware_uart: UART0
+```
+
 ## Tech Support & Product Discussion
 
 Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_advanced.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_advanced.md
@@ -1,10 +1,10 @@
 ---
-description: ESPHome cookbook for reTerminal E1001 / E1002 / E1003 / E1004 - Advanced peripherals (buttons, buzzer, battery monitoring, SHT4x sensor, deep sleep, multi-page dashboards).
-title: ESPHome Cookbook - Advanced (reTerminal E Series)
+description: ESPHome cookbook for reTerminal E1001 / E1002 / E1003 / E1004 - buttons, buzzer, onboard LED, battery monitoring, SHT4x sensor, deep sleep, and multi-page dashboards.
+title: 'ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power (reTerminal E Series)'
 image: https://files.seeedstudio.com/wiki/reterminal_e10xx/img/27.webp
 slug: /reterminal_e10xx_with_esphome_advanced
 sidebar_position: 4
-sidebar_label: ESPHome (Advanced)
+sidebar_label: 'ESPHome - I/O, Battery & Power'
 last_update:
   date: 04/28/2026
   author: Citric
@@ -16,15 +16,15 @@ url: https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced/
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# ESPHome Cookbook - Advanced: reTerminal E Series
+# ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power (reTerminal E Series)
 
 :::tip Prerequisites
-This page assumes you've already worked through the [Basic ESPHome cookbook for reTerminal E Series](/reterminal_e10xx_with_esphome) (device on Wi-Fi, Home Assistant integration online, first dashboard rendered). For the platform-level YAML skeleton and Home Assistant integration steps, see [Work with ESPHome](/epaper_work_with_esphome).
+This page assumes you've already worked through the [ESPHome display cookbook for reTerminal E Series](/reterminal_e10xx_with_esphome) (device on Wi-Fi, Home Assistant integration online, first dashboard rendered). For the platform-level YAML skeleton and Home Assistant integration steps, see [Work with ESPHome](/epaper_work_with_esphome). For RTC, microSD card detect, and microphone setup, see [ESPHome Cookbook: RTC, SD Card & Microphone](/reterminal_e10xx_with_esphome_rtc_sd_microphone).
 :::
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/27.jpg" style={{width:700, height:'auto'}}/></div><br />
 
-This article explores advanced ESPHome configurations for your reTerminal E Series ePaper Display device, building upon the foundational concepts covered in our [Basic ESPHome Usage guide](https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome). If you're new to ESPHome or the reTerminal E Series, we recommend starting with the basic guide before diving into these advanced applications.
+This article covers the onboard I/O and power-related ESPHome configurations for your reTerminal E Series ePaper Display device, building upon the foundational concepts covered in our [ESPHome display cookbook](https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome). If you're new to ESPHome or the reTerminal E Series, we recommend starting with the display guide before using these hardware examples.
 
 ## Hardware Capabilities
 
@@ -207,11 +207,11 @@ logger:
 # Enable Home Assistant API
 api:
   encryption:
-    key: "m+rOiVDwjdvePoiG1zritvcD0Kl/a2zmsnuG+4IfWlw="
+    key: "REPLACE_WITH_YOUR_API_KEY"
 
 ota:
   - platform: esphome
-    password: "710fecea969062a5775b287a54f3c0f5"
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
 
 wifi:
   ssid: !secret wifi_ssid
@@ -220,7 +220,7 @@ wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "Reterminal-E10Xx"
-    password: "tRc2fXaYE54Q"
+    password: "ChangeMe123"
 
 captive_portal:
 
@@ -645,11 +645,11 @@ logger:
 # Enable Home Assistant API
 api:
   encryption:
-    key: "g93yP72UIyVsz9WfffaDMK+JeIQYROIFRK+VIQjkM+g="
+    key: "REPLACE_WITH_YOUR_API_KEY"
 
 ota:
   - platform: esphome
-    password: "1ff187393ee444aa2e892779dc78e488"
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
 
 wifi:
   ssid: !secret wifi_ssid
@@ -658,7 +658,7 @@ wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "reTerminal-E1001"
-    password: "yoUkaGlJaDpC"
+    password: "ChangeMe123"
 
 captive_portal:
 
@@ -967,11 +967,11 @@ logger:
 # Enable Home Assistant API
 api:
   encryption:
-    key: "g93yP72UIyVsz9WfffaDMK+JeIQYROIFRK+VIQjkM+g="
+    key: "REPLACE_WITH_YOUR_API_KEY"
 
 ota:
   - platform: esphome
-    password: "1ff187393ee444aa2e892779dc78e488"
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
 
 wifi:
   ssid: !secret wifi_ssid
@@ -980,7 +980,7 @@ wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "reTerminal-E1002"
-    password: "yoUkaGlJaDpC"
+    password: "ChangeMe123"
 
 captive_portal:
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
@@ -522,9 +522,9 @@ In a typical ESPHome setup, the SD card status can be used to:
 If your goal is direct SD card file read/write, refer to the Arduino SD card cookbook instead.
 :::
 
-## PDM Microphone Initialization
+## PDM Microphone Power Check
 
-This demo enables the onboard PDM microphone power rail and initializes the microphone through ESPHome's I2S audio component.
+This demo enables the onboard PDM microphone power rail and displays the microphone pin assignment on the ePaper screen. It keeps the YAML minimal so you can verify the display update first, then add the optional ESPHome I2S microphone configuration if you want to use the microphone with Home Assistant Voice Assistant.
 
 The microphone uses these pins:
 
@@ -578,20 +578,10 @@ spi:
   clk_pin: GPIO7
   mosi_pin: GPIO9
 
-i2s_audio:
-  i2s_lrclk_pin: GPIO42
-
 output:
   - platform: gpio
     pin: GPIO38
     id: mic_power_enable
-
-microphone:
-  - platform: i2s_audio
-    id: onboard_mic
-    adc_type: external
-    pdm: true
-    i2s_din_pin: GPIO41
 
 font:
   - file: "gfonts://Inter@700"
@@ -615,10 +605,10 @@ display:
       inverted: true
     update_interval: 300s
     lambda: |-
-      it.printf(400, 40, id(font_title), TextAlign::TOP_CENTER, "PDM Microphone Demo");
-      it.printf(400, 135, id(font_body), TextAlign::TOP_CENTER, "Microphone: initialized");
+      it.printf(400, 40, id(font_title), TextAlign::TOP_CENTER, "PDM Microphone Power");
+      it.printf(400, 135, id(font_body), TextAlign::TOP_CENTER, "Mic Power: ON");
       it.printf(400, 190, id(font_body), TextAlign::TOP_CENTER, "CLK GPIO42 / DATA GPIO41");
-      it.printf(400, 245, id(font_body), TextAlign::TOP_CENTER, "Power enable: GPIO38");
+      it.printf(400, 245, id(font_body), TextAlign::TOP_CENTER, "I2S microphone: optional");
 ```
 
 </TabItem>
@@ -665,20 +655,10 @@ spi:
   clk_pin: GPIO7
   mosi_pin: GPIO9
 
-i2s_audio:
-  i2s_lrclk_pin: GPIO42
-
 output:
   - platform: gpio
     pin: GPIO38
     id: mic_power_enable
-
-microphone:
-  - platform: i2s_audio
-    id: onboard_mic
-    adc_type: external
-    pdm: true
-    i2s_din_pin: GPIO41
 
 font:
   - file: "gfonts://Inter@700"
@@ -697,10 +677,10 @@ display:
       const auto BLACK = Color(0, 0, 0, 0);
       const auto BLUE = Color(0, 0, 255, 0);
 
-      it.printf(400, 40, id(font_title), BLACK, TextAlign::TOP_CENTER, "PDM Microphone Demo");
-      it.printf(400, 135, id(font_body), BLUE, TextAlign::TOP_CENTER, "Microphone: initialized");
+      it.printf(400, 40, id(font_title), BLACK, TextAlign::TOP_CENTER, "PDM Microphone Power");
+      it.printf(400, 135, id(font_body), BLUE, TextAlign::TOP_CENTER, "Mic Power: ON");
       it.printf(400, 190, id(font_body), BLACK, TextAlign::TOP_CENTER, "CLK GPIO42 / DATA GPIO41");
-      it.printf(400, 245, id(font_body), BLACK, TextAlign::TOP_CENTER, "Power enable: GPIO38");
+      it.printf(400, 245, id(font_body), BLACK, TextAlign::TOP_CENTER, "I2S microphone: optional");
 ```
 
 </TabItem>
@@ -709,16 +689,29 @@ display:
 This configuration:
 
 - Enables microphone power through `GPIO38`.
-- Uses `GPIO42` as the PDM clock pin.
-- Uses `GPIO41` as the PDM data input pin.
-- Initializes the onboard microphone as `id(onboard_mic)`.
+- Shows the PDM clock pin `GPIO42` and data pin `GPIO41` on the ePaper screen.
+- Keeps the main demo close to the RTC and microSD demos, so the display refresh can be verified before adding the audio component.
+
+If you want to expose the onboard PDM microphone to ESPHome, add the following optional block after confirming that the screen demo refreshes correctly:
+
+```yaml
+i2s_audio:
+  i2s_lrclk_pin: GPIO42
+
+microphone:
+  - platform: i2s_audio
+    id: onboard_mic
+    adc_type: external
+    pdm: true
+    i2s_din_pin: GPIO41
+```
 
 The following image shows the expected result on reTerminal E1002. The same demo works on both reTerminal E1001 and E1002. The main difference is the display output: E1001 shows a monochrome result, while E1002 can show a color result.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/254.jpeg" style={{width:700, height:'auto'}}/></div>
 
 :::note
-This demo only initializes the microphone hardware. A complete Home Assistant Assist voice pipeline requires additional voice assistant configuration, and recording audio directly to the SD card is better handled by the Arduino microphone examples.
+This demo only verifies microphone power control and the related pin assignment on the ePaper screen. A complete Home Assistant Assist voice pipeline requires the optional microphone block above and additional voice assistant configuration. Recording audio directly to the SD card is better handled by the Arduino microphone examples.
 :::
 
 ## Demo 4: Complete RTC, SD Card and Microphone Status Dashboard

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
@@ -1,0 +1,568 @@
+---
+description: ESPHome cookbook for reTerminal E1001 / E1002 - PCF8563 RTC time sync, microSD card power and detect pins, and onboard PDM microphone initialization.
+title: 'ESPHome Cookbook: RTC, SD Card & Microphone (reTerminal E Series)'
+image: https://files.seeedstudio.com/wiki/reterminal_e10xx/img/27.webp
+slug: /reterminal_e10xx_with_esphome_rtc_sd_microphone
+sidebar_position: 5
+sidebar_label: 'ESPHome - RTC, SD & Microphone'
+last_update:
+  date: 06/12/2026
+  author: Citric
+createdAt: '2026-06-12'
+updatedAt: '2026-06-12'
+url: https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_rtc_sd_microphone/
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# ESPHome Cookbook: RTC, SD Card & Microphone (reTerminal E Series)
+
+:::tip Read the display cookbook first
+This page assumes your reTerminal E Series device is already running ESPHome, connected to Wi-Fi, and visible in Home Assistant. If you have not flashed a first display example yet, start with **[ESPHome Cookbook: Display Basics](/reterminal_e10xx_with_esphome)**. For buttons, buzzer, LED, battery monitoring, SHT4x, and deep sleep, see **[ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power](/reterminal_e10xx_with_esphome_advanced)**.
+:::
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/27.jpg" style={{width:700, height:'auto'}}/></div><br />
+
+## Introduction
+
+The first ESPHome cookbook focuses on the ePaper display, and the second cookbook covers everyday onboard peripherals such as buttons, buzzer, LED, battery monitoring, the SHT4x sensor, and deep sleep. This page covers three additional hardware blocks that are useful for more complete Home Assistant devices:
+
+- **PCF8563 RTC** - keeps calendar time through an external real-time clock chip on the I²C bus.
+- **microSD card slot** - provides card insertion detection and a switchable SD power rail.
+- **PDM microphone** - initializes the onboard digital microphone so it can be referenced by ESPHome audio features.
+
+The examples below currently target **reTerminal E1001** and **reTerminal E1002**, matching the tested ESPHome hardware examples for these two models.
+
+:::note Model coverage
+The RTC and microSD hardware are available across the reTerminal E Series hardware family, but the ready-to-copy ESPHome display examples on this page are provided for E1001 and E1002. The onboard microphone examples apply to models with the PDM microphone hardware; E1004 does not include the microphone.
+:::
+
+## Hardware Pin Summary
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <th>Hardware Block</th>
+      <th>ESPHome Component</th>
+      <th>Pin / Address</th>
+      <th>Purpose</th>
+    </tr>
+    <tr>
+      <td>PCF8563 RTC</td>
+      <td><code>time.pcf8563</code></td>
+      <td>I²C address <code>0x51</code>, SDA <code>GPIO19</code>, SCL <code>GPIO20</code></td>
+      <td>Read hardware time on boot and write Home Assistant time back to the RTC.</td>
+    </tr>
+    <tr>
+      <td>microSD SPI bus</td>
+      <td><code>spi</code></td>
+      <td>SCLK <code>GPIO7</code>, MOSI <code>GPIO9</code>, MISO <code>GPIO8</code></td>
+      <td>Shared SPI bus used by the ePaper display and the SD card interface.</td>
+    </tr>
+    <tr>
+      <td>microSD power enable</td>
+      <td><code>output.gpio</code></td>
+      <td><code>GPIO16</code></td>
+      <td>Turns on the SD card power rail during boot.</td>
+    </tr>
+    <tr>
+      <td>microSD card detect</td>
+      <td><code>binary_sensor.gpio</code></td>
+      <td><code>GPIO15</code>, active LOW</td>
+      <td>Reports whether a card is inserted.</td>
+    </tr>
+    <tr>
+      <td>PDM microphone power</td>
+      <td><code>output.gpio</code></td>
+      <td><code>GPIO38</code></td>
+      <td>Enables microphone power before the audio bus starts.</td>
+    </tr>
+    <tr>
+      <td>PDM microphone clock</td>
+      <td><code>i2s_audio</code></td>
+      <td><code>GPIO42</code></td>
+      <td>Provides the PDM clock signal.</td>
+    </tr>
+    <tr>
+      <td>PDM microphone data</td>
+      <td><code>microphone.i2s_audio</code></td>
+      <td><code>GPIO41</code></td>
+      <td>Receives microphone data from the onboard PDM microphone.</td>
+    </tr>
+  </table>
+</div>
+
+## Prerequisites
+
+- A reTerminal E1001 or reTerminal E1002 already added to ESPHome.
+- Home Assistant with the ESPHome integration enabled.
+- Wi-Fi credentials stored in ESPHome `secrets.yaml`.
+- For RTC time retention after power loss, install a CR1220 coin cell in the RTC battery holder.
+- For SD card detection, insert a formatted microSD card into the card slot.
+
+:::caution Keep your API and OTA secrets private
+The examples use placeholders such as `REPLACE_WITH_YOUR_API_KEY` and `REPLACE_WITH_YOUR_OTA_PASSWORD`. Do not publish your real API encryption key, OTA password, Wi-Fi password, or Home Assistant token in a public repository.
+:::
+
+## Step 1: Add the Shared Buses and Power Enables
+
+Add the shared SPI, I²C, and I²S bus definitions after `captive_portal:` in your ESPHome YAML. These buses are the foundation for the RTC, SD card detect circuit, microphone, and display.
+
+```yaml
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+i2s_audio:
+  i2s_lrclk_pin: GPIO42
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    id: bsp_sd_enable
+
+  - platform: gpio
+    pin: GPIO38
+    id: mic_power_enable
+```
+
+Then enable the SD card and microphone power rails during boot:
+
+```yaml
+esphome:
+  name: reterminal-e1001
+  friendly_name: reTerminal_E1001
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - pcf8563.read_time:
+```
+
+For E1002, keep the same boot sequence and change only the device name:
+
+```yaml
+esphome:
+  name: reterminal-e1002
+  friendly_name: reTerminal_E1002
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - pcf8563.read_time:
+```
+
+## Step 2: Configure the PCF8563 RTC
+
+The PCF8563 is connected to the same I²C bus as the onboard SHT4x sensor. In ESPHome, you can read the RTC on boot and write the Home Assistant time back to the RTC after Home Assistant syncs.
+
+```yaml
+time:
+  - platform: pcf8563
+    id: rtc_time
+    address: 0x51
+    update_interval: never
+
+  - platform: homeassistant
+    on_time_sync:
+      then:
+        - pcf8563.write_time:
+```
+
+This configuration does two things:
+
+- `pcf8563.read_time` reads the hardware RTC during boot.
+- `pcf8563.write_time` writes the current Home Assistant time back to the PCF8563 after synchronization.
+
+:::tip
+If the displayed RTC time is wrong after a full power cycle, check whether the CR1220 coin cell is installed and still healthy. Without the coin cell, the PCF8563 cannot retain time when the main battery and USB power are removed.
+:::
+
+## Step 3: Add microSD Card Detection
+
+ESPHome can read the card-detect pin as a binary sensor. The card-detect signal is active LOW, so the GPIO sensor is configured with `inverted: true`.
+
+```yaml
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO15
+      mode: INPUT_PULLUP
+      inverted: true
+    id: sd_card_detect
+    name: "SD Card Detected"
+```
+
+:::note ESPHome SD card scope
+This example reports whether a card is inserted and enables the SD card power rail. ESPHome does not provide the same general-purpose SD file operations as an Arduino sketch, such as opening arbitrary files, creating folders, or recording WAV files directly from this YAML. For direct file read/write workflows, use the Arduino SD card cookbook instead.
+:::
+
+## Step 4: Initialize the PDM Microphone
+
+The onboard PDM microphone uses an I²S audio interface in PDM mode. The microphone power rail must be enabled before the microphone is used.
+
+```yaml
+microphone:
+  - platform: i2s_audio
+    id: onboard_mic
+    adc_type: external
+    pdm: true
+    i2s_din_pin: GPIO41
+```
+
+This initializes the onboard microphone so ESPHome audio-related features can reference `id(onboard_mic)`.
+
+:::note
+A full Home Assistant Assist voice pipeline may require additional Home Assistant and ESPHome configuration beyond microphone initialization, especially if you also want local wake-word detection or audio output. This page only covers the onboard microphone hardware setup.
+:::
+
+## Step 5: Display RTC, SD, and Microphone Status
+
+The following complete examples show a simple hardware status dashboard:
+
+- RTC date and time from the PCF8563.
+- microSD insertion status from `GPIO15`.
+- microphone hardware status from the configured PDM pins.
+
+<Tabs>
+<TabItem value="For E1001" label="For E1001" default>
+
+```yaml
+esphome:
+  name: reterminal-e1001
+  friendly_name: reTerminal_E1001
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - pcf8563.read_time:
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "reTerminal-E1001"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+i2s_audio:
+  i2s_lrclk_pin: GPIO42
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    id: bsp_sd_enable
+
+  - platform: gpio
+    pin: GPIO38
+    id: mic_power_enable
+
+time:
+  - platform: pcf8563
+    id: rtc_time
+    address: 0x51
+    update_interval: never
+
+  - platform: homeassistant
+    on_time_sync:
+      then:
+        - pcf8563.write_time:
+
+microphone:
+  - platform: i2s_audio
+    id: onboard_mic
+    adc_type: external
+    pdm: true
+    i2s_din_pin: GPIO41
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO15
+      mode: INPUT_PULLUP
+      inverted: true
+    id: sd_card_detect
+    name: "SD Card Detected"
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_small
+    size: 20
+  - file: "gfonts://Inter@700"
+    id: font_medium
+    size: 32
+
+display:
+  - platform: waveshare_epaper
+    id: epaper_display
+    model: 7.50inv2
+    cs_pin: GPIO10
+    dc_pin: GPIO11
+    reset_pin:
+      number: GPIO12
+      inverted: false
+    busy_pin:
+      number: GPIO13
+      inverted: true
+    update_interval: 300s
+    lambda: |-
+      it.printf(400, 20, id(font_medium), TextAlign::TOP_CENTER,
+                "reTerminal E1001 Hardware Status");
+      it.line(20, 60, 780, 60);
+
+      auto now = id(rtc_time).now();
+      if (now.is_valid()) {
+        it.strftime(30, 95, id(font_medium), "%Y-%m-%d %H:%M", now);
+        ESP_LOGD("status", "RTC time is valid");
+      } else {
+        it.printf(30, 95, id(font_medium), "RTC: waiting for sync");
+        ESP_LOGW("status", "RTC time is not valid yet");
+      }
+
+      if (id(sd_card_detect).state) {
+        it.printf(30, 155, id(font_medium), "SD Card: inserted");
+      } else {
+        it.printf(30, 155, id(font_medium), "SD Card: not detected");
+      }
+
+      it.printf(30, 215, id(font_medium), "PDM Mic: enabled");
+      it.printf(30, 265, id(font_small), "I2C: SDA GPIO19 / SCL GPIO20");
+      it.printf(30, 295, id(font_small), "SD SPI: CLK GPIO7 / MOSI GPIO9 / MISO GPIO8");
+      it.printf(30, 325, id(font_small), "Mic: CLK GPIO42 / DATA GPIO41 / EN GPIO38");
+```
+
+</TabItem>
+<TabItem value="For E1002" label="For E1002">
+
+```yaml
+esphome:
+  name: reterminal-e1002
+  friendly_name: reTerminal_E1002
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - pcf8563.read_time:
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "reTerminal-E1002"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+i2s_audio:
+  i2s_lrclk_pin: GPIO42
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    id: bsp_sd_enable
+
+  - platform: gpio
+    pin: GPIO38
+    id: mic_power_enable
+
+time:
+  - platform: pcf8563
+    id: rtc_time
+    address: 0x51
+    update_interval: never
+
+  - platform: homeassistant
+    on_time_sync:
+      then:
+        - pcf8563.write_time:
+
+microphone:
+  - platform: i2s_audio
+    id: onboard_mic
+    adc_type: external
+    pdm: true
+    i2s_din_pin: GPIO41
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO15
+      mode: INPUT_PULLUP
+      inverted: true
+    id: sd_card_detect
+    name: "SD Card Detected"
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_small
+    size: 20
+  - file: "gfonts://Inter@700"
+    id: font_medium
+    size: 32
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: Seeed-reTerminal-E1002
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK = Color(0, 0, 0, 0);
+      const auto BLUE = Color(0, 0, 255, 0);
+      const auto GREEN = Color(0, 255, 0, 0);
+      const auto RED = Color(255, 0, 0, 0);
+
+      it.printf(400, 20, id(font_medium), BLACK, TextAlign::TOP_CENTER,
+                "reTerminal E1002 Hardware Status");
+      it.line(20, 60, 780, 60, BLACK);
+
+      auto now = id(rtc_time).now();
+      if (now.is_valid()) {
+        it.strftime(30, 95, id(font_medium), BLUE, "%Y-%m-%d %H:%M", now);
+        ESP_LOGD("status", "RTC time is valid");
+      } else {
+        it.printf(30, 95, id(font_medium), RED, "RTC: waiting for sync");
+        ESP_LOGW("status", "RTC time is not valid yet");
+      }
+
+      if (id(sd_card_detect).state) {
+        it.printf(30, 155, id(font_medium), GREEN, "SD Card: inserted");
+      } else {
+        it.printf(30, 155, id(font_medium), RED, "SD Card: not detected");
+      }
+
+      it.printf(30, 215, id(font_medium), BLUE, "PDM Mic: enabled");
+      it.printf(30, 265, id(font_small), BLACK, "I2C: SDA GPIO19 / SCL GPIO20");
+      it.printf(30, 295, id(font_small), BLACK, "SD SPI: CLK GPIO7 / MOSI GPIO9 / MISO GPIO8");
+      it.printf(30, 325, id(font_small), BLACK, "Mic: CLK GPIO42 / DATA GPIO41 / EN GPIO38");
+```
+
+</TabItem>
+</Tabs>
+
+## Expected Result
+
+After the firmware is uploaded and the device reconnects to Home Assistant:
+
+- The display shows the RTC time after the first successful Home Assistant time sync.
+- The `SD Card Detected` binary sensor appears in Home Assistant.
+- Inserting or removing a microSD card changes the `SD Card Detected` state.
+- The screen shows `PDM Mic: enabled` after the microphone power rail and I²S microphone configuration are initialized.
+
+## Troubleshooting
+
+### Q1: Why does the screen show "RTC: waiting for sync"?
+
+The device has not received a valid time yet. Confirm that the device is connected to Wi-Fi, the ESPHome API is connected to Home Assistant, and Home Assistant has the correct system time. After Home Assistant syncs time, ESPHome writes the time back to the PCF8563 RTC.
+
+### Q2: Why does the RTC time disappear after removing power?
+
+The PCF8563 needs a CR1220 coin cell to keep time when the main battery and USB power are removed. Install or replace the coin cell, boot the device again, and let Home Assistant sync the time once.
+
+### Q3: Why does Home Assistant always show the SD card as not detected?
+
+Check three things:
+
+- Confirm the card is fully inserted into the slot.
+- Make sure `bsp_sd_enable` on `GPIO16` is turned on during boot.
+- Keep `GPIO15` configured as `INPUT_PULLUP` with `inverted: true`, because the detect signal is active LOW.
+
+### Q4: Can ESPHome record microphone audio directly to the SD card?
+
+Not with the simple YAML shown in this page. The microphone snippet initializes the onboard PDM microphone for ESPHome audio features, while the SD card snippet only powers the SD rail and reads the detect pin. If your goal is to record WAV files to the SD card, use the Arduino microphone and SD examples instead.
+
+### Q5: Why is there no serial log over USB?
+
+The reTerminal E Series uses a CH340K USB-to-UART bridge on UART0. Keep this logger setting in your YAML:
+
+```yaml
+logger:
+  hardware_uart: UART0
+```
+
+## Resources
+
+- **[Wiki]** [ESPHome Cookbook: Display Basics](/reterminal_e10xx_with_esphome)
+- **[Wiki]** [ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power](/reterminal_e10xx_with_esphome_advanced)
+- **[Wiki]** [Work with ESPHome](/epaper_work_with_esphome)
+- **[Wiki]** [Arduino Cookbook: RTC, Low Power, Audio & Touch](/reterminal_e10xx_with_arduino_peripherals_2)
+- **[Documentation]** [ESPHome Time Component](https://esphome.io/components/time/)
+- **[Documentation]** [ESPHome I²S Audio Component](https://esphome.io/components/i2s_audio.html)
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="button_tech_support_container">
+<a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+<a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+</div>
+
+<div class="button_tech_support_container">
+<a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+<a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+</div>

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
@@ -289,6 +289,10 @@ This configuration:
 - Writes the Home Assistant time back to the hardware RTC.
 - Displays the current date and time on the ePaper screen.
 
+The following image shows the expected result on reTerminal E1002. The same demo works on both reTerminal E1001 and E1002. The main difference is the display output: E1001 shows a monochrome result, while E1002 can show a color result.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/252.jpeg" style={{width:700, height:'auto'}}/></div>
+
 :::tip
 If the RTC time does not stay correct after a full power cycle, install or replace the CR1220 coin cell for the RTC backup holder.
 :::
@@ -501,6 +505,10 @@ This configuration:
 - Shows the card state on the ePaper screen.
 - Exposes `SD Card Detected` to Home Assistant as a binary sensor.
 
+The following image shows the expected result on reTerminal E1002. The same demo works on both reTerminal E1001 and E1002. The main difference is the display output: E1001 shows a monochrome result, while E1002 can show a color result.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/253.jpeg" style={{width:700, height:'auto'}}/></div>
+
 :::note How ESPHome uses the microSD card
 In this ESPHome cookbook, the microSD card is used as a device status signal. The demo checks whether a card is inserted, shows the result on the screen, and exposes the same state to Home Assistant.
 
@@ -704,6 +712,10 @@ This configuration:
 - Uses `GPIO42` as the PDM clock pin.
 - Uses `GPIO41` as the PDM data input pin.
 - Initializes the onboard microphone as `id(onboard_mic)`.
+
+The following image shows the expected result on reTerminal E1002. The same demo works on both reTerminal E1001 and E1002. The main difference is the display output: E1001 shows a monochrome result, while E1002 can show a color result.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/254.jpeg" style={{width:700, height:'auto'}}/></div>
 
 :::note
 This demo only initializes the microphone hardware. A complete Home Assistant Assist voice pipeline requires additional voice assistant configuration, and recording audio directly to the SD card is better handled by the Arduino microphone examples.
@@ -1011,6 +1023,10 @@ display:
 </details>
 
 When the firmware is running, the screen shows the RTC time, SD card state, and microphone initialization status on one page.
+
+The following image shows the expected result on reTerminal E1002. The same demo works on both reTerminal E1001 and E1002. The main difference is the display output: E1001 shows a monochrome result, while E1002 can show a color result.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/255.jpeg" style={{width:700, height:'auto'}}/></div>
 
 ## FAQ
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
@@ -1056,6 +1056,12 @@ logger:
   hardware_uart: UART0
 ```
 
+### Q3: Why does the screen not refresh in the RTC or microphone demo?
+
+If a microSD card is inserted, remove the card first and restart the device. Except for the microSD card detection demo, the other demos on this page do not need the card to be inserted. Keeping a card inserted may affect the shared SPI bus and prevent the ePaper screen from refreshing correctly.
+
+After removing the card, upload or restart the RTC or microphone demo again. The ePaper screen should refresh normally.
+
 ## Resources
 
 - **[Wiki]** [ESPHome Cookbook: Display Basics](/reterminal_e10xx_with_esphome)

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
@@ -1,5 +1,5 @@
 ---
-description: ESPHome cookbook for reTerminal E1001 / E1002 - PCF8563 RTC time sync, microSD card power and detect pins, and onboard PDM microphone initialization.
+description: ESPHome cookbook for reTerminal E1001 / E1002 - standalone demos for PCF8563 RTC time sync, microSD card detection, onboard PDM microphone initialization, and a combined hardware status dashboard.
 title: 'ESPHome Cookbook: RTC, SD Card & Microphone (reTerminal E Series)'
 image: https://files.seeedstudio.com/wiki/reterminal_e10xx/img/27.webp
 slug: /reterminal_e10xx_with_esphome_rtc_sd_microphone
@@ -18,235 +18,99 @@ import TabItem from '@theme/TabItem';
 
 # ESPHome Cookbook: RTC, SD Card & Microphone (reTerminal E Series)
 
-:::tip Read the display cookbook first
-This page assumes your reTerminal E Series device is already running ESPHome, connected to Wi-Fi, and visible in Home Assistant. If you have not flashed a first display example yet, start with **[ESPHome Cookbook: Display Basics](/reterminal_e10xx_with_esphome)**. For buttons, buzzer, LED, battery monitoring, SHT4x, and deep sleep, see **[ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power](/reterminal_e10xx_with_esphome_advanced)**.
+:::tip Prerequisites
+This page assumes you have already completed the [ESPHome display cookbook for reTerminal E Series](/reterminal_e10xx_with_esphome) and your device is online in Home Assistant. For buttons, buzzer, LED, battery monitoring, SHT4x, and deep sleep, see [ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power](/reterminal_e10xx_with_esphome_advanced).
 :::
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/27.jpg" style={{width:700, height:'auto'}}/></div><br />
 
-## Introduction
+This cookbook continues the reTerminal E Series ESPHome examples with three onboard hardware blocks that are not covered in the display and I/O cookbooks:
 
-The first ESPHome cookbook focuses on the ePaper display, and the second cookbook covers everyday onboard peripherals such as buttons, buzzer, LED, battery monitoring, the SHT4x sensor, and deep sleep. This page covers three additional hardware blocks that are useful for more complete Home Assistant devices:
+- **PCF8563 RTC** - read hardware time from the onboard RTC and sync it from Home Assistant.
+- **microSD card slot** - enable the SD power rail and report whether a card is inserted.
+- **PDM microphone** - enable the onboard microphone power rail and initialize the PDM microphone through ESPHome.
 
-- **PCF8563 RTC** - keeps calendar time through an external real-time clock chip on the I²C bus.
-- **microSD card slot** - provides card insertion detection and a switchable SD power rail.
-- **PDM microphone** - initializes the onboard digital microphone so it can be referenced by ESPHome audio features.
-
-The examples below currently target **reTerminal E1001** and **reTerminal E1002**, matching the tested ESPHome hardware examples for these two models.
+Each section below is organized as a small standalone ESPHome demo. You can copy one complete YAML example, replace the API and OTA placeholders, and upload it directly from ESPHome.
 
 :::note Model coverage
-The RTC and microSD hardware are available across the reTerminal E Series hardware family, but the ready-to-copy ESPHome display examples on this page are provided for E1001 and E1002. The onboard microphone examples apply to models with the PDM microphone hardware; E1004 does not include the microphone.
+The ready-to-copy examples in this page are written for **reTerminal E1001** and **reTerminal E1002**, matching the tested ESPHome hardware examples. The onboard microphone examples apply to models that include the PDM microphone hardware; reTerminal E1004 does not include the microphone.
 :::
 
-## Hardware Pin Summary
+## Hardware Capabilities
+
+The following pins are used by the demos in this cookbook.
 
 <div class="table-center">
   <table align="center">
     <tr>
-      <th>Hardware Block</th>
+      <th>Function</th>
       <th>ESPHome Component</th>
       <th>Pin / Address</th>
-      <th>Purpose</th>
     </tr>
     <tr>
       <td>PCF8563 RTC</td>
       <td><code>time.pcf8563</code></td>
-      <td>I²C address <code>0x51</code>, SDA <code>GPIO19</code>, SCL <code>GPIO20</code></td>
-      <td>Read hardware time on boot and write Home Assistant time back to the RTC.</td>
-    </tr>
-    <tr>
-      <td>microSD SPI bus</td>
-      <td><code>spi</code></td>
-      <td>SCLK <code>GPIO7</code>, MOSI <code>GPIO9</code>, MISO <code>GPIO8</code></td>
-      <td>Shared SPI bus used by the ePaper display and the SD card interface.</td>
-    </tr>
-    <tr>
-      <td>microSD power enable</td>
-      <td><code>output.gpio</code></td>
-      <td><code>GPIO16</code></td>
-      <td>Turns on the SD card power rail during boot.</td>
+      <td>I2C address <code>0x51</code>, SDA <code>GPIO19</code>, SCL <code>GPIO20</code></td>
     </tr>
     <tr>
       <td>microSD card detect</td>
       <td><code>binary_sensor.gpio</code></td>
       <td><code>GPIO15</code>, active LOW</td>
-      <td>Reports whether a card is inserted.</td>
     </tr>
     <tr>
-      <td>PDM microphone power</td>
+      <td>microSD power enable</td>
+      <td><code>output.gpio</code></td>
+      <td><code>GPIO16</code></td>
+    </tr>
+    <tr>
+      <td>PDM microphone power enable</td>
       <td><code>output.gpio</code></td>
       <td><code>GPIO38</code></td>
-      <td>Enables microphone power before the audio bus starts.</td>
     </tr>
     <tr>
       <td>PDM microphone clock</td>
       <td><code>i2s_audio</code></td>
       <td><code>GPIO42</code></td>
-      <td>Provides the PDM clock signal.</td>
     </tr>
     <tr>
       <td>PDM microphone data</td>
       <td><code>microphone.i2s_audio</code></td>
       <td><code>GPIO41</code></td>
-      <td>Receives microphone data from the onboard PDM microphone.</td>
+    </tr>
+    <tr>
+      <td>Shared SPI bus</td>
+      <td><code>spi</code></td>
+      <td>CLK <code>GPIO7</code>, MOSI <code>GPIO9</code>, MISO <code>GPIO8</code></td>
     </tr>
   </table>
 </div>
 
-## Prerequisites
-
-- A reTerminal E1001 or reTerminal E1002 already added to ESPHome.
-- Home Assistant with the ESPHome integration enabled.
-- Wi-Fi credentials stored in ESPHome `secrets.yaml`.
-- For RTC time retention after power loss, install a CR1220 coin cell in the RTC battery holder.
-- For SD card detection, insert a formatted microSD card into the card slot.
-
-:::caution Keep your API and OTA secrets private
-The examples use placeholders such as `REPLACE_WITH_YOUR_API_KEY` and `REPLACE_WITH_YOUR_OTA_PASSWORD`. Do not publish your real API encryption key, OTA password, Wi-Fi password, or Home Assistant token in a public repository.
+:::caution Keep your secrets private
+The examples use placeholders such as `REPLACE_WITH_YOUR_API_KEY` and `REPLACE_WITH_YOUR_OTA_PASSWORD`. Do not publish your real API encryption key, OTA password, Wi-Fi password, or Home Assistant token.
 :::
 
-## Step 1: Add the Shared Buses and Power Enables
+## RTC Time Sync
 
-Add the shared SPI, I²C, and I²S bus definitions after `captive_portal:` in your ESPHome YAML. These buses are the foundation for the RTC, SD card detect circuit, microphone, and display.
+This demo reads time from the onboard **PCF8563 RTC** and displays it on the ePaper screen. When Home Assistant syncs time to the device, ESPHome writes that time back to the hardware RTC.
 
-```yaml
-spi:
-  clk_pin: GPIO7
-  mosi_pin: GPIO9
-  miso_pin: GPIO8
+The RTC uses the shared I2C bus:
 
-i2c:
-  scl: GPIO20
-  sda: GPIO19
+- SDA: `GPIO19`
+- SCL: `GPIO20`
+- RTC address: `0x51`
 
-i2s_audio:
-  i2s_lrclk_pin: GPIO42
-
-output:
-  - platform: gpio
-    pin: GPIO16
-    id: bsp_sd_enable
-
-  - platform: gpio
-    pin: GPIO38
-    id: mic_power_enable
-```
-
-Then enable the SD card and microphone power rails during boot:
-
-```yaml
-esphome:
-  name: reterminal-e1001
-  friendly_name: reTerminal_E1001
-  on_boot:
-    priority: 600
-    then:
-      - output.turn_on: bsp_sd_enable
-      - output.turn_on: mic_power_enable
-      - delay: 200ms
-      - pcf8563.read_time:
-```
-
-For E1002, keep the same boot sequence and change only the device name:
-
-```yaml
-esphome:
-  name: reterminal-e1002
-  friendly_name: reTerminal_E1002
-  on_boot:
-    priority: 600
-    then:
-      - output.turn_on: bsp_sd_enable
-      - output.turn_on: mic_power_enable
-      - delay: 200ms
-      - pcf8563.read_time:
-```
-
-## Step 2: Configure the PCF8563 RTC
-
-The PCF8563 is connected to the same I²C bus as the onboard SHT4x sensor. In ESPHome, you can read the RTC on boot and write the Home Assistant time back to the RTC after Home Assistant syncs.
-
-```yaml
-time:
-  - platform: pcf8563
-    id: rtc_time
-    address: 0x51
-    update_interval: never
-
-  - platform: homeassistant
-    on_time_sync:
-      then:
-        - pcf8563.write_time:
-```
-
-This configuration does two things:
-
-- `pcf8563.read_time` reads the hardware RTC during boot.
-- `pcf8563.write_time` writes the current Home Assistant time back to the PCF8563 after synchronization.
-
-:::tip
-If the displayed RTC time is wrong after a full power cycle, check whether the CR1220 coin cell is installed and still healthy. Without the coin cell, the PCF8563 cannot retain time when the main battery and USB power are removed.
-:::
-
-## Step 3: Add microSD Card Detection
-
-ESPHome can read the card-detect pin as a binary sensor. The card-detect signal is active LOW, so the GPIO sensor is configured with `inverted: true`.
-
-```yaml
-binary_sensor:
-  - platform: gpio
-    pin:
-      number: GPIO15
-      mode: INPUT_PULLUP
-      inverted: true
-    id: sd_card_detect
-    name: "SD Card Detected"
-```
-
-:::note ESPHome SD card scope
-This example reports whether a card is inserted and enables the SD card power rail. ESPHome does not provide the same general-purpose SD file operations as an Arduino sketch, such as opening arbitrary files, creating folders, or recording WAV files directly from this YAML. For direct file read/write workflows, use the Arduino SD card cookbook instead.
-:::
-
-## Step 4: Initialize the PDM Microphone
-
-The onboard PDM microphone uses an I²S audio interface in PDM mode. The microphone power rail must be enabled before the microphone is used.
-
-```yaml
-microphone:
-  - platform: i2s_audio
-    id: onboard_mic
-    adc_type: external
-    pdm: true
-    i2s_din_pin: GPIO41
-```
-
-This initializes the onboard microphone so ESPHome audio-related features can reference `id(onboard_mic)`.
-
-:::note
-A full Home Assistant Assist voice pipeline may require additional Home Assistant and ESPHome configuration beyond microphone initialization, especially if you also want local wake-word detection or audio output. This page only covers the onboard microphone hardware setup.
-:::
-
-## Step 5: Display RTC, SD, and Microphone Status
-
-The following complete examples show a simple hardware status dashboard:
-
-- RTC date and time from the PCF8563.
-- microSD insertion status from `GPIO15`.
-- microphone hardware status from the configured PDM pins.
+You can use this example by replacing the placeholder values and uploading the complete YAML to your device.
 
 <Tabs>
 <TabItem value="For E1001" label="For E1001" default>
 
 ```yaml
 esphome:
-  name: reterminal-e1001
-  friendly_name: reTerminal_E1001
+  name: reterminal-e1001-rtc-demo
+  friendly_name: reTerminal_E1001_RTC_Demo
   on_boot:
     priority: 600
     then:
-      - output.turn_on: bsp_sd_enable
-      - output.turn_on: mic_power_enable
-      - delay: 200ms
       - pcf8563.read_time:
 
 esp32:
@@ -269,7 +133,623 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
   ap:
-    ssid: "reTerminal-E1001"
+    ssid: "E1001-RTC-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+time:
+  - platform: pcf8563
+    id: rtc_time
+    address: 0x51
+    update_interval: never
+
+  - platform: homeassistant
+    on_time_sync:
+      then:
+        - pcf8563.write_time:
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 26
+
+display:
+  - platform: waveshare_epaper
+    id: epaper_display
+    model: 7.50inv2
+    cs_pin: GPIO10
+    dc_pin: GPIO11
+    reset_pin:
+      number: GPIO12
+      inverted: false
+    busy_pin:
+      number: GPIO13
+      inverted: true
+    update_interval: 300s
+    lambda: |-
+      it.printf(400, 40, id(font_title), TextAlign::TOP_CENTER, "RTC Time Sync Demo");
+      auto now = id(rtc_time).now();
+      if (now.is_valid()) {
+        it.strftime(400, 135, id(font_title), TextAlign::TOP_CENTER, "%Y-%m-%d", now);
+        it.strftime(400, 190, id(font_title), TextAlign::TOP_CENTER, "%H:%M:%S", now);
+        ESP_LOGD("rtc_demo", "RTC time is valid");
+      } else {
+        it.printf(400, 150, id(font_body), TextAlign::TOP_CENTER, "RTC: waiting for sync");
+        ESP_LOGW("rtc_demo", "RTC time is not valid yet");
+      }
+```
+
+</TabItem>
+<TabItem value="For E1002" label="For E1002">
+
+```yaml
+esphome:
+  name: reterminal-e1002-rtc-demo
+  friendly_name: reTerminal_E1002_RTC_Demo
+  on_boot:
+    priority: 600
+    then:
+      - pcf8563.read_time:
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1002-RTC-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+time:
+  - platform: pcf8563
+    id: rtc_time
+    address: 0x51
+    update_interval: never
+
+  - platform: homeassistant
+    on_time_sync:
+      then:
+        - pcf8563.write_time:
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 26
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: Seeed-reTerminal-E1002
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK = Color(0, 0, 0, 0);
+      const auto RED = Color(255, 0, 0, 0);
+      const auto BLUE = Color(0, 0, 255, 0);
+
+      it.printf(400, 40, id(font_title), BLACK, TextAlign::TOP_CENTER, "RTC Time Sync Demo");
+      auto now = id(rtc_time).now();
+      if (now.is_valid()) {
+        it.strftime(400, 135, id(font_title), BLUE, TextAlign::TOP_CENTER, "%Y-%m-%d", now);
+        it.strftime(400, 190, id(font_title), BLUE, TextAlign::TOP_CENTER, "%H:%M:%S", now);
+        ESP_LOGD("rtc_demo", "RTC time is valid");
+      } else {
+        it.printf(400, 150, id(font_body), RED, TextAlign::TOP_CENTER, "RTC: waiting for sync");
+        ESP_LOGW("rtc_demo", "RTC time is not valid yet");
+      }
+```
+
+</TabItem>
+</Tabs>
+
+This configuration:
+
+- Reads the PCF8563 RTC once during boot.
+- Uses Home Assistant time as the source of truth after the device connects.
+- Writes the Home Assistant time back to the hardware RTC.
+- Displays the current date and time on the ePaper screen.
+
+:::tip
+If the RTC time does not stay correct after a full power cycle, install or replace the CR1220 coin cell for the RTC backup holder.
+:::
+
+## MicroSD Card Detection
+
+This demo reports whether a microSD card is inserted. It also turns on the SD card power rail through `GPIO16`.
+
+The card detect pin is active LOW, so the binary sensor uses `inverted: true`.
+
+You can use this example by replacing the placeholder values and uploading the complete YAML to your device.
+
+<Tabs>
+<TabItem value="For E1001" label="For E1001" default>
+
+```yaml
+esphome:
+  name: reterminal-e1001-sd-demo
+  friendly_name: reTerminal_E1001_SD_Demo
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - delay: 200ms
+      - component.update: epaper_display
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1001-SD-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    id: bsp_sd_enable
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO15
+      mode: INPUT_PULLUP
+      inverted: true
+    id: sd_card_detect
+    name: "SD Card Detected"
+    on_press:
+      then:
+        - logger.log: "SD card inserted"
+        - component.update: epaper_display
+    on_release:
+      then:
+        - logger.log: "SD card removed"
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 28
+
+display:
+  - platform: waveshare_epaper
+    id: epaper_display
+    model: 7.50inv2
+    cs_pin: GPIO10
+    dc_pin: GPIO11
+    reset_pin:
+      number: GPIO12
+      inverted: false
+    busy_pin:
+      number: GPIO13
+      inverted: true
+    update_interval: 300s
+    lambda: |-
+      it.printf(400, 40, id(font_title), TextAlign::TOP_CENTER, "microSD Card Detection");
+      if (id(sd_card_detect).state) {
+        it.printf(400, 160, id(font_body), TextAlign::TOP_CENTER, "SD Card: inserted");
+      } else {
+        it.printf(400, 160, id(font_body), TextAlign::TOP_CENTER, "SD Card: not detected");
+      }
+      it.printf(400, 230, id(font_body), TextAlign::TOP_CENTER, "Detect pin: GPIO15");
+```
+
+</TabItem>
+<TabItem value="For E1002" label="For E1002">
+
+```yaml
+esphome:
+  name: reterminal-e1002-sd-demo
+  friendly_name: reTerminal_E1002_SD_Demo
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - delay: 200ms
+      - component.update: epaper_display
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1002-SD-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    id: bsp_sd_enable
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO15
+      mode: INPUT_PULLUP
+      inverted: true
+    id: sd_card_detect
+    name: "SD Card Detected"
+    on_press:
+      then:
+        - logger.log: "SD card inserted"
+        - component.update: epaper_display
+    on_release:
+      then:
+        - logger.log: "SD card removed"
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 28
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: Seeed-reTerminal-E1002
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK = Color(0, 0, 0, 0);
+      const auto RED = Color(255, 0, 0, 0);
+      const auto GREEN = Color(0, 255, 0, 0);
+
+      it.printf(400, 40, id(font_title), BLACK, TextAlign::TOP_CENTER, "microSD Card Detection");
+      if (id(sd_card_detect).state) {
+        it.printf(400, 160, id(font_body), GREEN, TextAlign::TOP_CENTER, "SD Card: inserted");
+      } else {
+        it.printf(400, 160, id(font_body), RED, TextAlign::TOP_CENTER, "SD Card: not detected");
+      }
+      it.printf(400, 230, id(font_body), BLACK, TextAlign::TOP_CENTER, "Detect pin: GPIO15");
+```
+
+</TabItem>
+</Tabs>
+
+This configuration:
+
+- Enables SD card power through `GPIO16`.
+- Reads the card-detect signal from `GPIO15`.
+- Shows the card state on the ePaper screen.
+- Exposes `SD Card Detected` to Home Assistant as a binary sensor.
+
+:::note ESPHome SD card scope
+This ESPHome demo detects card insertion. It does not provide general-purpose file read/write operations such as opening files, creating folders, or recording WAV files to the SD card. For direct SD card file operations, use the Arduino SD card cookbook.
+:::
+
+## PDM Microphone Initialization
+
+This demo enables the onboard PDM microphone power rail and initializes the microphone through ESPHome's I2S audio component.
+
+The microphone uses these pins:
+
+- Power enable: `GPIO38`
+- PDM clock: `GPIO42`
+- PDM data: `GPIO41`
+
+You can use this example by replacing the placeholder values and uploading the complete YAML to your device.
+
+<Tabs>
+<TabItem value="For E1001" label="For E1001" default>
+
+```yaml
+esphome:
+  name: reterminal-e1001-mic-demo
+  friendly_name: reTerminal_E1001_Mic_Demo
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - logger.log: "PDM microphone power enabled"
+      - component.update: epaper_display
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1001-Mic-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+i2s_audio:
+  i2s_lrclk_pin: GPIO42
+
+output:
+  - platform: gpio
+    pin: GPIO38
+    id: mic_power_enable
+
+microphone:
+  - platform: i2s_audio
+    id: onboard_mic
+    adc_type: external
+    pdm: true
+    i2s_din_pin: GPIO41
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 26
+
+display:
+  - platform: waveshare_epaper
+    id: epaper_display
+    model: 7.50inv2
+    cs_pin: GPIO10
+    dc_pin: GPIO11
+    reset_pin:
+      number: GPIO12
+      inverted: false
+    busy_pin:
+      number: GPIO13
+      inverted: true
+    update_interval: 300s
+    lambda: |-
+      it.printf(400, 40, id(font_title), TextAlign::TOP_CENTER, "PDM Microphone Demo");
+      it.printf(400, 135, id(font_body), TextAlign::TOP_CENTER, "Microphone: initialized");
+      it.printf(400, 190, id(font_body), TextAlign::TOP_CENTER, "CLK GPIO42 / DATA GPIO41");
+      it.printf(400, 245, id(font_body), TextAlign::TOP_CENTER, "Power enable: GPIO38");
+```
+
+</TabItem>
+<TabItem value="For E1002" label="For E1002">
+
+```yaml
+esphome:
+  name: reterminal-e1002-mic-demo
+  friendly_name: reTerminal_E1002_Mic_Demo
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - logger.log: "PDM microphone power enabled"
+      - component.update: epaper_display
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1002-Mic-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+i2s_audio:
+  i2s_lrclk_pin: GPIO42
+
+output:
+  - platform: gpio
+    pin: GPIO38
+    id: mic_power_enable
+
+microphone:
+  - platform: i2s_audio
+    id: onboard_mic
+    adc_type: external
+    pdm: true
+    i2s_din_pin: GPIO41
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 26
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: Seeed-reTerminal-E1002
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK = Color(0, 0, 0, 0);
+      const auto BLUE = Color(0, 0, 255, 0);
+
+      it.printf(400, 40, id(font_title), BLACK, TextAlign::TOP_CENTER, "PDM Microphone Demo");
+      it.printf(400, 135, id(font_body), BLUE, TextAlign::TOP_CENTER, "Microphone: initialized");
+      it.printf(400, 190, id(font_body), BLACK, TextAlign::TOP_CENTER, "CLK GPIO42 / DATA GPIO41");
+      it.printf(400, 245, id(font_body), BLACK, TextAlign::TOP_CENTER, "Power enable: GPIO38");
+```
+
+</TabItem>
+</Tabs>
+
+This configuration:
+
+- Enables microphone power through `GPIO38`.
+- Uses `GPIO42` as the PDM clock pin.
+- Uses `GPIO41` as the PDM data input pin.
+- Initializes the onboard microphone as `id(onboard_mic)`.
+
+:::note
+This demo only initializes the microphone hardware. A complete Home Assistant Assist voice pipeline requires additional voice assistant configuration, and recording audio directly to the SD card is better handled by the Arduino microphone examples.
+:::
+
+## Demo 4: Complete RTC, SD Card and Microphone Status Dashboard
+
+This demo combines the three features above into one hardware status page:
+
+1. RTC date and time from the PCF8563.
+2. microSD card insertion status from `GPIO15`.
+3. PDM microphone initialization status.
+
+For a better understanding, run the single-function demos first before trying this combined example.
+
+<details>
+<summary>Click here to view the full code</summary>
+
+<Tabs>
+<TabItem value="For E1001" label="For E1001" default>
+
+```yaml
+esphome:
+  name: reterminal-e1001-hardware-status
+  friendly_name: reTerminal_E1001_Hardware_Status
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - pcf8563.read_time:
+      - component.update: epaper_display
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1001-HW-Status"
     password: "ChangeMe123"
 
 captive_portal:
@@ -305,6 +785,7 @@ time:
     on_time_sync:
       then:
         - pcf8563.write_time:
+        - component.update: epaper_display
 
 microphone:
   - platform: i2s_audio
@@ -321,6 +802,12 @@ binary_sensor:
       inverted: true
     id: sd_card_detect
     name: "SD Card Detected"
+    on_press:
+      then:
+        - component.update: epaper_display
+    on_release:
+      then:
+        - component.update: epaper_display
 
 font:
   - file: "gfonts://Inter@700"
@@ -363,9 +850,9 @@ display:
         it.printf(30, 155, id(font_medium), "SD Card: not detected");
       }
 
-      it.printf(30, 215, id(font_medium), "PDM Mic: enabled");
-      it.printf(30, 265, id(font_small), "I2C: SDA GPIO19 / SCL GPIO20");
-      it.printf(30, 295, id(font_small), "SD SPI: CLK GPIO7 / MOSI GPIO9 / MISO GPIO8");
+      it.printf(30, 215, id(font_medium), "PDM Mic: initialized");
+      it.printf(30, 265, id(font_small), "RTC: I2C address 0x51");
+      it.printf(30, 295, id(font_small), "SD: DET GPIO15 / EN GPIO16");
       it.printf(30, 325, id(font_small), "Mic: CLK GPIO42 / DATA GPIO41 / EN GPIO38");
 ```
 
@@ -374,8 +861,8 @@ display:
 
 ```yaml
 esphome:
-  name: reterminal-e1002
-  friendly_name: reTerminal_E1002
+  name: reterminal-e1002-hardware-status
+  friendly_name: reTerminal_E1002_Hardware_Status
   on_boot:
     priority: 600
     then:
@@ -383,6 +870,7 @@ esphome:
       - output.turn_on: mic_power_enable
       - delay: 200ms
       - pcf8563.read_time:
+      - component.update: epaper_display
 
 esp32:
   board: esp32-s3-devkitc-1
@@ -404,7 +892,7 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
   ap:
-    ssid: "reTerminal-E1002"
+    ssid: "E1002-HW-Status"
     password: "ChangeMe123"
 
 captive_portal:
@@ -440,6 +928,7 @@ time:
     on_time_sync:
       then:
         - pcf8563.write_time:
+        - component.update: epaper_display
 
 microphone:
   - platform: i2s_audio
@@ -456,6 +945,12 @@ binary_sensor:
       inverted: true
     id: sd_card_detect
     name: "SD Card Detected"
+    on_press:
+      then:
+        - component.update: epaper_display
+    on_release:
+      then:
+        - component.update: epaper_display
 
 font:
   - file: "gfonts://Inter@700"
@@ -495,29 +990,24 @@ display:
         it.printf(30, 155, id(font_medium), RED, "SD Card: not detected");
       }
 
-      it.printf(30, 215, id(font_medium), BLUE, "PDM Mic: enabled");
-      it.printf(30, 265, id(font_small), BLACK, "I2C: SDA GPIO19 / SCL GPIO20");
-      it.printf(30, 295, id(font_small), BLACK, "SD SPI: CLK GPIO7 / MOSI GPIO9 / MISO GPIO8");
+      it.printf(30, 215, id(font_medium), BLUE, "PDM Mic: initialized");
+      it.printf(30, 265, id(font_small), BLACK, "RTC: I2C address 0x51");
+      it.printf(30, 295, id(font_small), BLACK, "SD: DET GPIO15 / EN GPIO16");
       it.printf(30, 325, id(font_small), BLACK, "Mic: CLK GPIO42 / DATA GPIO41 / EN GPIO38");
 ```
 
 </TabItem>
 </Tabs>
 
-## Expected Result
+</details>
 
-After the firmware is uploaded and the device reconnects to Home Assistant:
+When the firmware is running, the screen shows the RTC time, SD card state, and microphone initialization status on one page.
 
-- The display shows the RTC time after the first successful Home Assistant time sync.
-- The `SD Card Detected` binary sensor appears in Home Assistant.
-- Inserting or removing a microSD card changes the `SD Card Detected` state.
-- The screen shows `PDM Mic: enabled` after the microphone power rail and I²S microphone configuration are initialized.
-
-## Troubleshooting
+## FAQ
 
 ### Q1: Why does the screen show "RTC: waiting for sync"?
 
-The device has not received a valid time yet. Confirm that the device is connected to Wi-Fi, the ESPHome API is connected to Home Assistant, and Home Assistant has the correct system time. After Home Assistant syncs time, ESPHome writes the time back to the PCF8563 RTC.
+The device has not received valid time yet. Confirm that Wi-Fi is connected, the ESPHome API is connected to Home Assistant, and Home Assistant has the correct system time. After Home Assistant syncs time, ESPHome writes the time back to the PCF8563 RTC.
 
 ### Q2: Why does the RTC time disappear after removing power?
 
@@ -531,11 +1021,15 @@ Check three things:
 - Make sure `bsp_sd_enable` on `GPIO16` is turned on during boot.
 - Keep `GPIO15` configured as `INPUT_PULLUP` with `inverted: true`, because the detect signal is active LOW.
 
-### Q4: Can ESPHome record microphone audio directly to the SD card?
+### Q4: Can ESPHome read and write files on the microSD card?
 
-Not with the simple YAML shown in this page. The microphone snippet initializes the onboard PDM microphone for ESPHome audio features, while the SD card snippet only powers the SD rail and reads the detect pin. If your goal is to record WAV files to the SD card, use the Arduino microphone and SD examples instead.
+This page only uses ESPHome to enable the SD power rail and read the card-detect pin. General file operations such as listing files, reading images, creating folders, or saving audio files are better handled by the Arduino SD card examples.
 
-### Q5: Why is there no serial log over USB?
+### Q5: Can ESPHome record microphone audio directly to the SD card?
+
+Not with the simple YAML shown in this page. The microphone demo initializes the onboard PDM microphone hardware. If your goal is to record WAV files to the SD card, use the Arduino microphone and SD examples instead.
+
+### Q6: Why is there no serial log over USB?
 
 The reTerminal E Series uses a CH340K USB-to-UART bridge on UART0. Keep this logger setting in your YAML:
 
@@ -549,9 +1043,10 @@ logger:
 - **[Wiki]** [ESPHome Cookbook: Display Basics](/reterminal_e10xx_with_esphome)
 - **[Wiki]** [ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power](/reterminal_e10xx_with_esphome_advanced)
 - **[Wiki]** [Work with ESPHome](/epaper_work_with_esphome)
+- **[Wiki]** [Arduino Cookbook: Onboard Peripherals](/reterminal_e10xx_with_arduino_peripherals)
 - **[Wiki]** [Arduino Cookbook: RTC, Low Power, Audio & Touch](/reterminal_e10xx_with_arduino_peripherals_2)
 - **[Documentation]** [ESPHome Time Component](https://esphome.io/components/time/)
-- **[Documentation]** [ESPHome I²S Audio Component](https://esphome.io/components/i2s_audio.html)
+- **[Documentation]** [ESPHome I2S Audio Component](https://esphome.io/components/i2s_audio.html)
 
 ## Tech Support & Product Discussion
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
@@ -501,8 +501,17 @@ This configuration:
 - Shows the card state on the ePaper screen.
 - Exposes `SD Card Detected` to Home Assistant as a binary sensor.
 
-:::note ESPHome SD card scope
-This ESPHome demo detects card insertion. It does not provide general-purpose file read/write operations such as opening files, creating folders, or recording WAV files to the SD card. For direct SD card file operations, use the Arduino SD card cookbook.
+:::note How ESPHome uses the microSD card
+In this ESPHome cookbook, the microSD card is used as a device status signal. The demo checks whether a card is inserted, shows the result on the screen, and exposes the same state to Home Assistant.
+
+This is because ESPHome is mainly designed for sensors, switches, displays, and Home Assistant automation. It is not usually used as a local file manager on the device. Tasks such as opening files, creating folders, writing logs, or recording WAV audio directly to the SD card are better handled with Arduino, where your firmware controls the SD card filesystem directly.
+
+In a typical ESPHome setup, the SD card status can be used to:
+- show whether storage is physically available;
+- trigger Home Assistant automations when a card is inserted or removed;
+- display hardware health information together with RTC, battery, and microphone status.
+
+If your goal is direct SD card file read/write, refer to the Arduino SD card cookbook instead.
 :::
 
 ## PDM Microphone Initialization

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/reterminal_e10xx_main_page.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/reterminal_e10xx_main_page.md
@@ -364,20 +364,28 @@ Beyond SenseCraft HMI, the reTerminal E Series integrates with several industry-
 			<th>E1004</th>
 		</tr>
 		<tr>
-			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome">ESPHome — Basic Usage</a></td>
-			<td>Plug the device into Home Assistant and draw simple graphics with YAML.</td>
+			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome">ESPHome — Display</a></td>
+			<td>Plug the device into Home Assistant and draw simple ePaper graphics with YAML.</td>
 			<td align="center">✅</td>
 			<td align="center">✅</td>
 			<td align="center">Planned</td>
 			<td align="center">via Home Assistant</td>
 		</tr>
 		<tr>
-			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced">ESPHome — Advanced Usage</a></td>
-			<td>Buttons, buzzer, battery monitoring, deep sleep, multi-page dashboards.</td>
+			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced">ESPHome — I/O, Battery &amp; Power</a></td>
+			<td>Buttons, buzzer, onboard LED, battery monitoring, deep sleep, multi-page dashboards.</td>
 			<td align="center">✅</td>
 			<td align="center">✅</td>
 			<td align="center">Planned</td>
 			<td align="center">via Home Assistant</td>
+		</tr>
+		<tr>
+			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_rtc_sd_microphone">ESPHome — RTC, SD &amp; Microphone</a></td>
+			<td>PCF8563 RTC time sync, microSD card detect, and onboard PDM microphone setup.</td>
+			<td align="center">✅</td>
+			<td align="center">✅</td>
+			<td align="center">Planned</td>
+			<td align="center">No mic</td>
 		</tr>
 		<tr>
 			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_trmnl">Works with TRMNL</a></td>


### PR DESCRIPTION
## Summary

This PR expands the reTerminal E10xx ESPHome documentation with clearer cookbook coverage and tested hardware-oriented examples.

Changes include:
- renames and clarifies the existing ESPHome display and advanced cookbook labels;
- adds a new RTC, microSD card, and PDM microphone ESPHome cookbook;
- provides standalone E1001 and E1002 YAML demos for RTC time sync, microSD card detection, microphone power check, and a combined hardware status dashboard;
- adds result image slots for each demo using E1002 screenshots while explaining the E1001/E1002 display difference;
- documents USB serial logging over CH340K/UART0;
- adds troubleshooting guidance for microSD cards affecting non-SD demo display refresh;
- updates related ESPHome navigation links and the reTerminal E10xx main page.

## Why

The existing ESPHome pages covered display basics and several basic onboard controls, but RTC, microSD card behavior, and microphone-related hardware were not documented in the same ESPHome cookbook style. This PR adds those missing examples while keeping each feature runnable as a small standalone demo.

## Validation

- `git diff --check upstream/docusaurus-version..HEAD`
- `yarn setup:links && yarn build:en`

`yarn build:en` completed successfully. The build still reports existing site-wide HTML minifier warnings on unrelated pages.