### PR TITLE
docs: add Wio Tracker L1 channel PSK troubleshooting

### DIFF
--- a/sites/en/docs/Network/Meshtastic_Network/Wio_Tracker_L1/get_started_with_wio_tracker_l1.md
+++ b/sites/en/docs/Network/Meshtastic_Network/Wio_Tracker_L1/get_started_with_wio_tracker_l1.md
@@ -411,6 +411,30 @@ Connect the device to your PC, double-press the `Reset` button. The yellow LED w
 
 Press the `Reset` button once to exit DFU mode.
 
+### Unable to Communicate on the Primary Channel
+
+If the device cannot communicate with nearby nodes or send messages, first check that the LoRa region and modem preset match the surrounding nodes. You should also check whether the default **PSK** has been changed. A different PSK on the primary channel will prevent the device from communicating with other nodes on that channel.
+
+The easiest way to find this issue is through the mobile app. Open the app, connect to the target device, then navigate to `Settings` -> `Channels`. Select the primary channel and check the **PSK** value. If it is different from the surrounding nodes, update it to the same PSK and save the channel settings.
+
+<Tabs>
+<TabItem value="ios" label="IOS App">
+
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/wio_tracker/communicate_problems_ios.png" alt="Check primary channel PSK in the iOS app" width={500} height="auto" /></p>
+
+</TabItem>
+
+<TabItem value="android" label="Android App">
+
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/wio_tracker/communicate_problem_and.png" alt="Check primary channel PSK in the Android app" width={900} height="auto" /></p>
+
+</TabItem>
+</Tabs>
+
+**Solution**
+
+If you are not sure which settings were changed, restore the device to its default settings by following the [Factory Reset](https://wiki.seeedstudio.com/get_started_with_meshtastic_wio_tracker_l1/#factory-reset) guide. If only the PSK was changed, set it back to `AQ==`.
+
 ### Device automatically turn off
 
 #### Description
@@ -441,9 +465,7 @@ NodeDB is the local database that stores information about nodes discovered in t
 
 Open the app and connect to the target device. Go to **Settings**->**Device**->**Device Config**->**Reset NodeDB**.
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/wio_tracker/L1nodeDB3.png" alt="Device entry in Settings" width={300} height="auto" /></p>
-
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/wio_tracker/L1nodeDB4.png" alt="Reset NodeDB button in Device Config" width={300} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/wio_tracker/L1nodeDBmerge.png" alt="Device settings and Reset NodeDB button in the app" width={600} height="auto" /></p>
 
 #### Exchange User Info
 


### PR DESCRIPTION
## Summary
- Add primary channel PSK troubleshooting for Wio Tracker L1 communication issues
- Add iOS and Android screenshots for checking channel PSK
- Replace separate NodeDB screenshots with the merged image

## Verification
- Confirmed final PR diff contains only the Wio Tracker L1 getting started page