### PR TITLE
Fix tutorial link for nRFConnect SDK Usage

### DIFF
--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/XIAO_nRF54LM20A_Matter_Usage.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/XIAO_nRF54LM20A_Matter_Usage.md
@@ -179,7 +179,7 @@ Thread routing devices such as Connect ZBT-1, Connect ZBT-2 or Home Assistant Ye
 
 :::tip
 
-This tutorial is based on VS Code and the nRF Connect Extension. If you are new to them, you can refer to [XIAO nRF54LM20A nRFConnect SDK Usage](http://localhost:3000/xiao_nrf54lm20a_getting_started/#nrfconnect-sdk-usage)
+This tutorial is based on VS Code and the nRF Connect Extension. If you are new to them, you can refer to [XIAO nRF54LM20A nRFConnect SDK Usage](https://wiki.seeedstudio.com/xiao_nrf54lm20a_ncs/#getting-started-with-ncs)
 
 :::
 

--- a/sites/es/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/es_XIAO_nRF54LM20A_Matter_Usage.md
+++ b/sites/es/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/es_XIAO_nRF54LM20A_Matter_Usage.md
@@ -179,7 +179,7 @@ También se pueden utilizar dispositivos de enrutamiento Thread como Connect ZBT
 
 :::tip
 
-Este tutorial se basa en VS Code y la extensión nRF Connect. Si eres nuevo en ellas, puedes consultar [XIAO nRF54LM20A nRFConnect SDK Usage](http://localhost:3000/xiao_nrf54lm20a_getting_started/#uso-del-sdk-nrfconnect)
+Este tutorial se basa en VS Code y la extensión nRF Connect. Si eres nuevo en ellas, puedes consultar [XIAO nRF54LM20A nRFConnect SDK Usage](https://wiki.seeedstudio.com/es/xiao_nrf54lm20a_ncs/)
 
 :::
 

--- a/sites/ja/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/ja_XIAO_nRF54LM20A_Matter_Usage.md
+++ b/sites/ja/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/ja_XIAO_nRF54LM20A_Matter_Usage.md
@@ -179,7 +179,7 @@ Connect ZBT-1、Connect ZBT-2、Home Assistant Yellow などの Thread ルーテ
 
 :::tip
 
-このチュートリアルは VS Code と nRF Connect Extension を前提としています。これらに不慣れな場合は、[XIAO nRF54LM20A nRFConnect SDK Usage](http://localhost:3000/xiao_nrf54lm20a_getting_started/#nrfconnect-sdk-usage) を参照してください。
+このチュートリアルは VS Code と nRF Connect Extension を前提としています。これらに不慣れな場合は、[XIAO nRF54LM20A nRFConnect SDK Usage](https://wiki.seeedstudio.com/ja/xiao_nrf54lm20a_ncs/) を参照してください。
 
 :::
 

--- a/sites/pt-BR/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/pt_XIAO_nRF54LM20A_Matter_Usage.md
+++ b/sites/pt-BR/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/pt_XIAO_nRF54LM20A_Matter_Usage.md
@@ -179,7 +179,7 @@ Dispositivos de roteamento Thread como Connect ZBT-1, Connect ZBT-2 ou Home Assi
 
 :::tip
 
-Este tutorial é baseado no VS Code e na extensão nRF Connect. Se você é iniciante neles, pode consultar [XIAO nRF54LM20A nRFConnect SDK Usage](http://localhost:3000/xiao_nrf54lm20a_getting_started/#uso-do-nrfconnect-sdk)
+Este tutorial é baseado no VS Code e na extensão nRF Connect. Se você é iniciante neles, pode consultar [XIAO nRF54LM20A nRFConnect SDK Usage](https://wiki.seeedstudio.com/pt-br/xiao_nrf54lm20a_ncs/)
 
 :::
 

--- a/sites/zh-CN/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/cn_XIAO_nRF54LM20A_Matter_Usage.md
+++ b/sites/zh-CN/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_nRF54LM20A-Sense/Wireless_Connection/cn_XIAO_nRF54LM20A_Matter_Usage.md
@@ -179,7 +179,7 @@ Home Assistant 是一个功能强大的开源家庭自动化平台，可让你�
 
 :::tip
 
-本教程基于 VS Code 和 nRF Connect 扩展。如果你对它们还不熟悉，可以参考 [XIAO nRF54LM20A nRFConnect SDK Usage](http://localhost:3000/xiao_nrf54lm20a_getting_started/#nrfconnect-sdk-usage)
+本教程基于 VS Code 和 nRF Connect 扩展。如果你对它们还不熟悉，可以参考 [XIAO nRF54LM20A nRFConnect SDK Usage](https://wiki.seeedstudio.com/cn/xiao_nrf54lm20a_ncs/)
 
 :::
 


### PR DESCRIPTION
Updated the link for the nRFConnect SDK Usage tutorial to point to the correct wiki page.