### PR TITLE
[新增] 补充 Ubuntu/macOS 系统 PCAN 驱动异常修复方案

### DIFF
--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
@@ -303,6 +303,77 @@ Disconnect the USB2CAN module, set the DIP switch to **120R**, and reconnect it 
 
 </details>
 
+<details>
+<summary>PCAN Firmware Download & Driver Repair Steps - Ubuntu</summary>
+
+Ubuntu users please refer to this guide
+
+1.> 📦 [Click to download USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.Switch USB2CAN to BOOT
+
+3.Please extract the USB2CAN.zip from step 1, and place flash_pcan_ubuntu.sh and pcan_canable_hw.bin (from inside USB2CAN.zip) in the same directory
+
+[Click to download flash_pcan_ubuntu.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_ubuntu.sh)
+
+If transferring from another computer (e.g. scp):
+
+```text
+scp flash_pcan_ubuntu.sh pcan_canable_hw.bin seeed@your_Ubuntu_IP:~/Downloads/
+```
+Or simply copy it onto a USB flash drive and plug it into the Ubuntu machine — as long as the files end up in ~/Downloads, the current directory, or /tmp, the script will find them automatically.
+
+4.Execute:
+
+```text
+bash flash_pcan_ubuntu.sh
+```
+
+Enter your password; wait for completion
+
+After completion, switch back to "120R"
+
+Re-plug the USB.
+
+</details>
+
+<details>
+<summary>PCAN Firmware Download & Driver Repair Steps - MAC</summary>
+
+MAC users please refer to this guide
+
+1.> 📦 [Click to download USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.Switch USB2CAN to BOOT
+
+3.Please extract the USB2CAN.zip from step 1, and place flash_pcan_mac.sh and pcan_canable_hw.bin (from inside USB2CAN.zip) in the same directory
+
+[Click to download flash_pcan_mac.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_mac.sh)
+
+If transferring from another computer (e.g. scp):
+
+```text
+scp flash_pcan_mac.sh pcan_canable_hw.bin seeed@your_MAC_IP:~/Downloads/
+```
+
+Or simply copy it onto a USB flash drive and plug it into the MAC — as long as the files end up in ~/Downloads, the current directory, or /tmp, the script will find them automatically.
+
+4.Execute:
+
+```text
+bash /Users/"your_username"/Downloads/flash_pcan_mac.sh "/Users/"your_username"/Downloads/pcan_canable_hw.bin"
+```
+
+The above command assumes the files are placed in the Mac Downloads path; adjust according to your actual path
+
+Enter your password; wait for completion
+
+After completion, switch back to "120R"
+
+Re-plug the USB.
+
+</details>
+
 <!-- ### 3. Write Motor IDs
 
 :::tip Pre-assembled kit users, please skip this step

--- a/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_Getting_Started.md
@@ -303,6 +303,77 @@ Desconecta el módulo USB2CAN, ajusta el interruptor DIP a **120R** y vuelve a c
 
 </details>
 
+<details>
+<summary>PCAN Pasos de descarga de firmware y reparación de controladores - Ubuntu</summary>
+
+Los usuarios de Ubuntu consulten esta guía
+
+1.> 📦 [Haga clic para descargar USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.Cambie USB2CAN a BOOT
+
+3.Por favor extraiga el USB2CAN.zip del paso 1, y coloque flash_pcan_ubuntu.sh y pcan_canable_hw.bin (de dentro de USB2CAN.zip) en el mismo directorio
+
+[Haga clic para descargar flash_pcan_ubuntu.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_ubuntu.sh)
+
+Si transfiere desde otra computadora (por ejemplo scp):
+
+```text
+scp flash_pcan_ubuntu.sh pcan_canable_hw.bin seeed@su_IP_de_Ubuntu:~/Downloads/
+```
+O simplemente cópielo en una memoria USB y conéctela a la máquina Ubuntu — siempre que los archivos terminen en ~/Downloads, el directorio actual, o /tmp, el script los encontrará automáticamente.
+
+4.Ejecute:
+
+```text
+bash flash_pcan_ubuntu.sh
+```
+
+Ingrese su contraseña; espere a que termine
+
+Al terminar, cambie de vuelta a "120R"
+
+Vuelva a conectar el USB.
+
+</details>
+
+<details>
+<summary>PCAN Pasos de descarga de firmware y reparación de controladores - MAC</summary>
+
+Los usuarios de MAC consulten esta guía
+
+1.> 📦 [Haga clic para descargar USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.Cambie USB2CAN a BOOT
+
+3.Por favor extraiga el USB2CAN.zip del paso 1, y coloque flash_pcan_mac.sh y pcan_canable_hw.bin (de dentro de USB2CAN.zip) en el mismo directorio
+
+[Haga clic para descargar flash_pcan_mac.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_mac.sh)
+
+Si transfiere desde otra computadora (por ejemplo scp):
+
+```text
+scp flash_pcan_mac.sh pcan_canable_hw.bin seeed@su_IP_de_MAC:~/Downloads/
+```
+
+O simplemente cópielo en una memoria USB y conéctela a la MAC — siempre que los archivos terminen en ~/Downloads, el directorio actual, o /tmp, el script los encontrará automáticamente.
+
+4.Ejecute:
+
+```text
+bash /Users/"su_nombre_de_usuario"/Downloads/flash_pcan_mac.sh "/Users/"su_nombre_de_usuario"/Downloads/pcan_canable_hw.bin"
+```
+
+El comando anterior asume que los archivos están en la ruta de descargas de Mac; ajuste según su ruta real
+
+Ingrese su contraseña; espere a que termine
+
+Al terminar, cambie de vuelta a "120R"
+
+Vuelva a conectar el USB.
+
+</details>
+
 <!-- ### 3. Write Motor IDs
 
 :::tip Pre-assembled kit users, please skip this step

--- a/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_Getting_Started.md
@@ -303,6 +303,77 @@ USB2CAN モジュールを取り外し、DIP スイッチを **120R** に設定�
 
 </details>
 
+<details>
+<summary>PCAN ファームウェアダウンロードとドライバ修復手順 - Ubuntu</summary>
+
+Ubuntu ユーザーはこちらのガイドを参照してください
+
+1.> 📦 [クリックして USB2CAN.zip をダウンロード](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.USB2CAN を BOOT に切り替えてください
+
+3.手順1の USB2CAN.zip を解凍し、flash_pcan_ubuntu.sh と USB2CAN.zip 内の pcan_canable_hw.bin を同じディレクトリに配置してください
+
+[クリックして flash_pcan_ubuntu.sh をダウンロード](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_ubuntu.sh)
+
+別のパソコンから転送する場合（例：scp）：
+
+```text
+scp flash_pcan_ubuntu.sh pcan_canable_hw.bin seeed@あなたのUbuntuのIP:~/Downloads/
+```
+または USB メモリにコピーして Ubuntu マシンに挿してコピーしても構いません — ファイルが ~/Downloads、カレントディレクトリ、または /tmp のいずれかにあれば、スクリプトが自動的に見つけます。
+
+4.実行：
+
+```text
+bash flash_pcan_ubuntu.sh
+```
+
+パスワードを入力してください；完了までお待ちください
+
+完了後、「120R」に戻してください
+
+USB を挿し直してください。
+
+</details>
+
+<details>
+<summary>PCAN ファームウェアダウンロードとドライバ修復手順 - MAC</summary>
+
+MAC ユーザーはこちらのガイドを参照してください
+
+1.> 📦 [クリックして USB2CAN.zip をダウンロード](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.USB2CAN を BOOT に切り替えてください
+
+3.手順1の USB2CAN.zip を解凍し、flash_pcan_mac.sh と USB2CAN.zip 内の pcan_canable_hw.bin を同じディレクトリに配置してください
+
+[クリックして flash_pcan_mac.sh をダウンロード](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_mac.sh)
+
+別のパソコンから転送する場合（例：scp）：
+
+```text
+scp flash_pcan_mac.sh pcan_canable_hw.bin seeed@あなたのMACのIP:~/Downloads/
+```
+
+または USB メモリにコピーして MAC に挿してコピーしても構いません — ファイルが ~/Downloads、カレントディレクトリ、または /tmp のいずれかにあれば、スクリプトが自動的に見つけます。
+
+4.実行：
+
+```text
+bash /Users/"あなたのユーザー名"/Downloads/flash_pcan_mac.sh "/Users/"あなたのユーザー名"/Downloads/pcan_canable_hw.bin"
+```
+
+上記のコマンドはファイルが Mac のダウンロードパスに配置されていることを前提としています。実際のパスに合わせて変更してください
+
+パスワードを入力してください；完了までお待ちください
+
+完了後、「120R」に戻してください
+
+USB を挿し直してください。
+
+</details>
+
 <!-- ### 3. モーター ID の書き込み
 
 :::tip 組立済みキットのユーザーは、この手順をスキップしてください

--- a/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_Getting_Started.md
@@ -303,6 +303,77 @@ Desconecte o módulo USB2CAN, ajuste o DIP switch para **120R** e reconecte-o ao
 
 </details>
 
+<details>
+<summary>PCAN Passos de download de firmware e reparo de driver - Ubuntu</summary>
+
+Usuários de Ubuntu consultem este guia
+
+1.> 📦 [Clique para baixar USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.Altere USB2CAN para BOOT
+
+3.Por favor extraia o USB2CAN.zip do passo 1, e coloque flash_pcan_ubuntu.sh e pcan_canable_hw.bin (de dentro do USB2CAN.zip) no mesmo diretório
+
+[Clique para baixar flash_pcan_ubuntu.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_ubuntu.sh)
+
+Se transferir de outro computador (por exemplo scp):
+
+```text
+scp flash_pcan_ubuntu.sh pcan_canable_hw.bin seeed@seu_IP_do_Ubuntu:~/Downloads/
+```
+Ou simplesmente copie para um pendrive e conecte na máquina Ubuntu — contanto que os arquivos terminem em ~/Downloads, no diretório atual, ou /tmp, o script os encontrará automaticamente.
+
+4.Execute:
+
+```text
+bash flash_pcan_ubuntu.sh
+```
+
+Digite sua senha; aguarde a conclusão
+
+Após concluir, altere de volta para "120R"
+
+Reconecte o USB.
+
+</details>
+
+<details>
+<summary>PCAN Passos de download de firmware e reparo de driver - MAC</summary>
+
+Usuários de MAC consultem este guia
+
+1.> 📦 [Clique para baixar USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.Altere USB2CAN para BOOT
+
+3.Por favor extraia o USB2CAN.zip do passo 1, e coloque flash_pcan_mac.sh e pcan_canable_hw.bin (de dentro do USB2CAN.zip) no mesmo diretório
+
+[Clique para baixar flash_pcan_mac.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_mac.sh)
+
+Se transferir de outro computador (por exemplo scp):
+
+```text
+scp flash_pcan_mac.sh pcan_canable_hw.bin seeed@seu_IP_do_MAC:~/Downloads/
+```
+
+Ou simplesmente copie para um pendrive e conecte na MAC — contanto que os arquivos terminem em ~/Downloads, no diretório atual, ou /tmp, o script os encontrará automaticamente.
+
+4.Execute:
+
+```text
+bash /Users/"seu_nome_de_usuário"/Downloads/flash_pcan_mac.sh "/Users/"seu_nome_de_usuário"/Downloads/pcan_canable_hw.bin"
+```
+
+O comando acima assume que os arquivos estão no caminho de downloads do Mac; ajuste conforme o seu caminho real
+
+Digite sua senha; aguarde a conclusão
+
+Após concluir, altere de volta para "120R"
+
+Reconecte o USB.
+
+</details>
+
 <!-- ### 3. Write Motor IDs
 
 :::tip Pre-assembled kit users, please skip this step

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
@@ -305,6 +305,72 @@ C:\Program Files (x86)\STMicroelectronics\Software\DfuSe v3.0.6\Bin\Driver
 
 </details>
 
+<details>
+
+<summary>PCAN 固件下载与驱动修复步骤-Ubuntu</summary>
+Ubuntu 用户请参考本指南
+
+1.> 📦 [点击下载 USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.USB2CAN 拨到 BOOT
+
+3.请将第一步的USB2CAN.zip压缩包解压，将flash_pcan_ubuntu.sh 和 USB2CAN.zip里面的pcan_canable_hw.bin 放同一目录
+
+[点击下载 flash_pcan_ubuntu.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_ubuntu.sh)
+
+如果是从别的电脑传过去的（比如 scp）：
+
+```text
+scp flash_pcan.sh pcan_canable_hw.bin seeed@你的Ubuntu的IP:~/Downloads/
+```
+或者直接拖进优盘再插到 Ubuntu 上复制过去，都行——只要最后落在 、当前目录，或者 里任意一个，脚本都能自动找到。~/Downloads~/下载/tmp
+
+4.执行：
+
+```text
+bash flash_pcan_ubuntu.sh
+```
+ 输入密码；等待完成
+
+完成后重新拨回"120R"
+
+重新插 USB。
+</details>
+
+<details>
+
+<summary>PCAN 固件下载与驱动修复步骤-MAC</summary>
+MAC 用户请参考本指南
+
+1.> 📦 [点击下载 USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.USB2CAN 拨到 BOOT
+
+3.请将第一步的USB2CAN.zip压缩包解压，将flash_pcan_mac.sh 和 USB2CAN.zip里面的pcan_canable_hw.bin 放同一目录
+
+[点击下载 flash_pcan_mac.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_mac.sh)
+
+如果是从别的电脑传过去的（比如 scp）：
+
+```text
+scp flash_pcan.sh pcan_canable_hw.bin seeed@你的MAC的IP:~/Downloads/
+```
+
+或者直接拖进优盘再插到 MAC 上复制过去，都行——只要最后落在 、当前目录，或者 里任意一个，脚本都能自动找到。~/Downloads~/下载/tmp
+
+4.执行：
+
+```text
+ bash /Users/"你的用户名"/Downloads/pcan_flash_mac.sh "/Users/"你的用户名"/Downloads/pcan_canable_hw.bin"
+```
+以上命令为文件放置在mac下载路径，按实际路径更改
+
+输入密码；等待完成
+
+完成后重新拨回"120R"
+
+重新插 USB。
+</details>
 
 <!-- ### 3.写入电机id
 


### PR DESCRIPTION
本次更新补充 USB2CAN (PCAN) 固件烧录与驱动修复文档：
1. 新增 Ubuntu 系统操作步骤
2. 新增 macOS 系统操作步骤
3. 同步提供英文、西班牙语、日语、巴西葡萄牙语多语言版本