### PR TITLE
docs(codecraft): add banner and CTA button across locales

### DIFF
--- a/sites/en/docs/Cloud_Chain/CodeCraft/0-codecraft-overview.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/0-codecraft-overview.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - Vibe Coding
   - SenseCraft AI
-image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp
 slug: /codecraft/codecraft-overview
 sidebar_class_name: hidden
 sidebar_position: 1
@@ -20,6 +20,14 @@ updatedAt: '2026-06-29'
 # CodeCraft User Guide
 
 Welcome to CodeCraft. This guide will help you quickly understand the platform, complete account preparation, and start using CodeCraft for zero-code project creation, community project reuse, and publishing your works.
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>Try CodeCraft Now 🚀</font></span></strong>
+    </a>
+</div>
 
 ## Documentation Contents
 

--- a/sites/en/docs/Cloud_Chain/CodeCraft/1-quick-start-and-support.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/1-quick-start-and-support.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - Quick Start
 sidebar_label: 1. Quick Start & Support
-image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-hardware-ecosystem-EN.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp
 slug: /codecraft/quick-start-and-support
 sidebar_position: 2
 last_update:
@@ -17,6 +17,14 @@ updatedAt: '2026-06-29'
 ---
 
 # CodeCraft Quick Start & Support
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>Try CodeCraft Now 🚀</font></span></strong>
+    </a>
+</div>
 
 ## 1.1 Introduction to CodeCraft
 

--- a/sites/es/docs/Cloud_Chain/CodeCraft/es_0-codecraft-overview.md
+++ b/sites/es/docs/Cloud_Chain/CodeCraft/es_0-codecraft-overview.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - Vibe Coding
   - SenseCraft AI
-image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp
 slug: /codecraft/codecraft-overview
 sidebar_class_name: hidden
 sidebar_position: 1
@@ -18,6 +18,14 @@ url: https://wiki.seeedstudio.com/es/codecraft/codecraft-overview/
 # Guía de usuario de CodeCraft
 
 Bienvenido a CodeCraft. Esta guía te ayudará a comprender rápidamente la plataforma, completar la preparación de la cuenta y empezar a usar CodeCraft para la creación de proyectos sin código, la reutilización de proyectos de la comunidad y la publicación de tus trabajos.
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>Prueba CodeCraft ahora 🚀</font></span></strong>
+    </a>
+</div>
 
 ## Contenido de la documentación
 

--- a/sites/es/docs/Cloud_Chain/CodeCraft/es_1-quick-start-and-support.md
+++ b/sites/es/docs/Cloud_Chain/CodeCraft/es_1-quick-start-and-support.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - Quick Start
 sidebar_label: 1. Inicio rápido y soporte
-image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp
 slug: /codecraft/quick-start-and-support
 sidebar_position: 2
 last_update:
@@ -15,6 +15,14 @@ url: https://wiki.seeedstudio.com/es/codecraft/quick-start-and-support/
 ---
 
 # Inicio rápido y soporte de CodeCraft
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>Prueba CodeCraft ahora 🚀</font></span></strong>
+    </a>
+</div>
 
 ## 1.1 Introducción a CodeCraft
 

--- a/sites/ja/docs/Cloud_Chain/CodeCraft/ja_0-codecraft-overview.md
+++ b/sites/ja/docs/Cloud_Chain/CodeCraft/ja_0-codecraft-overview.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - Vibe Coding
   - SenseCraft AI
-image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp
 slug: /codecraft/codecraft-overview
 sidebar_class_name: hidden
 sidebar_position: 1
@@ -18,6 +18,14 @@ url: https://wiki.seeedstudio.com/ja/codecraft/codecraft-overview/
 # CodeCraft ユーザーガイド
 
 CodeCraft へようこそ。本ガイドでは、プラットフォームの概要をすばやく理解し、アカウント準備を完了し、CodeCraft を使ってノーコードでのプロジェクト作成、コミュニティプロジェクトの再利用、作品の公開を始める方法を説明します。
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>CodeCraft を今すぐ体験 🚀</font></span></strong>
+    </a>
+</div>
 
 ## ドキュメント内容
 

--- a/sites/ja/docs/Cloud_Chain/CodeCraft/ja_1-quick-start-and-support.md
+++ b/sites/ja/docs/Cloud_Chain/CodeCraft/ja_1-quick-start-and-support.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - クイックスタート
 sidebar_label: 1. クイックスタート & サポート
-image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp
 slug: /codecraft/quick-start-and-support
 sidebar_position: 2
 last_update:
@@ -15,6 +15,14 @@ url: https://wiki.seeedstudio.com/ja/codecraft/quick-start-and-support/
 ---
 
 # CodeCraft クイックスタート & サポート
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>CodeCraft を今すぐ体験 🚀</font></span></strong>
+    </a>
+</div>
 
 ## 1.1 CodeCraft の概要
 

