### PR TITLE
Fix dead neptune.ai transfer-learning link in YOLOv8 classification doc (all language variants)

### DIFF
--- a/sites/en/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/YOLOv8_custom_classification_model.md
+++ b/sites/en/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/YOLOv8_custom_classification_model.md
@@ -361,7 +361,7 @@ For the classification, we're going to use one of [pre-trained models already av
 This models have been trained on ImageNet and are fine tuned for classification.
  We're going to use it and train it on our data.
 
-This is what's know as [transfer learning](https://www.bestaiweb.ai/glossary/transfer-learning/).
+This is what's know as [transfer learning](https://web.archive.org/web/20251006174754/https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras).
 
 I'm going to use the model [YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt). Probably others will work fine too, but because we don't need real time, its a trade off on speed and accuracy.
 

--- a/sites/en/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/YOLOv8_custom_classification_model.md
+++ b/sites/en/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/YOLOv8_custom_classification_model.md
@@ -361,7 +361,7 @@ For the classification, we're going to use one of [pre-trained models already av
 This models have been trained on ImageNet and are fine tuned for classification.
  We're going to use it and train it on our data.
 
-This is what's know as [transfer learning](https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras).
+This is what's know as [transfer learning](https://www.bestaiweb.ai/glossary/transfer-learning/).
 
 I'm going to use the model [YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt). Probably others will work fine too, but because we don't need real time, its a trade off on speed and accuracy.
 

