### PR TITLE
[codex] Update ePaper OpenDisplay and Zephyr docs

### DIFF
--- a/sites/en/docs/Sensor/ePaper_Displays/Application/work_with_openepaperlink.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/Application/work_with_openepaperlink.md
@@ -1,24 +1,27 @@
 ---
-description: Drive Seeed ePaper hardware over Bluetooth Low Energy with the OpenEPaperLink (OEPL) and OpenDisplay open-source ecosystems - covers the XIAO ePaper Display Board EN04 and the ePaper Breakout Board for Seeed Studio XIAO.
+description: Drive Seeed ePaper hardware with the OpenDisplay and OpenEPaperLink ecosystems over Bluetooth Low Energy, including reTerminal E1001, E1002, E1003, XIAO ePaper Display Board EN04, and the XIAO ePaper Breakout Board path.
 title: Work with OpenEPaperLink / OpenDisplay
 keywords:
   - ePaper display
   - OpenEPaperLink
   - OEPL
   - OpenDisplay
+  - reTerminal E1001
+  - reTerminal E1002
+  - reTerminal E1003
   - EN04
   - ePaper Breakout Board
 image: https://files.seeedstudio.com/wiki/Epaper/EN04/EN04_2.webp
 slug: /EN04_opendisplay
 sidebar_position: 9
 last_update:
-  date: 04/28/2026
+  date: 06/30/2026
   author: dimo
 aliases:
   - /epaper_breakout_board_with_oepl
 createdAt: '2026-04-28'
 url: https://wiki.seeedstudio.com/EN04_opendisplay/
-updatedAt: '2026-06-03'
+updatedAt: '2026-06-30'
 ---
 
 import Tabs from '@theme/Tabs';
@@ -26,183 +29,277 @@ import TabItem from '@theme/TabItem';
 
 # Work with OpenEPaperLink / OpenDisplay
 
