### PR TITLE
Update: add XIAO ESP32-C3 Rust example

### DIFF
--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Series_Projects.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_Series_Projects.md
@@ -6,7 +6,7 @@ keywords:
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /xiao_topic_page
 last_update:
-  date: 06/04/2026
+  date: 7/15/2026
   author: Carla Guo
 createdAt: '2023-07-07'
 updatedAt: '2026-06-04'
@@ -469,7 +469,7 @@ We can't do it without the love, contribution that we get from the community, an
   </tr>
   <tr>
    <th style={{width:333, height:'auto'}}><a href="https://github.com/Wumpf/Seeed-nRF52840-Sense-projects" target="_blank">XIAO nRF52840 (Sense)</a></th>
-   <th style={{width:333, height:'auto'}}><a href="" target="_blank"></a></th>
+   <th style={{width:333, height:'auto'}}><a href="https://github.com/uFerris-rs/uferris-bsp/tree/master/examples/xiao-esp32-c3" target="_blank">XIAO ESP32-C3</a></th>
             <th style={{width:333, height:'auto'}}><a href="" target="_blank"></a></th>
   </tr>
  </table>


### PR DESCRIPTION
## Summary
- Add XIAO ESP32-C3 to the Rust table on the XIAO topic page
- Link it to the uFerris BSP example
- Update last_update.date

## Test
- yarn build