--- a/sites/es/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/es_YOLOv8_custom_classification_model.md
+++ b/sites/es/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/es_YOLOv8_custom_classification_model.md
@@ -331,7 +331,7 @@ Para la clasificación, vamos a usar uno de los [modelos pre-entrenados ya dispo
 Estos modelos han sido entrenados en ImageNet y están ajustados para clasificación.
 Vamos a usarlo y entrenarlo con nuestros datos.
 
-Esto es lo que se conoce como [aprendizaje por transferencia](https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras).
+Esto es lo que se conoce como [aprendizaje por transferencia](https://www.bestaiweb.ai/glossary/transfer-learning/).
 
 Voy a usar el modelo [YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt). Probablemente otros también funcionen bien, pero como no necesitamos tiempo real, es un equilibrio entre velocidad y precisión.
 

--- a/sites/es/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/es_YOLOv8_custom_classification_model.md
+++ b/sites/es/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/es_YOLOv8_custom_classification_model.md
@@ -331,7 +331,7 @@ Para la clasificación, vamos a usar uno de los [modelos pre-entrenados ya dispo
 Estos modelos han sido entrenados en ImageNet y están ajustados para clasificación.
 Vamos a usarlo y entrenarlo con nuestros datos.
 
-Esto es lo que se conoce como [aprendizaje por transferencia](https://www.bestaiweb.ai/glossary/transfer-learning/).
+Esto es lo que se conoce como [aprendizaje por transferencia](https://web.archive.org/web/20251006174754/https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras).
 
 Voy a usar el modelo [YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt). Probablemente otros también funcionen bien, pero como no necesitamos tiempo real, es un equilibrio entre velocidad y precisión.
 

--- a/sites/ja/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/ja_YOLOv8_custom_classification_model.md
+++ b/sites/ja/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/ja_YOLOv8_custom_classification_model.md
@@ -361,7 +361,7 @@ names: ["Barn Swallow","Common Firecrest","Common Nightingale","Eurasian Chaffin
 これらのモデルはImageNetで訓練されており、分類用にファインチューニングされています。
 これを使用して、私たちのデータで訓練します。
 
-これは[転移学習](https://www.bestaiweb.ai/glossary/transfer-learning/)として知られているものです。
+これは[転移学習](https://web.archive.org/web/20251006174754/https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras)として知られているものです。
 
 私は[YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt)モデルを使用します。おそらく他のモデルでも問題なく動作するでしょうが、リアルタイムが必要ないため、速度と精度のトレードオフになります。
 

--- a/sites/ja/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/ja_YOLOv8_custom_classification_model.md
+++ b/sites/ja/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/ja_YOLOv8_custom_classification_model.md
@@ -361,7 +361,7 @@ names: ["Barn Swallow","Common Firecrest","Common Nightingale","Eurasian Chaffin
 これらのモデルはImageNetで訓練されており、分類用にファインチューニングされています。
 これを使用して、私たちのデータで訓練します。
 
-これは[転移学習](https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras)として知られているものです。
+これは[転移学習](https://www.bestaiweb.ai/glossary/transfer-learning/)として知られているものです。
 
 私は[YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt)モデルを使用します。おそらく他のモデルでも問題なく動作するでしょうが、リアルタイムが必要ないため、速度と精度のトレードオフになります。
 

--- a/sites/pt-BR/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/pt_YOLOv8_custom_classification_model.md
+++ b/sites/pt-BR/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/pt_YOLOv8_custom_classification_model.md
@@ -361,7 +361,7 @@ Para a classificação, vamos usar um dos [modelos pré‑treinados já disponí
 Esses modelos foram treinados no ImageNet e são ajustados para classificação.
  Vamos usá‑lo e treiná‑lo com nossos dados.
 
-Isto é o que é conhecido como [transfer learning](https://www.bestaiweb.ai/glossary/transfer-learning/).
+Isto é o que é conhecido como [transfer learning](https://web.archive.org/web/20251006174754/https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras).
 
 Vou usar o modelo [YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt). Provavelmente outros também funcionarão bem, mas como não precisamos de tempo real, é um compromisso entre velocidade e precisão.
 

--- a/sites/pt-BR/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/pt_YOLOv8_custom_classification_model.md
+++ b/sites/pt-BR/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/pt_YOLOv8_custom_classification_model.md
@@ -361,7 +361,7 @@ Para a classificação, vamos usar um dos [modelos pré‑treinados já disponí
 Esses modelos foram treinados no ImageNet e são ajustados para classificação.
  Vamos usá‑lo e treiná‑lo com nossos dados.
 
-Isto é o que é conhecido como [transfer learning](https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras).
+Isto é o que é conhecido como [transfer learning](https://www.bestaiweb.ai/glossary/transfer-learning/).
 
 Vou usar o modelo [YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt). Provavelmente outros também funcionarão bem, mas como não precisamos de tempo real, é um compromisso entre velocidade e precisão.
 

--- a/sites/zh-CN/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/cn_YOLOv8_custom_classification_model.md
+++ b/sites/zh-CN/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/cn_YOLOv8_custom_classification_model.md
@@ -358,7 +358,7 @@ names: ["Barn Swallow","Common Firecrest","Common Nightingale","Eurasian Chaffin
 这些模型已经在 ImageNet 上进行了训练，并针对分类任务进行了微调。
 我们将使用它并在我们的数据上进行训练。
 
-这就是所谓的[迁移学习](https://www.bestaiweb.ai/glossary/transfer-learning/)。
+这就是所谓的[迁移学习](https://web.archive.org/web/20251006174754/https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras)。
 
 我将使用模型 [YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt)。可能其他模型也能很好地工作，但因为我们不需要实时性，这是速度和准确性之间的权衡。
 

--- a/sites/zh-CN/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/cn_YOLOv8_custom_classification_model.md
+++ b/sites/zh-CN/docs/Edge/NVIDIA_Jetson/Application/Computer_Vision/cn_YOLOv8_custom_classification_model.md
@@ -358,7 +358,7 @@ names: ["Barn Swallow","Common Firecrest","Common Nightingale","Eurasian Chaffin
 这些模型已经在 ImageNet 上进行了训练，并针对分类任务进行了微调。
 我们将使用它并在我们的数据上进行训练。
 
-这就是所谓的[迁移学习](https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras)。
+这就是所谓的[迁移学习](https://www.bestaiweb.ai/glossary/transfer-learning/)。
 
 我将使用模型 [YOLOv8l-cls](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-cls.pt)。可能其他模型也能很好地工作，但因为我们不需要实时性，这是速度和准确性之间的权衡。
 


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes the *transfer learning* definition link in `YOLOv8_custom_classification_model.md` across all 5 language variants (en/es/ja/pt-BR/zh-CN — same fix in each file). The link now points to a live page explaining the concept: https://www.bestaiweb.ai/glossary/transfer-learning/

**Disclosure:** I'm one of the authors of bestaiweb.ai. I've suggested our link because the page genuinely covers the same ground as the dead article. Happy to switch it to the Wayback snapshot of the original instead if you prefer: https://web.archive.org/web/20251006174754/https://neptune.ai/blog/transfer-learning-guide-examples-for-images-and-text-in-keras