--- a/sites/pt-BR/docs/Cloud_Chain/CodeCraft/pt_0-codecraft-overview.md
+++ b/sites/pt-BR/docs/Cloud_Chain/CodeCraft/pt_0-codecraft-overview.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - Vibe Coding
   - SenseCraft AI
-image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp
 slug: /codecraft/codecraft-overview
 sidebar_class_name: hidden
 sidebar_position: 1
@@ -18,6 +18,14 @@ url: https://wiki.seeedstudio.com/pt-br/codecraft/codecraft-overview/
 # Guia do Usuário CodeCraft
 
 Bem-vindo ao CodeCraft. Este guia ajudará você a entender rapidamente a plataforma, concluir a preparação da conta e começar a usar o CodeCraft para criação de projetos sem código, reutilização de projetos da comunidade e publicação de seus trabalhos.
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>Experimente o CodeCraft agora 🚀</font></span></strong>
+    </a>
+</div>
 
 ## Conteúdo da Documentação
 

--- a/sites/pt-BR/docs/Cloud_Chain/CodeCraft/pt_1-quick-start-and-support.md
+++ b/sites/pt-BR/docs/Cloud_Chain/CodeCraft/pt_1-quick-start-and-support.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - Quick Start
 sidebar_label: 1. Quick Start & Support
-image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp
 slug: /codecraft/quick-start-and-support
 sidebar_position: 2
 last_update:
@@ -15,6 +15,14 @@ url: https://wiki.seeedstudio.com/pt-br/codecraft/quick-start-and-support/
 ---
 
 # Início Rápido e Suporte do CodeCraft
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>Experimente o CodeCraft agora 🚀</font></span></strong>
+    </a>
+</div>
 
 ## 1.1 Introdução ao CodeCraft
 

--- a/sites/zh-CN/docs/Cloud_Chain/CodeCraft/cn_0-codecraft-overview.md
+++ b/sites/zh-CN/docs/Cloud_Chain/CodeCraft/cn_0-codecraft-overview.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - Vibe Coding
   - SenseCraft AI
-image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner-ZH.webp
 slug: /codecraft/codecraft-overview
 sidebar_class_name: hidden
 sidebar_position: 1
@@ -18,6 +18,14 @@ url: https://wiki.seeedstudio.com/cn/codecraft/codecraft-overview/
 # CodeCraft 用户指南
 
 欢迎使用 CodeCraft。本指南将帮助你快速了解平台、完成账号准备，并开始使用 CodeCraft 进行零代码项目创作、社区项目复用与作品发布。
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner-ZH.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>立即体验 CodeCraft 🚀</font></span></strong>
+    </a>
+</div>
 
 ## 文档目录
 

--- a/sites/zh-CN/docs/Cloud_Chain/CodeCraft/cn_1-quick-start-and-support.md
+++ b/sites/zh-CN/docs/Cloud_Chain/CodeCraft/cn_1-quick-start-and-support.md
@@ -5,7 +5,7 @@ keywords:
   - CodeCraft
   - 快速入门
 sidebar_label: 1. 快速入门与账户支持
-image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+image: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner-ZH.webp
 slug: /codecraft/quick-start-and-support
 sidebar_position: 2
 last_update:
@@ -15,6 +15,14 @@ url: https://wiki.seeedstudio.com/cn/codecraft/quick-start-and-support/
 ---
 
 # CodeCraft 快速入门与账户支持
+
+![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner-ZH.webp)
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>立即体验 CodeCraft 🚀</font></span></strong>
+    </a>
+</div>
 
 ## 1.1 认识 CodeCraft
 


### PR DESCRIPTION
## What's changed

Adds the CodeCraft banner and a call-to-action button to the CodeCraft docs, in all 5 locales (en, zh-CN, ja, es, pt-BR):

- **Overview page** (`*0-codecraft-overview.md`): banner added below the welcome paragraph; frontmatter `image:` switched from the Seeed logo to the banner.
- **Quick Start page** (`*1-quick-start-and-support.md`): banner added right under the page title; frontmatter `image:` switched to the banner.
- **CTA button** under each banner linking to https://codecraft.seeed.cc, using the wiki's standard `get_one_now_container` style with localized label text (e.g. “Try CodeCraft Now 🚀” / “立即体验 CodeCraft 🚀”).

Banner URLs:
- en / ja / es / pt-BR: https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp
- zh-CN (localized): https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner-ZH.webp

Since `scripts/generateWiki.js` sources homepage card covers from doc frontmatter, the Latest Wiki card will pick up the new image on the next regeneration — `src/utils/wiki.js` is intentionally left untouched.

Verified locally on the es and zh-CN dev servers — banner and CTA render correctly on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)