### PR TITLE
Add ESP32S3 MeshCore settings persistence FAQ

### DIFF
--- a/sites/en/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/Other_Community_Firmware/get_started_with_esp32s3_meshcore.md
+++ b/sites/en/docs/Network/Meshtastic_Network/XIAO_ESP32S3_&_SX1262_Kit/Other_Community_Firmware/get_started_with_esp32s3_meshcore.md
@@ -312,6 +312,62 @@ Also, you can adjust the advert broadcast interval. The interval range of `auto 
 
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshcore/SolarNode/AdvertInterval.jpg" alt="pir" width={300} height="auto" /></p>
 
+## FAQ
+
+### Device loses saved settings after power loss
+
+If the device name, LoRa Region, or other settings appear to be saved successfully in the app but disappear after the device is powered off, check whether the ESP32-S3 flash partition table is abnormal.
+
+You can use [ESPConnect](https://thelastoutpostworkshop.github.io/ESPConnect/) to inspect the ESP32-S3 flash memory partition table. ESPConnect is only applicable to ESP devices and cannot be used with nRF52840 devices.
+
+1. Open ESPConnect and select a baud rate of `115200`.
+
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshcore/ESP32S3/710-2.png" alt="ESPConnect baud rate selection" width={800} height="auto" /></p>
+
+2. Click **Connect**, then select **USB JTAG/serial debug unit**.
+
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshcore/ESP32S3/710-3.png" alt="Select USB JTAG serial debug unit in ESPConnect" width={600} height="auto" /></p>
+
+3. After the device is connected, open the **Partitions** page.
+4. Check whether `spiffs` exists in the partition list.
+
+If the partition table is abnormal, the ESPConnect **Partitions** page may show only:
+
+- `nvs`
+- `phy_init`
+- `factory`
+
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshcore/ESP32S3/710-4.png" alt="ESPConnect partition table without SPIFFS" width={800} height="auto" /></p>
+
+However, the official MeshCore v1.15 `merged.bin` firmware should include:
+
+- `nvs`
+- `otadata`
+- `app0`
+- `app1`
+- `spiffs` 1.5 MB
+- `coredump`
+
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshcore/ESP32S3/710-5.png" alt="ESPConnect partition table with SPIFFS" width={800} height="auto" /></p>
+
+MeshCore v1.15 writes the device name and Region settings to `/new_prefs` in SPIFFS. If the `spiffs` partition does not exist, these settings are only kept in RAM. The mobile app may show that the settings were saved successfully, but they will be lost after power is removed.
+
+This usually happens when the normal firmware file is flashed, for example:
+
+```text
+Xiao_S3_WIO_companion_radio_ble-v1.15.0-dee3e26.bin
+```
+
+Instead, the full merged firmware should be flashed, for example:
+
+```text
+Xiao_S3_WIO_companion_radio_ble-v1.15.0-dee3e26-merged.bin
+```
+
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshcore/ESP32S3/710-1.png" alt="MeshCore flasher download options for normal and merged firmware" width={800} height="auto" /></p>
+
+To fix this issue, erase the device and flash the merged firmware version again.
+
 ## Resource
 - **[PDF]**[The Schematic Diagram of the SX1262 compatible with Xiao ESP32-S3](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Schematic_Diagram_Wio-SX1262_for_XIAO.pdf)
 - **[PDF]**[Wio-SX1262 Module Datasheet](https://files.seeedstudio.com/products/SenseCAP/Wio_SX1262/Wio-SX1262_Module_Datasheet.pdf)


### PR DESCRIPTION
## Summary
- Add an FAQ explaining why ESP32S3 MeshCore settings may be lost after power loss when SPIFFS is missing.
- Add ESPConnect troubleshooting steps and screenshots for checking the partition table.
- Clarify that users should erase and flash the merged firmware.

## Verification
- Ran `yarn start:en`; Docusaurus served the English site at `http://localhost:3000/`.
- Confirmed `http://localhost:3000/get_started_with_esp32s3_meshcore/` returned `200 OK`.
- Confirmed the five added image URLs returned `200 image/png`.