### PR TITLE
Update: io_expander_for_xiao.md - remove purchase link and add discontinued caution

### DIFF
--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Expansion_board/gpio_expander_for_xiao.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Expansion_board/gpio_expander_for_xiao.md
@@ -5,7 +5,7 @@ image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /io_expander_for_xiao
 sku: 103030415
 last_update:
-  date: 04/29/2026
+  date: 07/09/2026
   author: Stephen Lo
 createdAt: '2023-09-19'
 updatedAt: '2026-04-29'
@@ -14,11 +14,10 @@ url: https://wiki.seeedstudio.com/io_expander_for_xiao/
 
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/gpio-expander-for-xiao/1.jpg" alt="pir" width={500} height="auto" /></p>
 
-<div class="get_one_now_container" style={{textAlign: 'center'}}>
-    <a class="get_one_now_item" href="https://www.seeedstudio.com/GPIO-Expander-for-XIAO-p-5795.html" target="_blank">
-            <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
-    </a>
-</div><br />
+:::caution
+This product is no longer available for purchase.
+:::
+
 
 The IO Expander for XIAO is a state-of-the-art expansion board designed to enhance the capabilities of the Seeed Studio XIAO series. Powered by the MCP23017 chip, this board offers an additional 16 IO pins, allowing users to expand their projects without constraints. Whether you're a hobbyist looking to experiment with more components or a professional seeking a reliable IO expansion solution, this board is tailored to meet your needs. Its compatibility with the XIAO series ensures seamless integration, making your development process smoother and more efficient.
 


### PR DESCRIPTION
## Changes
- Removed the "Get One Now" purchase link/button from the IO Expander for XIAO page
- Added a `caution` admonition box indicating the product is no longer available for purchase
- Updated `last_update.date` to 07/09/2026

## File Changed
- `sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Expansion_board/gpio_expander_for_xiao.md`

## Motivation
This product has been discontinued and is no longer sold on the Seeed Studio store. The purchase link was leading to a dead page.