-The [OpenEPaperLink (OEPL)](https://openepaperlink.de/) ecosystem and the related [OpenDisplay](https://opendisplay.org/) project are open-source firmware/protocol stacks for driving e-paper displays. Modern releases run over **Bluetooth Low Energy** — your phone, computer, or Home Assistant talks directly to the device, no dedicated 802.15.4 access point required.
+[OpenDisplay](https://opendisplay.org/) and [OpenEPaperLink (OEPL)](https://openepaperlink.de/) are open-source ecosystems for driving ePaper displays over **Bluetooth Low Energy (BLE)**. A phone, computer, or Home Assistant host can connect to the display directly, so the basic workflow does not require an 802.15.4 access point.
 
-This guide covers two Seeed hardware paths into that ecosystem:
+This guide covers two Seeed hardware paths:
 
-- **XIAO ePaper Display Board EN04** — an integrated kit running the OpenDisplay firmware over BLE.
-- **ePaper Breakout Board for Seeed Studio XIAO** — a more modular DIY path using the OEPL Config Builder + OEPL Image Uploader together with a XIAO nRF52840 series board.
+- **OpenDisplay Toolbox path** — recommended for ready-to-use OpenDisplay firmware on **reTerminal E1001**, **reTerminal E1002**, **reTerminal E1003**, and **XIAO ePaper Display Board EN04**.
+- **OEPL_BLE path** — useful for a modular DIY setup with **ePaper Breakout Board for Seeed Studio XIAO** and a **XIAO nRF52840 series board**.
 
-Both flows share a common philosophy (BLE configuration, web-based tooling, low-power), but the hardware and firmware/web tools differ. Pick the tab that matches your hardware throughout the article.
+The user experience is similar in both paths: install firmware, configure the device over BLE, then upload an image. The tools and supported presets differ, so follow the tab that matches your hardware.
 
 ## Compatible Hardware
 
 <Tabs groupId="oepl-hardware">
-<TabItem value="en04" label="XIAO ePaper Display Board EN04" default>
+<TabItem value="reterminal" label="reTerminal E Series" default>
+
+The OpenDisplay Toolbox includes presets for **reTerminal E1001**, **reTerminal E1002**, and **reTerminal E1003**.
 
 <div class="table-center">
-<table align="center">
-    <tr>
-        <th>XIAO ePaper Display Board EN04</th>
-    </tr>
-    <tr>
-    <td><div align="center"><img width ={300} src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/diy_kit_pic.jpg"/></div>
-    <div class="get_one_now_container" style={{textAlign: 'center'}}>
-        <a class="get_one_now_item" href="https://www.seeedstudio.com/XIAO-ePaper-DIY-Kit-EN04.html" target="_blank">
-                <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
-        </a>
-    </div></td>
-    </tr>
-</table>
+	<table align="center">
+		<tr>
+			<th>reTerminal E1001</th>
+			<th>reTerminal E1002</th>
+			<th>reTerminal E1003</th>
+		</tr>
+		<tr>
+			<td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/132.jpg" style={{width:250, height:'auto'}}/></div></td>
+			<td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/132.jpg" style={{width:250, height:'auto'}}/></div></td>
+			<td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/e1003/1.jpg" style={{width:250, height:'auto'}}/></div></td>
+		</tr>
+		<tr>
+			<td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+				<a class="get_one_now_item" href="https://www.seeedstudio.com/reTerminal-E1001-p-6534.html" target="_blank" rel="noopener noreferrer">
+				<strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+				</a>
+			</div></td>
+			<td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+				<a class="get_one_now_item" href="https://www.seeedstudio.com/reTerminal-E1002-p-6533.html" target="_blank" rel="noopener noreferrer">
+				<strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+				</a>
+			</div></td>
+			<td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+				<a class="get_one_now_item" href="https://www.seeedstudio.com/reTerminal-E1003-p-6731.html" target="_blank" rel="noopener noreferrer">
+				<strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+				</a>
+			</div></td>
+		</tr>
+		<tr>
+			<td align="center">7.5" monochrome, 800 × 480</td>
+			<td align="center">7.3" Spectra 6 color, 800 × 480</td>
+			<td align="center">10.3" monochrome, 1404 × 1872, touch</td>
+		</tr>
+		<tr>
+			<td align="center"><a href="https://opendisplay.org/firmware/toolbox/index.html?config=reterminal-e1001" target="_blank" rel="noopener noreferrer">Open in Toolbox</a></td>
+			<td align="center"><a href="https://opendisplay.org/firmware/toolbox/index.html?config=reterminal-e1002" target="_blank" rel="noopener noreferrer">Open in Toolbox</a></td>
+			<td align="center"><a href="https://opendisplay.org/firmware/toolbox/index.html?config=reterminal-e1003" target="_blank" rel="noopener noreferrer">Open in Toolbox</a></td>
+		</tr>
+	</table>
 </div>
 
-Powered by **XIAO nRF52840 Plus**, the XIAO EN04 ePaper Display Board is the easiest way to get started with Bluetooth-enabled e-paper displays. Direct wireless control from your phone, computer, or Home Assistant — no dedicated AP needed.
+Use this path when you want to run OpenDisplay firmware directly on a finished reTerminal E Series device.
+
+:::caution
+Installing OpenDisplay firmware replaces the firmware currently running on the device. Keep a restore path ready by using the official reTerminal E-Series Firmware Hub or the firmware package recommended by your product Wiki.
+:::
+
+</TabItem>
+<TabItem value="en04" label="XIAO ePaper Display Board EN04">
+
+<div class="table-center">
+	<table align="center">
+		<tr>
+			<th>XIAO ePaper Display Board EN04</th>
+		</tr>
+		<tr>
+			<td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/diy_kit_pic.jpg" style={{width:300, height:'auto'}}/></div></td>
+		</tr>
+		<tr>
+			<td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+				<a class="get_one_now_item" href="https://www.seeedstudio.com/XIAO-ePaper-Display-Board-nRF52840-EN04-p-6589.html" target="_blank" rel="noopener noreferrer">
+				<strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+				</a>
+			</div></td>
+		</tr>
+		<tr>
+			<td align="center"><a href="https://opendisplay.org/firmware/toolbox/index.html?driver=en04" target="_blank" rel="noopener noreferrer">Open EN04 in Toolbox</a></td>
+		</tr>
+	</table>
+</div>
+
+EN04 is an nRF52840-based ePaper driver board. It is the most direct DIY path for OpenDisplay when you want to pair a supported ePaper panel with a BLE-focused controller.
 
 </TabItem>
 <TabItem value="breakout" label="ePaper Breakout Board + XIAO nRF52840">
 
-<table align="center">
-  <tr>
-    <th>4.26" Monochrome ePaper Display</th>
-    <th>ePaper Breakout Board for Seeed Studio XIAO</th>
-    <th>Seeed Studio XIAO nRF52840 Sense Plus</th>
-  </tr>
-  <tr>
-    <td><div style={{textAlign:'center'}}><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/1/-/1-114993631-4.26-monochrome-eink--epaper-display.jpg" style={{width:300, height:'auto'}}/></div></td>
-    <td><div style={{textAlign:'center'}}><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/4/-/4-105990172-epaper-breakout-board-45back.jpg" style={{width:300, height:'auto'}}/></div></td>
-    <td><div style={{textAlign:'center'}}><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/2/-/2-102010694-seeedstudio-xiao-nrf52840-sense-plus-45font_1.jpg" style={{width:300, height:'auto'}}/></div></td>
-  </tr>
-  <tr>
-    <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
-      <a class="get_one_now_item" href="https://www.seeedstudio.com/4-26-Monochrome-SPI-ePaper-Display-p-6398.html" target="_blank">
-            <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
-      </a>
-    </div></td>
-    <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
-      <a class="get_one_now_item" href="https://www.seeedstudio.com/ePaper-Breakout-Board-p-5804.html" target="_blank">
-            <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
-      </a>
-    </div></td>
-    <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
-        <a class="get_one_now_item" href="https://www.seeedstudio.com/Seeed-Studio-XIAO-nRF52840-Sense-Plus-p-6360.html" target="_blank">
-              <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
-        </a>
-    </div></td>
-  </tr>
-</table>
+<div class="table-center">
+	<table align="center">
+		<tr>
+			<th>4.26" Monochrome ePaper Display</th>
+			<th>ePaper Breakout Board for Seeed Studio XIAO</th>
+			<th>Seeed Studio XIAO nRF52840 Sense Plus</th>
+		</tr>
+		<tr>
+			<td><div style={{textAlign:'center'}}><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/1/-/1-114993631-4.26-monochrome-eink--epaper-display.jpg" style={{width:250, height:'auto'}}/></div></td>
+			<td><div style={{textAlign:'center'}}><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/4/-/4-105990172-epaper-breakout-board-45back.jpg" style={{width:250, height:'auto'}}/></div></td>
+			<td><div style={{textAlign:'center'}}><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/2/-/2-102010694-seeedstudio-xiao-nrf52840-sense-plus-45font_1.jpg" style={{width:250, height:'auto'}}/></div></td>
+		</tr>
+		<tr>
+			<td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+				<a class="get_one_now_item" href="https://www.seeedstudio.com/4-26-Monochrome-SPI-ePaper-Display-p-6398.html" target="_blank" rel="noopener noreferrer">
+				<strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+				</a>
+			</div></td>
+			<td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+				<a class="get_one_now_item" href="https://www.seeedstudio.com/ePaper-breakout-Board-for-XIAO-V2-p-6374.html" target="_blank" rel="noopener noreferrer">
+				<strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+				</a>
+			</div></td>
+			<td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+				<a class="get_one_now_item" href="https://www.seeedstudio.com/Seeed-Studio-XIAO-nRF52840-Sense-Plus-p-6360.html" target="_blank" rel="noopener noreferrer">
+				<strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+				</a>
+			</div></td>
+		</tr>
+	</table>
+</div>
 
-:::tip
-The whole **XIAO nRF52840 series** can drive this DIY kit — not only the Sense Plus shown above. The community OEPL project supports the 4.26" screen out of the box; more screen sizes will be added over time.
-:::
+Use this path when you want a modular OEPL_BLE build. The XIAO nRF52840 series can drive this DIY kit, and the community OEPL workflow provides separate tools for configuration and image upload.
 
 </TabItem>
 </Tabs>
 
-## Why use OpenEPaperLink / OpenDisplay?
+## Why Use OpenDisplay / OpenEPaperLink?
 
-- **No access point required** — uses Bluetooth Low Energy for direct communication. No 802.15.4 hardware needed.
-- **Web-based tools** — install firmware, configure devices, and upload images straight from your browser.
-- **Purpose-built hardware support** — XIAO nRF52840 family, EN04, EE04, etc.
-- **Open source & free** — actively developed on GitHub.
-- **Multiple microcontrollers** — nRF52840, ESP32-S3, ESP32-C6, ESP32-C3.
-- **Simple flow** — drag-and-drop firmware install, configure via web, no complex programming.
-- **Battery efficient** — optimised for low-power e-paper.
-- **Active community** — [OpenDisplay Discord](https://discord.gg/WG7tbTzF9Z).
+- **BLE-first workflow** — configure and upload images without a dedicated 802.15.4 access point.
+- **Browser-based tools** — install firmware, select presets, configure devices, and upload images from a supported browser.
+- **Seeed hardware presets** — OpenDisplay Toolbox includes presets for reTerminal E1001, E1002, E1003, and EN04.
+- **Home Assistant support** — OpenDisplay devices can be added through Home Assistant's official OpenDisplay integration.
+- **Open-source ecosystem** — firmware, tools, and integrations are developed in public repositories.
 
 ## Step 1: Hardware Setup
 
 <Tabs groupId="oepl-hardware">
-<TabItem value="en04" label="XIAO ePaper Display Board EN04" default>
+<TabItem value="reterminal" label="reTerminal E Series" default>
 
-**Step 1. Connect display to the driver board**  
-Align the FPC cable with the connector on the XIAO EN04 board, then secure the latch.
+**Step 1.** Connect the reTerminal E Series device to your computer with a USB-C data cable.
+
+**Step 2.** Turn the device on and keep it close to the computer. The browser will use USB for firmware installation and BLE for configuration.
+
+**Step 3.** Match your hardware to the correct OpenDisplay Toolbox preset:
+
+<div class="table-center">
+	<table align="center">
+		<tr>
+			<th>Device</th>
+			<th>Toolbox Preset</th>
+			<th>Display</th>
+		</tr>
+		<tr>
+			<td>reTerminal E1001</td>
+			<td><code>reterminal-e1001</code></td>
+			<td>7.5" monochrome, 800 × 480</td>
+		</tr>
+		<tr>
+			<td>reTerminal E1002</td>
+			<td><code>reterminal-e1002</code></td>
+			<td>7.3" Spectra 6 color, 800 × 480</td>
+		</tr>
+		<tr>
+			<td>reTerminal E1003</td>
+			<td><code>reterminal-e1003</code></td>
+			<td>10.3" monochrome, 1404 × 1872</td>
+		</tr>
+	</table>
+</div>
+
+</TabItem>
+<TabItem value="en04" label="XIAO ePaper Display Board EN04">
+
+**Step 1.** Insert the ePaper panel FPC cable into the EN04 connector and lock the latch.
 
 :::tip
-The metal side of the FPC cable should face upwards, otherwise no content will be displayed. Most displays have `1` and `50` printed on the FPC; align them with the matching numbers on the board.
+For the 50-pin connector, align the printed `1` and `50` marks on the FPC with the matching marks on the board. On the EN04 kit shown below, the metal contact side of the FPC faces upward.
 :::
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/hardware.jpg" style={{width:600, height:'auto'}}/></div>
 
-**Step 2. Attach the battery**  
-Connect the battery cable to the JST connector on the driver board. Red wire to **+**, black to **−**.
+**Step 2.** Connect the battery to the JST connector. Red wire goes to **+**, black wire goes to **-**.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/battery.jpg" style={{width:600, height:'auto'}}/></div>
 
+**Step 3.** Connect the EN04 board to your computer with a USB-C data cable.
+
 :::caution
-Double-check the polarity. Different batteries can have mixed wiring. Misaligned wires can be removed from the JST connector with a needle and re-inserted correctly.
+Check battery polarity before powering the board. A battery connector with reversed polarity can damage the hardware.
 :::
 
 </TabItem>
 <TabItem value="breakout" label="ePaper Breakout Board + XIAO nRF52840">
 
-Connect the **XIAO nRF52840 (Sense Plus)** to the **ePaper Breakout Board**, then attach the **4.26" monochrome ePaper screen** to the FPC connector. Use a USB-C data cable to connect the XIAO to your computer.
+**Step 1.** Mount the XIAO nRF52840 series board on the ePaper Breakout Board.
+
+**Step 2.** Insert the ePaper panel FPC cable into the breakout board connector and lock the latch.
+
+**Step 3.** Connect the XIAO to your computer with a USB-C data cable.
 
 </TabItem>
 </Tabs>
 
-## Step 2: Flash the Firmware
+## Step 2: Install Firmware
 
 <Tabs groupId="oepl-hardware">
-<TabItem value="en04" label="XIAO ePaper Display Board EN04" default>
+<TabItem value="reterminal" label="reTerminal E Series" default>
 
-The easiest path is the OpenDisplay web installer.
+OpenDisplay provides direct Toolbox presets for the reTerminal E Series.
 
-**Step 1.** Open the [OpenDisplay Web Installer](https://opendisplay.org/firmware/install/index.html) in a browser.
+**Step 1.** Open the matching Toolbox preset in Chrome or Edge:
 
-**Step 2.** Choose **Seeed EN04 4.26** or **Seeed EN04 7.3** (or whichever preset matches your display) from the device list.
+- [reTerminal E1001 Toolbox preset](https://opendisplay.org/firmware/toolbox/index.html?config=reterminal-e1001)
+- [reTerminal E1002 Toolbox preset](https://opendisplay.org/firmware/toolbox/index.html?config=reterminal-e1002)
+- [reTerminal E1003 Toolbox preset](https://opendisplay.org/firmware/toolbox/index.html?config=reterminal-e1003)
 
-**Step 3.** Click **Download Firmware** and save `NRF52840.uf2` locally.
+**Step 2.** Confirm that the selected preset matches your device.
 
-**Step 4.** Connect the EN04 board via USB-C.
+**Step 3.** Click **Install firmware (USB)**.
 
-**Step 5.** Press the reset button **twice** consecutively. A USB drive will appear on your computer (the EN04 in DFU mode). Copy `NRF52840.uf2` to that drive.
+**Step 4.** In the browser pairing dialog, select the USB serial device that appears when the reTerminal is connected.
 
-:::tip
-If the installer fails:
+**Step 5.** Wait until the installer finishes and the device reboots.
 
-- Try a different USB cable (some are power-only — use a data cable).
-- Press the reset button twice on the EN04 to re-enter DFU mode.
-- Try a different USB port.
-:::
+After installation, continue with BLE configuration in the next step.
 
-**Step 6.** Open the [OpenDisplay Configuration Page](https://opendisplay.org/firmware/config/?config=nrf52840-en04-s6) and connect to your board.
+</TabItem>
+<TabItem value="en04" label="XIAO ePaper Display Board EN04">
 
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/step6.png" style={{width:600, height:'auto'}}/></div>
+The current OpenDisplay flow uses the Toolbox for EN04 setup.
 
-If you selected **Seeed EN04 4.26** or **Seeed EN04 7.3**, you'll see **Auto Install to Device** — the easiest way to configure the kit.
+**Step 1.** Open [OpenDisplay Toolbox for EN04](https://opendisplay.org/firmware/toolbox/index.html?driver=en04) in Chrome or Edge.
 
-**Step 7.** Press the **Connect** button. Select the new device in the pairing dialog and press **Pair**.
+**Step 2.** Select the panel that matches your connected ePaper display.
 
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/step7.png" style={{width:500, height:'auto'}}/></div>
+**Step 3.** Click **Install firmware (USB)** and follow the browser prompt.
 
-**Step 8.** Press **Auto Install to Device** to save the configuration to the board.
+**Step 4.** If the browser asks for bootloader mode, double-press the reset button on the EN04 board, then select the newly detected USB device.
 
-After installation and configuration, the display shows a startup screen and is ready to receive content over BLE.
+**Step 5.** Wait for the firmware installation to finish.
 
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/boot_screen.jpg" style={{width:500, height:'auto'}}/></div>
+The EN04 will reboot into OpenDisplay firmware and can then be configured over BLE.
 
 </TabItem>
 <TabItem value="breakout" label="ePaper Breakout Board + XIAO nRF52840">
 
-The XIAO nRF52840 needs the **OEPL_BLE** firmware before the OEPL Config Builder can talk to it.
+The XIAO nRF52840 + Breakout Board path uses **OEPL_BLE** firmware before the OEPL Config Builder can connect to it.
 
-**Step 1.** Download the latest `OEPL_BLE` firmware from the official OEPL release page.
+**Step 1.** Open the [OEPL_BLE release page](https://github.com/OpenEPaperLink/OEPL_BLE/releases) and download the firmware package that matches your XIAO nRF52840 board.
 
 <div class="github_container" style={{textAlign: 'center'}}>
-    <a class="github_item" href="https://github.com/OpenEPaperLink/OEPL_BLE/releases/tag/test7" target="_blank" rel="noopener noreferrer">
-    <strong><span><font color={'FFFFFF'} size={"4"}> Download the firmware</font></span></strong>
-    </a>
+	<a class="github_item" href="https://github.com/OpenEPaperLink/OEPL_BLE/releases" target="_blank" rel="noopener noreferrer">
+	<strong><span><font color={'FFFFFF'} size={"4"}> Download OEPL_BLE Firmware</font></span></strong>
+	</a>
 </div>
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/hub_oepl.png" style={{width:700, height:'auto'}}/></div>
 
-**Step 2.** Connect the XIAO nRF52840 + Breakout Board + screen, plug the XIAO into your computer via USB-C, then **press the reset button twice**. The XIAO appears as a USB drive on your computer.
+**Step 2.** Double-press the reset button on the XIAO. It appears as a USB drive.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/file_pic.png" style={{width:700, height:'auto'}}/></div>
 
-**Step 3.** Drag-and-drop the downloaded `.uf2` firmware onto that USB drive. The XIAO will reboot and run the new firmware on the next power cycle.
+**Step 3.** Drag the downloaded `.uf2` firmware file to the USB drive.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/firmware.jpg" style={{width:700, height:'auto'}}/></div>
+
+The XIAO reboots and runs OEPL_BLE firmware on the next power cycle.
 
 </TabItem>
 </Tabs>
@@ -210,49 +307,59 @@ The XIAO nRF52840 needs the **OEPL_BLE** firmware before the OEPL Config Builder
 ## Step 3: Configure the Device over BLE
 
 <Tabs groupId="oepl-hardware">
-<TabItem value="en04" label="XIAO ePaper Display Board EN04" default>
+<TabItem value="reterminal" label="reTerminal E Series" default>
 
-The OpenDisplay configuration step from the previous flash workflow already handles this — your EN04 should now boot to the OpenDisplay startup screen and accept image uploads.
+**Step 1.** In the same OpenDisplay Toolbox page, click **Configure over Bluetooth**.
+
+**Step 2.** Select your reTerminal device in the BLE pairing dialog.
+
+**Step 3.** Wait for the Toolbox to write the selected preset to the device.
+
+**Step 4.** Confirm that the display refreshes or shows the OpenDisplay startup/test image.
+
+The device is now ready for image upload through OpenDisplay tools or Home Assistant.
+
+</TabItem>
+<TabItem value="en04" label="XIAO ePaper Display Board EN04">
+
+**Step 1.** In the OpenDisplay Toolbox, keep **EN04** selected as the driver board and confirm the matching panel option.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/step6.png" style={{width:600, height:'auto'}}/></div>
+
+**Step 2.** Click **Configure over Bluetooth**.
+
+**Step 3.** Select the EN04 device in the BLE pairing dialog.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/step7.png" style={{width:500, height:'auto'}}/></div>
+
+**Step 4.** Wait until the Toolbox writes the configuration and the display refreshes.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/boot_screen.jpg" style={{width:500, height:'auto'}}/></div>
 
 </TabItem>
 <TabItem value="breakout" label="ePaper Breakout Board + XIAO nRF52840">
 
-Open the [OEPL Config Builder](https://config.openepaperlink.org/), then connect to your XIAO via BLE. (If no device shows up, re-flash the firmware and try again.)
+**Step 1.** Open the [OEPL Config Builder](https://config.openepaperlink.org/).
+
+**Step 2.** Click **Connect** and select your XIAO nRF52840 device from the BLE pairing dialog.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/Connect_demo_2.png" style={{width:700, height:'auto'}}/></div>
 
-When you see "Connected" in the terminal, you can use:
-
-- **Read Config** — read the current configuration from the MCU.
-- **Write Config** — write a new configuration to the MCU.
-- **Reboot** — reboot the MCU.
-
-### Builder panel
-
-Pick variables and parameters in the panel to compose your configuration.
-
-- **system_config** — host IC and power management pins.
-- **manufacturer_data** — manufacturer identifier and board info.
-- **power_option** — power supply and sleep settings.
-- **display** — display / panel information (can repeat for multiple displays).
-- **led** — optional LED configuration (repeatable).
-- **sensor_data** — optional sensor readings / definitions (repeatable).
-- **data_bus** — bus definitions (I2C / SPI / …).
-- **binary_inputs** — buttons, switches.
+**Step 3.** Use the builder panels to configure the host IC, power settings, display, LEDs, sensors, buses, and binary inputs.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/Builder_demo_1.png" style={{width:700, height:'auto'}}/></div>
 
-You can export the configuration as `.bin`, `Hex`, or `JSON`, or import a saved JSON. A ready-made configuration for the 4.26" screen is available below.
+**Step 4.** For the Seeed 4.26" monochrome ePaper setup, import the sample configuration below.
 
 <div align="center">
-<a href="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/oep_config_base.json" target="_blank">
+<a href="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/oep_config_base.json" target="_blank" rel="noopener noreferrer">
 <p style={{textAlign: 'center'}}><button type="button" className="download" style={{backgroundColor: '#00A418', borderRadius: '8px', border: 'none', color: '#fff', padding: '12px 24px', textAlign: 'center', textDecoration: 'none', display: 'inline-block', fontSize: '16px', margin: '4px 2px', cursor: 'pointer'}}>4.26" sample config (JSON)</button></p>
 </a>
 </div>
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/Package_import_1.png" style={{width:700, height:'auto'}}/></div>
 
-After dialing in the configuration, click **Write Config** to save it to the MCU.
+**Step 5.** Click **Write Config** to save the configuration to the MCU.
 
 </TabItem>
 </Tabs>
@@ -260,378 +367,236 @@ After dialing in the configuration, click **Write Config** to save it to the MCU
 ## Step 4: Upload Images
 
 <Tabs groupId="oepl-hardware">
-<TabItem value="en04" label="XIAO ePaper Display Board EN04" default>
+<TabItem value="reterminal" label="reTerminal E Series" default>
 
-The OpenDisplay project has a dedicated browser-based uploader.
+OpenDisplay devices can receive images through the browser display tool.
 
-**Step 1.** Open the [OpenDisplay BLE Tester](https://opendisplay.org/firmware/display/index.html).
+**Step 1.** Open the [OpenDisplay display tool](https://opendisplay.org/firmware/display/index.html).
 
-**Step 2.** Click **Connect** and pick your OpenDisplay device from the BLE pairing dialog.
+**Step 2.** Click **Connect** and select your reTerminal device from the BLE pairing dialog.
 
-**Step 3.** Click **Select Image** and choose a file from your computer.
+**Step 3.** Click **Select Image** and choose a local image file.
+
+**Step 4.** Click **Upload Image**.
+
+When the transfer finishes, the ePaper display refreshes and shows the uploaded image.
+
+:::tip
+Use an image size that matches your panel for the cleanest result:
+
+- reTerminal E1001: 800 × 480 px
+- reTerminal E1002: 800 × 480 px
+- reTerminal E1003: 1404 × 1872 px
+:::
+
+</TabItem>
+<TabItem value="en04" label="XIAO ePaper Display Board EN04">
+
+**Step 1.** Open the [OpenDisplay display tool](https://opendisplay.org/firmware/display/index.html).
+
+**Step 2.** Click **Connect** and select the EN04 device from the BLE pairing dialog.
+
+**Step 3.** Click **Select Image** and choose a local image file.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/upload_image.png" style={{width:500, height:'auto'}}/></div>
 
+**Step 4.** Click **Upload Image**. The ePaper display refreshes after the transfer completes.
+
 :::tip
-For best results:
-
-- Use images that match your display resolution (the 7.3" panel is 800×480 px).
-- Black-and-white images render best on monochrome displays.
-- The tool automatically converts and dithers colour images.
+Use an image size that matches your connected panel. For example, a 7.3" Spectra 6 panel uses 800 × 480 px.
 :::
-
-**Step 4.** Click **Upload Image**. The e-paper refreshes and your image appears.
-
-You can also create custom content with image editors (GIMP, Photoshop), Python + Pillow scripts, web-based image generators, or a Home Assistant integration (covered below).
 
 </TabItem>
 <TabItem value="breakout" label="ePaper Breakout Board + XIAO nRF52840">
 
-The OEPL Image Uploader is also a BLE web tool. The pin assignments differ from the Config Builder firmware, so you need to flash a slightly different image upload firmware first.
+The OEPL Image Uploader is a separate BLE web tool for the OEPL_BLE path.
 
-<div align="center">
-<a href="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/oep_config_base.json" target="_blank">
-<p style={{textAlign: 'center'}}><button type="button" className="download" style={{backgroundColor: '#00A418', borderRadius: '8px', border: 'none', color: '#fff', padding: '12px 24px', textAlign: 'center', textDecoration: 'none', display: 'inline-block', fontSize: '16px', margin: '4px 2px', cursor: 'pointer'}}>Click here to get the firmware</button></p>
-</a>
-</div>
+**Step 1.** Open the [OEPL Image Uploader](https://atc1441.github.io/ATC_BLE_OEPL_Image_Upload.html).
 
-In the **E-Paper prefix filter(s)** field, change the value to `OEPL` — otherwise the uploader cannot find the device.
+**Step 2.** In **E-Paper prefix filter(s)**, enter `OEPL`.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/Image_Upload_4.png" style={{width:350, height:'auto'}}/></div>
 
+**Step 3.** Connect to the XIAO device over BLE.
+
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/Image_Upload_6.png" style={{width:500, height:'auto'}}/></div>
 
-Click **Select File** to choose a local file for upload.
+**Step 4.** Click **Select File** and choose a local image.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/Image_Upload_2.png" style={{width:550, height:'auto'}}/></div>
 
-When the file transfer is finished, click **Upload Image** to push it to the e-paper.
+**Step 5.** Click **Upload Image**.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/eInk/xiao-expansion/Image_Upload_5.png" style={{width:350, height:'auto'}}/></div>
 
-When you see **Upload Complete**, the e-paper has been refreshed with the new image.
+When the uploader shows **Upload Complete**, the ePaper display has been refreshed.
 
 </TabItem>
 </Tabs>
 
-## Home Assistant Integration (EN04 / OpenDisplay only)
+## Home Assistant Integration
 
-:::tip
-To integrate with Home Assistant, you need a Bluetooth-capable setup:
-
-- **Home Assistant Green** (built-in Bluetooth)
-- **Home Assistant OS / Supervised** on hardware with Bluetooth support
-- **ESPHome Bluetooth Proxy** (recommended for better range — see below)
-
-**Note:** Shelly devices acting as Bluetooth proxies **do not** support active connections required by OpenDisplay, so they cannot be used.
-:::
-
-**Step 1. Install the integration**
-
-For detailed installation instructions, see the [OpenDisplay Home Assistant Integration repository](https://github.com/OpenEPaperLink/Home_Assistant_Integration?tab=readme-ov-file#getting-help).
-
-The easiest path is via **HACS** (Home Assistant Community Store):
-
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=OpenEpaperLink&repository=Home_Assistant_Integration)
-
-:::info
-After installing the custom integration via HACS, **restart Home Assistant** for the changes to take effect.
-:::
-
-**Step 2. Add the discovered device**
-
-Once Home Assistant is back up:
-
-1. Go to **Settings → Devices & services**.
-2. Find your OpenDisplay device under **Discovered**.
-3. Click **Add**.
-4. Set the **Name** and **Area**, then click **Finish**.
-
-A new image appears on the display, confirming Home Assistant is connected.
-
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/pair_ha.jpg" style={{width:500, height:'auto'}}/></div>
-
-### Automating display updates
-
-The primary service is `open_epaper_link.drawcustom`, which lets you draw text, icons, images, and shapes. See the [drawcustom docs](https://github.com/OpenDisplay-org/Home_Assistant_Integration/blob/main/docs/drawcustom/supported_types.md) for the full type/parameter reference.
-
-#### Example 1 — display sensor data (Visual Editor)
-
-1. Go to **Settings → Automations & Scenes** and click **Create Automation**.
-2. Add a **Time Pattern** trigger (e.g. every 10 minutes).
-
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/add_trigger.png" style={{width:800, height:'auto'}}/></div>
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/fill_trigger.png" style={{width:800, height:'auto'}}/></div>
-
-3. Add an **Action** → **OpenDisplay: Draw Custom Image**.
-
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/add_action.png" style={{width:800, height:'auto'}}/></div>
-
-4. Pick the target device.
-
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/pick_target.png" style={{width:800, height:'auto'}}/></div>
-
-5. In the **Payload** field, enter the layout configuration:
-
-```yaml
-- type: "text"
-  value: "Living Room"
-  x: "50%"
-  y: 50
-  anchor: "mm"
-  size: 70
-  color: "red"
-- type: "icon"
-  value: "mdi:thermometer"
-  x: "35%"
-  y: 200
-  anchor: "mm"
-  size: 100
-  color: "black"
-- type: "text"
-  value: "{{ states('sensor.living_room_temperature') }}°C"
-  x: "65%"
-  y: 200
-  anchor: "mm"
-  size: 100
-  color: "black"
-- type: "icon"
-  value: "mdi:water-percent"
-  x: "35%"
-  y: 350
-  anchor: "mm"
-  size: 100
-  color: "black"
-- type: "text"
-  value: "{{ states('sensor.living_room_humidity') }}%"
-  x: "65%"
-  y: 350
-  anchor: "mm"
-  size: 100
-  color: "black"
-```
-
-:::caution Entity IDs
-The entity IDs above (e.g. `sensor.living_room_temperature`) are placeholders. Replace them with your actual Home Assistant entity IDs.
-:::
-
-#### Example 2 — countdown timer (YAML)
-
-For advanced users, edit the automation as YAML. This example counts down to a date and renders the result on the display.
-
-```yaml
-alias: Update ePaper Display - Countdown
-description: Displays days until Christmas
-triggers:
-  - at: "00:00:00"
-    trigger: time
-actions:
-  - variables:
-      days_left: "{{ (as_datetime('2025-12-24').date() - now().date()).days }}"
-  - action: open_epaper_link.drawcustom
-    data:
-      background: white
-      payload:
-        - type: text
-          value: "{{ 'Christmas Countdown' if days_left > 0 else '' }}"
-          x: 50%
-          "y": 50
-          anchor: mm
-          size: 60
-          color: black
-        - type: text
-          value: "{{ days_left if days_left > 0 else '' }}"
-          x: 50%
-          "y": 240
-          anchor: mm
-          size: 250
-          color: red
-        - type: text
-          value: >-
-            {{ 'Day Left' if days_left == 1 else ('Days Left' if days_left > 0
-            else '') }}
-          x: 50%
-          "y": 430
-          anchor: mm
-          size: 60
-          color: black
-        - type: text
-          value: "{{ 'It''s Christmas!!!' if days_left == 0 else '' }}"
-          x: 50%
-          "y": 50%
-          anchor: mm
-          size: 100
-          color: red
-    target:
-      device_id: 2ad706d4aa7c657b6fe99a733cef2253
-```
-
-:::caution Device ID
-The `device_id` above is a placeholder. Find your actual device ID by:
-
-1. Creating a new automation in the Visual Editor.
-2. Selecting your OpenDisplay device in the action settings.
-3. Switching to **YAML mode** (three-dot menu in the action card).
-4. Copying the `device_id` and pasting it into your automation.
-:::
-
-## Bonus
-
-Looking for a stylish way to mount the display? This 3D-printed insert fits the IKEA RODÅLM picture frame and makes mounting easy:
-
-- **[MakerWorld]** [Seeed 7.3" Spectra Insert for IKEA RODALM Frame](https://makerworld.com/pl/models/2103122-seeed-7-3-spectra-insert-for-ikea-rodalm-frame)
-
-## Troubleshooting
-
-### Firmware installation issues
-
-**Problem**: PC doesn't detect a new USB drive after connecting the board.
-
-- Try a different USB cable (data cable, not power-only).
-- Press the reset button twice after connecting the board.
-
-### Configuration issues
-
-**Problem**: The board isn't discovered.
-
-- Verify the LED on the board blinks — confirms the device is powered.
-- Try rebooting the board.
-- Re-flash the firmware.
-
-**Problem**: Display shows nothing after firmware installation.
-
-- Verify the FPC cable orientation (metal contacts facing up).
-- Confirm the cable is fully inserted and latched.
-- Re-check the configuration via the configurator.
-
-### Bluetooth connection issues
-
-**Problem**: Cannot find the device in Bluetooth pairing.
-
-- Ensure the device is powered on and the firmware is installed.
-- Move closer (within 2–3 m).
-- Confirm Bluetooth is enabled on your computer / phone.
-
-**Problem**: Connection drops during image upload.
-
-- Stay close to the device during upload.
-- Charge the battery sufficiently or power via USB.
-- Avoid uploading very large images.
-- Try again in a less congested Bluetooth environment.
-
-### Battery and power issues
-
-**Problem**: Short battery life.
-
-- Configure longer sleep intervals in the configurator.
-- Always run the latest firmware (each release improves power use).
-- Reduce display refresh frequency.
-- Verify the battery is fully charged (4.2 V for Li-Po).
-
-**Problem**: Device won't charge.
-
-- Check polarity (red = +, black = −).
-- Verify the charging cable provides ≥500 mA.
-- Ensure the power switch is **ON**.
-- Try a different USB power source.
-
-### Home Assistant / Integration issues
-
-**Problem**: "Insufficient connection slots" when adding devices via Raspberry Pi + HA.
-
-This often happens because the Raspberry Pi's built-in Bluetooth adapter has hit its concurrent connection limit.
-
-![Error: Insufficient connection slots](https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/esphome_proxy/1.png)
-*Example of the "Insufficient connection slots" message.*
-
-**Recommended fix**: use an ESP32 device (e.g. XIAO ESP32S3) as an **ESPHome Bluetooth Proxy**. This offloads the Bluetooth connection from the Pi, providing more stable "slots" for your e-paper displays.
-
-## Using ESPHome Bluetooth Proxy
-
-If you hit "Insufficient connection slots" using a Raspberry Pi with Home Assistant, an ESPHome Bluetooth Proxy is the most effective fix.
+Home Assistant has an official **OpenDisplay** integration for OpenDisplay firmware devices. It communicates over BLE and provides the `opendisplay.upload_image` action for sending images to the display.
 
 ### Prerequisites
 
-- An ESP32 device (e.g. XIAO ESP32S3).
+- Home Assistant 2026.4 or later.
+- A working Bluetooth setup that supports active BLE connections.
+- An OpenDisplay firmware device powered on and within Bluetooth range.
+
+The following Bluetooth paths are suitable:
+
+- Home Assistant Green or another Home Assistant host with supported Bluetooth hardware.
+- ESPHome Bluetooth Proxy running ESPHome firmware 2022.9.3 or later.
+
+:::info
+Shelly Bluetooth proxies are useful for passive BLE sensors, but OpenDisplay image upload requires active BLE connections. Use a Home Assistant Bluetooth adapter or ESPHome Bluetooth Proxy for this workflow.
+:::
+
+### Add the Device
+
+**Step 1.** In Home Assistant, go to **Settings > Devices & services**.
+
+**Step 2.** If the device is discovered automatically, click **Add** on the OpenDisplay card.
+
+**Step 3.** If it is not discovered automatically, click **Add Integration**, search for **OpenDisplay**, and follow the setup flow.
+
+**Step 4.** Assign the device name and area.
+
+After the device is added, Home Assistant can discover and connect to the OpenDisplay device over Bluetooth.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/pair_ha.jpg" style={{width:500, height:'auto'}}/></div>
+
+### Upload an Image from Home Assistant
+
+Store your image in Home Assistant's local media folder, then call `opendisplay.upload_image`.
+
+```yaml
+action: opendisplay.upload_image
+data:
+  device_id: "your_device_id"
+  image:
+    media_content_id: "media-source://media_source/local/photo.png"
+    media_content_type: "image/png"
+```
+
+For scheduled updates, use the same action inside an automation.
+
+```yaml
+triggers:
+  - trigger: time
+    at: "08:00:00"
+actions:
+  - action: opendisplay.upload_image
+    data:
+      device_id: "your_device_id"
+      image:
+        media_content_id: "media-source://media_source/local/daily.png"
+        media_content_type: "image/png"
+```
+
+:::tip
+Use Home Assistant automations to generate or copy a new PNG before calling `opendisplay.upload_image`. The OpenDisplay integration then handles the BLE transfer to the display.
+:::
+
+### Optional: Custom Draw Payloads
+
+The OpenDisplay community also maintains a HACS integration with a `drawcustom` workflow for drawing text, icons, shapes, QR codes, images, plots, and progress bars directly from Home Assistant payloads.
+
+Use this path when you specifically need draw-command layouts instead of uploading a prepared image.
+
+<div class="github_container" style={{textAlign: 'center'}}>
+	<a class="github_item" href="https://github.com/OpenDisplay-org/Home_Assistant_Integration" target="_blank" rel="noopener noreferrer">
+	<strong><span><font color={'FFFFFF'} size={"4"}> OpenDisplay HACS Integration</font></span></strong>
+	</a>
+</div>
+
+In the Home Assistant visual editor, create an automation, add a time trigger, then add the OpenDisplay draw action and select the target device.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/add_trigger.png" style={{width:800, height:'auto'}}/></div>
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/fill_trigger.png" style={{width:800, height:'auto'}}/></div>
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/add_action.png" style={{width:800, height:'auto'}}/></div>
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/pick_target.png" style={{width:800, height:'auto'}}/></div>
+
+## Using ESPHome Bluetooth Proxy
+
+An ESPHome Bluetooth Proxy extends Bluetooth coverage and improves reliability when the display is far from the Home Assistant host.
+
+### Prerequisites
+
+- An ESP32 device, such as XIAO ESP32S3.
 - ESPHome installed in Home Assistant.
-- A USB data cable to connect the ESP32 to your Pi (for the first flash).
+- A USB data cable for the first flash.
 
-### Step-by-step configuration
+### Step-by-step Configuration
 
-1. **Connect the device** — plug the XIAO ESP32S3 into a USB port on your Raspberry Pi.
+**Step 1.** Connect the ESP32 device to the computer or Home Assistant host used for flashing.
 
-2. **Create a new ESPHome configuration** with the YAML below:
+**Step 2.** Create a new ESPHome device and use a Bluetooth Proxy configuration similar to the example below.
 
-   ![ESPHome YAML Configuration](https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/esphome_proxy/2.png)
+```yaml
+esphome:
+  name: esps3-proxy
+  friendly_name: ESP32S3 Bluetooth Proxy
 
-   ```yaml
-   esphome:
-     name: esps3-proxy
-     friendly_name: ESP32S3 Bluetooth Proxy
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: esp-idf
 
-   esp32:
-     board: esp32-s3-devkitc-1
-     framework:
-       type: esp-idf
+logger:
+  level: INFO
 
-   # 1. Enable detailed logging (useful for debugging)
-   logger:
-     level: VERY_VERBOSE
+esp32_ble_tracker:
+  scan_parameters:
+    active: true
 
-   # 2. Core: Enable Bluetooth Tracker
-   esp32_ble_tracker:
-     scan_parameters:
-       active: true
+bluetooth_proxy:
+  active: true
 
-   # 3. Core: Enable Bluetooth Proxy
-   bluetooth_proxy:
-     active: true
+api:
+  encryption:
+    key: "YOUR_ENCRYPTION_KEY"
 
-   api:
-     encryption:
-       key: "YOUR_ENCRYPTION_KEY"
+ota:
+  - platform: esphome
+    password: "YOUR_OTA_PASSWORD"
 
-   ota:
-     - platform: esphome
-       password: "YOUR_OTA_PASSWORD"
+wifi:
+  ssid: "YOUR_WIFI_SSID"
+  password: "YOUR_WIFI_PASSWORD"
 
-   wifi:
-     ssid: "YOUR_WIFI_SSID"
-     password: "YOUR_WIFI_PASSWORD"
+captive_portal:
+```
 
-   captive_portal:
-   ```
+**Step 3.** Click **Install** in ESPHome and flash the firmware to the ESP32 device.
 
-3. **Install / flash**:
+**Step 4.** After the ESP32 connects to Wi-Fi, add the discovered Bluetooth Proxy in Home Assistant.
 
-   - Pick **Install → Plug into this computer** (or the device running ESPHome).
+**Step 5.** Keep the proxy close to the OpenDisplay device during image uploads.
 
-     ![ESPHome flashing process](https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/esphome_proxy/4.png)
+When the proxy is working, Home Assistant shows the Bluetooth Proxy as connected and the ePaper display can be discovered through it.
 
-   - On first flash, ESPHome may download the `esp-idf` toolchain. Make sure your environment has stable Internet access to GitHub.
-   - After compilation, the logs show "WiFi connected" and Bluetooth scan activity.
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/esphome_proxy/5.png" style={{width:700, height:'auto'}}/></div>
 
-4. **Add the proxy to Home Assistant**:
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/esphome_proxy/6.png" style={{width:700, height:'auto'}}/></div>
 
-   - Home Assistant will automatically discover the new Bluetooth Proxy.
-   - Once added, your e-paper displays should be discoverable through the proxy without the "insufficient slots" error.
+## Bonus: 3D Printed Mount
 
-   ![Success: Bluetooth Proxy connected](https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/esphome_proxy/5.png)
+For EN04 with the 7.3" Spectra panel, this community model provides an insert for the IKEA RODALM picture frame:
 
-   ![Success: e-paper display added](https://files.seeedstudio.com/wiki/Epaper/EN04/OPEL/esphome_proxy/6.png)
+- **[MakerWorld]** [Seeed 7.3" Spectra Insert for IKEA RODALM Frame](https://makerworld.com/pl/models/2103122-seeed-7-3-spectra-insert-for-ikea-rodalm-frame)
 
 ## Resources
 
-- **[GitHub]** [OpenDisplay firmware](https://github.com/OpenDisplay-org/Firmware)
-- **[GitHub]** [OEPL_BLE firmware](https://github.com/OpenEPaperLink/OEPL_BLE)
-- **[Web Tool]** [OpenDisplay firmware web installer](https://opendisplay.org/firmware/install/index.html)
-- **[Web Tool]** [OpenDisplay configuration builder](https://opendisplay.org/firmware/config/index.html)
-- **[Web Tool]** [OpenDisplay display tester](https://opendisplay.org/firmware/display/index.html)
+- **[Web Tool]** [OpenDisplay Toolbox](https://opendisplay.org/firmware/toolbox/index.html)
+- **[Web Tool]** [OpenDisplay display tool](https://opendisplay.org/firmware/display/index.html)
 - **[Web Tool]** [OEPL Config Builder](https://config.openepaperlink.org/)
 - **[Web Tool]** [OEPL Image Uploader](https://atc1441.github.io/ATC_BLE_OEPL_Image_Upload.html)
-- **[Discord]** [OpenDisplay Community](https://discord.gg/WG7tbTzF9Z)
-- **[Website]** [OpenDisplay Official Site](https://opendisplay.org)
-- **[Website]** [OpenEPaperLink Official Site](https://openepaperlink.de/)
+- **[Home Assistant]** [Official OpenDisplay Integration](https://www.home-assistant.io/integrations/opendisplay/)
 
 ## Tech Support & Product Discussion
 

--- a/sites/en/docs/Sensor/ePaper_Displays/Application/work_with_zephyr.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/Application/work_with_zephyr.md
@@ -1,0 +1,198 @@
+---
+description: Use Zephyr RTOS with Seeed Studio reTerminal E Series ePaper devices, with official Zephyr board documentation links for reTerminal E1001, E1002, and E1003.
+title: Work with Zephyr
+keywords:
+  - ePaper display
+  - Zephyr
+  - RTOS
+  - reTerminal
+  - ESP32-S3
+image: https://files.seeedstudio.com/wiki/reterminal_e10xx/img/206.png
+slug: /epaper_work_with_zephyr
+sidebar_position: 11
+last_update:
+  date: 06/30/2026
+  author: Citric
+createdAt: '2026-06-30'
+url: https://wiki.seeedstudio.com/epaper_work_with_zephyr/
+updatedAt: '2026-06-30'
+---
+
+# Work with Zephyr
+
+[Zephyr](https://www.zephyrproject.org/) is an open-source real-time operating system for embedded devices. It is useful when you want a production-oriented firmware stack with a build system, device tree based hardware description, kernel services, drivers, and upstream board definitions.
+
+Zephyr already includes official board documentation for **reTerminal E1001**, **reTerminal E1002**, and **reTerminal E1003**. This Wiki page is a Seeed ePaper entry point: use it to choose the correct board target, then follow the official Zephyr documentation for installation, build, flashing, and debugging.
+
+## When to Use Zephyr
+
+Use Zephyr when your project needs:
+
+- a structured RTOS development workflow;
+- upstream board support and long-term maintainable firmware;
+- kernel features such as threads, timers, queues, and device drivers;
+- a consistent build and flashing workflow across multiple embedded boards;
+- direct access to ESP32-S3 peripherals through Zephyr APIs.
+
+If your goal is a Home Assistant dashboard, no-code page design, or Arduino-style drawing API, start from the matching application page on the [Seeed ePaper Displays overview](/seeed_epaper_displays). Zephyr is best suited for developers who want to build custom firmware at the RTOS level.
+
+## Supported Devices
+
+Prepare one of the following reTerminal E Series devices before starting Zephyr development.
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <th>reTerminal E1001</th>
+      <th>reTerminal E1002</th>
+      <th>reTerminal E1003</th>
+    </tr>
+    <tr>
+      <td><div style={{textAlign:'center'}}><a href="https://www.seeedstudio.com/reTerminal-E1001-p-6534.html" target="_blank" rel="noopener noreferrer"><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/24.jpg" style={{width:220, height:'auto'}}/></a></div></td>
+      <td><div style={{textAlign:'center'}}><a href="https://www.seeedstudio.com/reTerminal-E1002-p-6533.html" target="_blank" rel="noopener noreferrer"><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/25.jpg" style={{width:220, height:'auto'}}/></a></div></td>
+      <td><div style={{textAlign:'center'}}><a href="https://www.seeedstudio.com/reTerminal-E1003-p-6731.html" target="_blank" rel="noopener noreferrer"><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/e1003/2-reTerminal-E1003-Epaper-Display.jpg" style={{width:220, height:'auto'}}/></a></div></td>
+    </tr>
+    <tr>
+      <td align="center">7.5" monochrome ePaper<br/>800 x 480</td>
+      <td align="center">7.3" full-color ePaper<br/>800 x 480</td>
+      <td align="center">10.3" monochrome ePaper<br/>1404 x 1872, touch</td>
+    </tr>
+    <tr>
+      <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+        <a class="get_one_now_item" href="https://www.seeedstudio.com/reTerminal-E1001-p-6534.html" target="_blank" rel="noopener noreferrer">
+        <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+        </a>
+      </div></td>
+      <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+        <a class="get_one_now_item" href="https://www.seeedstudio.com/reTerminal-E1002-p-6533.html" target="_blank" rel="noopener noreferrer">
+        <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+        </a>
+      </div></td>
+      <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+        <a class="get_one_now_item" href="https://www.seeedstudio.com/reTerminal-E1003-p-6731.html" target="_blank" rel="noopener noreferrer">
+        <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+        </a>
+      </div></td>
+    </tr>
+    <tr>
+      <td align="center"><code>reterminal_e1001/esp32s3/procpu</code></td>
+      <td align="center"><code>reterminal_e1002/esp32s3/procpu</code></td>
+      <td align="center"><code>reterminal_e1003/esp32s3/procpu</code></td>
+    </tr>
+  </table>
+</div>
+
+The quick-start command examples below use the `procpu` target. For dual-core details, hardware feature tables, supported runners, and debug options, use the official board page for your device.
+
+## Recommended Reading Path
+
+Follow this path when setting up Zephyr for the first time:
+
+1. Open the [Zephyr Getting Started Guide](https://docs.zephyrproject.org/latest/develop/getting_started/index.html) and install the Zephyr toolchain, Python dependencies, west, and SDK for your operating system.
+2. Open the official board page for your device from the [Official Zephyr Documentation](#official-zephyr-documentation) section.
+3. Read the board page overview to confirm the display size, SoC, onboard sensors, keys, LEDs, RTC, and battery-related hardware described by Zephyr.
+4. Use the board page **Supported Features** section to check which peripherals are already described in Zephyr.
+5. Use the board page **Programming and Debugging** section for build, flash, reset, and debug commands.
+
+:::tip
+Keep the official Zephyr board page open while developing. It is the source of truth for current board targets, supported features, runners, and build options.
+:::
+
+## Quick Command Pattern
+
+After your Zephyr workspace is ready, build the `hello_world` sample with the board target that matches your device.
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <th>Device</th>
+      <th>Build command</th>
+    </tr>
+    <tr>
+      <td>reTerminal E1001</td>
+      <td><code>west build -b reterminal_e1001/esp32s3/procpu samples/hello_world</code></td>
+    </tr>
+    <tr>
+      <td>reTerminal E1002</td>
+      <td><code>west build -b reterminal_e1002/esp32s3/procpu samples/hello_world</code></td>
+    </tr>
+    <tr>
+      <td>reTerminal E1003</td>
+      <td><code>west build -b reterminal_e1003/esp32s3/procpu samples/hello_world</code></td>
+    </tr>
+  </table>
+</div>
+
+Then flash the built image:
+
+```shell
+west flash
+```
+
+If the board stays in download mode after flashing, use the reset option documented by Zephyr:
+
+```shell
+west flash --reset-type watchdog-reset
+```
+
+For MCUboot, sysbuild, faster flashing, OpenOCD debugging, and advanced runner options, follow the **Programming and Debugging** section on the official board page for your device.
+
+## Official Zephyr Documentation
+
+Use the links below as the main references for Zephyr-specific setup and board details:
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <th>Topic</th>
+      <th>Use this when you need to</th>
+      <th>Link</th>
+    </tr>
+    <tr>
+      <td>Zephyr Getting Started</td>
+      <td>Install Zephyr, west, Python dependencies, and the Zephyr SDK.</td>
+      <td><a href="https://docs.zephyrproject.org/latest/develop/getting_started/index.html" target="_blank" rel="noopener noreferrer">Open Getting Started</a></td>
+    </tr>
+    <tr>
+      <td>Zephyr Boards</td>
+      <td>Search all Zephyr-supported boards and confirm current target names.</td>
+      <td><a href="https://docs.zephyrproject.org/latest/boards/index.html" target="_blank" rel="noopener noreferrer">Open Boards index</a></td>
+    </tr>
+    <tr>
+      <td>reTerminal E1001</td>
+      <td>Build, flash, and debug Zephyr applications for reTerminal E1001.</td>
+      <td><a href="https://docs.zephyrproject.org/latest/boards/seeed/reterminal_e1001/doc/index.html" target="_blank" rel="noopener noreferrer">Open E1001 docs</a></td>
+    </tr>
+    <tr>
+      <td>reTerminal E1002</td>
+      <td>Build, flash, and debug Zephyr applications for reTerminal E1002.</td>
+      <td><a href="https://docs.zephyrproject.org/latest/boards/seeed/reterminal_e1002/doc/index.html" target="_blank" rel="noopener noreferrer">Open E1002 docs</a></td>
+    </tr>
+    <tr>
+      <td>reTerminal E1003</td>
+      <td>Build, flash, and debug Zephyr applications for reTerminal E1003.</td>
+      <td><a href="https://docs.zephyrproject.org/latest/boards/seeed/reterminal_e1003/doc/index.html" target="_blank" rel="noopener noreferrer">Open E1003 docs</a></td>
+    </tr>
+  </table>
+</div>
+
+## Related Seeed Wiki Pages
+
+- [Seeed ePaper Displays overview](/seeed_epaper_displays)
+- [Getting Started with reTerminal E1001](/getting_started_with_reterminal_e1001)
+- [Getting Started with reTerminal E1002](/getting_started_with_reterminal_e1002)
+- [Getting Started with reTerminal E1003](/getting_started_with_reterminal_e1003)
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="button_tech_support_container">
+<a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+<a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+</div>
+
+<div class="button_tech_support_container">
+<a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+<a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+</div>

--- a/sites/en/docs/Sensor/ePaper_Displays/seeed_epaper_displays.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/seeed_epaper_displays.md
@@ -24,7 +24,7 @@ Seeed Studio offers an end-to-end ePaper portfolio organized around three produc
 2. **Driver / Expansion Boards** — pair an MCU with universal or large-format ePaper screens to build your own product.
 3. **DIY Kits & Bare Panels** — designed for the maker community, optimized for specific platforms such as TRMNL or XIAO.
 
-All three lines share the **same software ecosystem**: SenseCraft HMI (no-code), Home Assistant / ESPHome, TRMNL, Arduino / ESP-IDF / PlatformIO, plus visual UI tools like SquareLine Vision, EEZ Studio, and Lopaka. Pick a hardware family, and the rest of the toolchain stays the same.
+All three lines share the **same software ecosystem**: SenseCraft HMI (no-code), Home Assistant / ESPHome, TRMNL, Arduino / ESP-IDF / PlatformIO, Zephyr, plus visual UI tools like SquareLine Vision, EEZ Studio, and Lopaka. Pick a hardware family, and the rest of the toolchain stays the same.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/206.png" style={{width:1000, height:'auto'}}/></div>
 
@@ -255,6 +255,12 @@ Every Seeed ePaper product converges into the same software ecosystem. Pick the 
       <td>All ESP32-S3 products (E1001–E1004, EE02–EE05, TRMNL Kit, XIAO Panel)</td>
     </tr>
     <tr>
+      <td><a href="https://wiki.seeedstudio.com/epaper_work_with_zephyr" target="_blank" rel="noopener noreferrer"><strong>Zephyr RTOS</strong></a></td>
+      <td align="center">RTOS</td>
+      <td>Upstream Zephyr board workflow with west, device tree, kernel services, drivers, flashing, and debugging.</td>
+      <td>reTerminal E1001 / E1002 / E1003</td>
+    </tr>
+    <tr>
       <td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_squareline_vision" target="_blank" rel="noopener noreferrer"><strong>SquareLine Vision</strong></a></td>
       <td align="center">Visual UI design</td>
       <td>Drag-and-drop LVGL UI in the browser, then export ready-to-compile code.</td>
@@ -301,6 +307,7 @@ Each tutorial below walks through one platform end-to-end:
 
 - [Work with Arduino](https://wiki.seeedstudio.com/epaper_work_with_arduino) — main reference: IDE setup, `Seeed_GFX` library, `driver.h` generation. Per-product cookbooks: reTerminal E Series — [ePaper Display](https://wiki.seeedstudio.com/reterminal_e10xx_with_arduino) & [Onboard Peripherals](https://wiki.seeedstudio.com/reterminal_e10xx_with_arduino_peripherals), [TRMNL DIY Kit](https://wiki.seeedstudio.com/ogdiy_kit_works_with_arduino), [XIAO 7.5" Panel](https://wiki.seeedstudio.com/xiao_075inch_epaper_panel_arduino).
 - [Work with PlatformIO](https://wiki.seeedstudio.com/epaper_work_with_platformio) — main reference: VS Code setup, `platformio.ini` configuration, `Seeed_GFX` setup, and per-product PlatformIO environment selection. Per-product cookbook: [EE04 / EE0x PlatformIO](https://wiki.seeedstudio.com/ee04_with_platformio).
+- [Work with Zephyr](https://wiki.seeedstudio.com/epaper_work_with_zephyr) — entry page for Zephyr RTOS support on reTerminal E1001, E1002, and E1003, with official Zephyr board documentation links and board targets.
 
 ### Open-source ESL / OEPL
 


### PR DESCRIPTION
## Summary

- Update the OpenEPaperLink / OpenDisplay ePaper application guide with current supported devices, restored product images, purchase links, and streamlined resources.
- Add a new Work with Zephyr application guide for reTerminal E1001, E1002, and E1003.
- Add Zephyr to the Seeed ePaper Displays software ecosystem and application tutorial index.

## Validation

- `git diff --check upstream/docusaurus-version..HEAD`
- English content check for the edited ePaper pages
- `yarn build:en`

## Notes

- The PR branch was created from `upstream/docusaurus-version` and only cherry-picks the two intended ePaper documentation commits.