### PR TITLE
docs(rebot-arm): improve B601 setup and control guidance

### DIFF
--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_Getting_Started.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_Getting_Started.md
@@ -9,20 +9,24 @@ keywords:
   - Lerobot
   - Pinocchio
   - 6 DOF
+image: https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/RS5_56.png
 slug: /rebot_b601_dm_getting_started
 translation:
   skip: [zh-CN]
 last_update:
-  date: 2026-04-13
+  date: 2026-07-28
   author: LiuJunjie
 createdAt: '2026-04-13'
-updatedAt: '2026-07-13'
+updatedAt: '2026-07-28'
 url: https://wiki.seeedstudio.com/rebot_b601_dm_getting_started/
 ---
 
 # Getting Started with reBot Arm B601-DM
 
-![traj_sim_geodesic](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/dm_pinocchio_mashcat/v2.0.png)
+<div align="center">
+    <img width={800}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/RS5_56.png" />
+</div>
 
 <p align="center">
     <a href="./LICENSE">
@@ -65,6 +69,15 @@ The reBot Arm B601-DM is available in multiple configurations to meet different 
 | **Body Only (Structure)** | ✅ | ❌ | ❌ | ✅ | [Coming Soon](https://www.seeedstudio.com/) |
 | **Body Only (Motors)** | ✅ | ❌ | ✅ | ❌ | [Coming Soon](https://www.seeedstudio.com/) |
 
+
+## Safety Disclaimer and Risk Notice
+
+<div style={{ display: "flex", justifyContent: "center", alignItems: "flex-start", gap: "16px" }}>
+    <img style={{ width: "calc(50% - 8px)", maxWidth: "420px", height: "auto" }}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/Chinese%20version%20statement.png" />
+    <img style={{ width: "calc(50% - 8px)", maxWidth: "420px", height: "auto" }}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/English%20Version%20Statement.png" />
+</div>
 
 ## About Power Supply
 
@@ -110,6 +123,15 @@ Before Assembly:
 </div>
 
 ## Step 2: Reset Motors ID
+
+:::tip
+When assembling the robotic arm, do not forget to connect the cable harness between Motor 1 and Motor 2. The exact position is highlighted in the image below. Before switching the 3-pin cable connection, make sure the current motor is disabled and the power is disconnected to avoid hot-plugging or incorrect operation that may cause abnormal motor parameters.
+
+<div align="center">
+    <img width={200}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/1to2_ID_set.jpg" />
+</div>
+:::
 
 ### AI AGENT
 

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_pinocchio.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_pinocchio.md
@@ -142,7 +142,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ### Step 2. Sync Environment (Install All Dependencies)
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git
 cd reBotArm_control_py
 uv sync
 ```
@@ -211,7 +211,7 @@ Input target angles for all joints to complete motor control in MIT control mode
 **How to Run**:
 ```bash
 uv run python example/3_mit_control.py
-> 30 0 0 0 0 0 # Control motor 1 to rotate 30 degrees
+> 30 0 0 0 0 0 0 # Control motor 1 to rotate 30 degrees
 > state
   pos (deg): ['+29.99', '+0.00', '-45.00', '+0.00', '+0.00', '+0.00']
 > q # Exit system
@@ -227,7 +227,7 @@ Input target angles for all joints to complete motor control in POS_VEL (Positio
 **How to Run**:
 ```bash
 uv run python example/4_pos_vel_control.py
-> 30 0 0 0 0 0 # Control motor 1 to rotate 30 degrees
+> 30 0 0 0 0 0 0 # Control motor 1 to rotate 30 degrees
 > state
   pos (deg): ['+29.99', '+0.00', '-45.00', '+0.00', '+0.00', '+0.00']
 > q # Exit system
@@ -339,7 +339,7 @@ uv run python example/7_arm_ik_control.py
 #Usage B
 > 0.3 0.0 0.4 0.0 0.0 0.5 # Control both position and orientation: move to the specified position while rotating the wrist yaw angle by 0.5 radians.
 
-> ctrl + c # Exit system
+> ctrl + c # Return to zero position and exit system
 ```
 :::danger
 Note that in this example code, the robotic arm moves very fast. Ensure that people and other devices are away from the arm's working radius.
@@ -369,7 +369,7 @@ uv run python example/8_arm_traj_control.py
 #Usage C
 > 0.3 0.0 0.4 0.0 0.0 0.0 5.0 # Move the arm to the specific position and specify 5.0 seconds to slowly move there. (Note: If entering time, the preceding orientation parameters 0 0 0 cannot be omitted)
 
-> ctrl + c # Exit system
+> ctrl + c # Return to zero position and exit system
 ```
 ---
 

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
@@ -15,10 +15,10 @@ slug: /rebot_b601_rs_getting_started
 translation:
   skip: [zh-CN]
 last_update:
-  date: 2026-05-26
+  date: 2026-07-28
   author: LiuJunjie
 createdAt: '2026-05-26'
-updatedAt: '2026-07-20'
+updatedAt: '2026-07-28'
 url: https://wiki.seeedstudio.com/rebot_b601_rs_getting_started/
 ---
 
@@ -45,6 +45,14 @@ url: https://wiki.seeedstudio.com/rebot_b601_rs_getting_started/
 The reBot Arm project has been open-sourced on [GitHub](https://github.com/Seeed-Projects/reBot-DevArm). This guide will take you through the quick start of B601-RS, from assembly to operation.
 The content of this guide is racing towards you at the speed of light — stay tuned.
 
+## Safety Disclaimer and Risk Notice
+
+<div style={{ display: "flex", justifyContent: "center", alignItems: "flex-start", gap: "16px" }}>
+    <img style={{ width: "calc(50% - 8px)", maxWidth: "420px", height: "auto" }}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/Chinese%20version%20statement.png" />
+    <img style={{ width: "calc(50% - 8px)", maxWidth: "420px", height: "auto" }}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/English%20Version%20Statement.png" />
+</div>
 
 ## About Power Supply
 
@@ -436,4 +444,27 @@ or
 DYLD_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
 ```
 
+#### Initialize RS Motor Control Parameters
 
+:::warning Complete parameter initialization before first use
+
+Most reBot Arm B601-RS examples run in MIT mode. Native Position (`pos_vel`) mode directly uses the position-loop gain `loc_kp` and maximum velocity `vel_max`. Its motion behavior is also affected by the speed-loop gain `spd_kp` and acceleration parameter `acc_rad`. If the recommended B601-RS parameters have not been initialized, or if the parameters saved on each joint are inconsistent, Position mode may show abnormal response, speed, or acceleration and deceleration behavior.
+
+First select `rebot-arm-robstride` under **Robot Model** in [MotorBridge Studio](https://motorbridge.github.io/motorbridge-studio/), scan and confirm that Joints 1-7 are all online, and complete the robotic arm zero calibration described above. Then perform the following steps:
+
+1. Click **Read Parameters** to read the parameters currently saved on all online joints. This operation only reads data and does not modify the motors. Wait until the page reports that the control parameters have been read successfully, and retain the current values as a record.
+2. Click **Apply Default Template** and confirm that the page reports the reBot Arm RobStride default parameter template has been applied to Joints 1-7. This operation only loads the recommended values into the page; it does not write them to the motors yet.
+
+<div align="center">
+  <img width={800} src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/en_b601_rs_motorbridge_read_params.png" alt="Read the B601-RS motor parameters and apply the default template" />
+</div>
+
+3. Click **Write Parameters**. Confirm that the robotic arm is safely supported and that no people or obstacles are nearby, then confirm the write operation in the dialog. Do not disconnect the power or plug or unplug motor cables while parameters are being written.
+
+<div align="center">
+  <img width={800} src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/en_b601_rs_motorbridge_write_params.png" alt="Confirm writing the B601-RS motor parameters" />
+</div>
+
+4. After writing is complete, MotorBridge Studio automatically reads the parameters back. Initialization is successful when the page reports that the post-write readback verification matches.
+
+:::

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_Getting_Started.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_Getting_Started.md
@@ -9,18 +9,24 @@ keywords:
   - Lerobot
   - Pinocchio
   - 6 自由度
+image: https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/RS5_56.png
 slug: /rebot_b601_dm_getting_started
 translation:
   skip: [zh-CN]
 last_update:
-  date: 2026-04-13
+  date: 2026-07-28
   author: LiuJunjie
 createdAt: '2026-04-13'
-updatedAt: '2026-07-20'
+updatedAt: '2026-07-28'
 url: https://wiki.seeedstudio.com/cn/rebot_b601_dm_getting_started/
 ---
 
 # reBot Arm B601-DM 快速入门
+
+<div align="center">
+    <img width={800}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/RS5_56.png" />
+</div>
 
 <p align="center">
     <a href="./LICENSE">
@@ -57,6 +63,15 @@ reBot Arm B601-DM 提供多种配置选项，以满足不同用户的需求。
 | **仅本体 (结构)** | ✅ | ❌ | ❌ | ✅ |  |
 | **仅本体 (电机)** | ✅ | ❌ | ✅ | ❌ |  |
 
+
+## 风险告知及免责声明
+
+<div style={{ display: "flex", justifyContent: "center", alignItems: "flex-start", gap: "16px" }}>
+    <img style={{ width: "calc(50% - 8px)", maxWidth: "420px", height: "auto" }}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/Chinese%20version%20statement.png" />
+    <img style={{ width: "calc(50% - 8px)", maxWidth: "420px", height: "auto" }}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/English%20Version%20Statement.png" />
+</div>
 
 ## 关于电源
 
@@ -97,6 +112,15 @@ reBot Arm B601-DM 提供多种配置选项，以满足不同用户的需求。
 </div>
 
 ## 第二步：写入电机ID及零点
+
+:::tip
+组装机械臂时，请不要忘记连接电机1到2之间的这根线束，具体位置如下图高亮处所示。接线时，请务必先让当前电机失能并断开电源，避免热插拔或误操作导致电机参数异常。
+
+<div align="center">
+    <img width={200}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/1to2_ID_set.jpg" />
+</div>
+:::
 
 ### AI AGNET
 
@@ -206,8 +230,6 @@ reBot Arm B601-DM 提供多种配置选项，以满足不同用户的需求。
 | **1号电机使能效果** | **2号电机使能效果** | **3号电机使能效果** | **4号电机使能效果** | **5号电机使能效果** | **6号电机使能效果** | **7号电机使能效果** |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/1_Enable.jpg" width="4000" /> | <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/2_Enable.jpg" width="4000" /> | <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/3_Enable.jpg" width="4000" /> | <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/4_Enable.jpg" width="4000" /> | <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/5_Enable.jpg" width="4000" /> | <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/6_Enable.jpg" width="4000" /> |  <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/7_Enable2.jpg" width="4000" /> |
-
-
 
 <div class="video-container">
 <iframe width="900" height="600" src="//player.bilibili.com/player.html?isOutside=true&aid=116440455775862&bvid=BV1r9d1BuESN&cid=37680973414&p=1&autoplay=0&muted=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
@@ -326,4 +348,3 @@ motorbridge-gateway -- --bind 127.0.0.1:9002 --vendor damiao --transport dm-seri
 
   2. 电机所有CANID变成了一样？
     - 在用[DM_Tools_v.1.8.0.1.exe（仅支持 Windows 系统）](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/DM_Tools_v1.8.0.1.exe)校准零点的时候千完别点CANID旁边的读取和设置两个按钮，调试的页面是通过CAN通讯链路完成的，如果点了设置，会把CANBUS上所有的电机设置成同一个CAN
-

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_pinocchio.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_pinocchio.md
@@ -142,7 +142,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ### 步骤 2. 同步环境（安装所有依赖）
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git
 cd reBotArm_control_py
 uv sync
 ```
@@ -211,7 +211,7 @@ uv run python example/2_zero_and_read.py
 **运行方式**：
 ```bash
 uv run python example/3_mit_control.py
-> 30 0 0 0 0 0 # 控制1号电机正转30度
+> 30 0 0 0 0 0 0 # 控制1号电机正转30度
 > state
   pos (deg): ['+29.99', '+0.00', '-45.00', '+0.00', '+0.00', '+0.00']
 > q # 退出系统
@@ -227,7 +227,7 @@ uv run python example/3_mit_control.py
 **运行方式**：
 ```bash
 uv run python example/4_pos_vel_control.py
-> 30 0 0 0 0 0 # 控制1号电机正转30度
+> 30 0 0 0 0 0 0 # 控制1号电机正转30度
 > state
   pos (deg): ['+29.99', '+0.00', '-45.00', '+0.00', '+0.00', '+0.00']
 > q # 退出系统
@@ -339,7 +339,7 @@ uv run python example/7_arm_ik_control.py
 #用法B
 > 0.3 0.0 0.4 0.0 0.0 0.5 #同时控制位置和姿态：走到指定位置，同时手腕偏航角旋转 0.5 弧度。
 
-> ctrl + c # 退出系统
+> ctrl + c # 回到零点并退出系统
 ```
 :::danger
 注意，在该实例代码下机械臂的速度会很快，需要保证人或其他设备远离机械臂的工作半径。
@@ -369,7 +369,7 @@ uv run python example/8_arm_traj_control.py
 #用法C
 > 0.3 0.0 0.4 0.0 0.0 0.0 5.0 #让机械臂走到特定位置，并指定用 5.0 秒 的时间慢慢挪过去。(注意：如果要输时间，前方的姿态参数 0 0 0 不能省略)
 
-> ctrl + c # 退出系统
+> ctrl + c # 回到零点并退出系统
 ```
 ---
 

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
@@ -15,10 +15,10 @@ slug: /rebot_b601_rs_getting_started
 translation:
   skip: [zh-CN]
 last_update:
-  date: 2026-05-26
+  date: 2026-07-28
   author: LiuJunjie
 createdAt: '2026-05-26'
-updatedAt: '2026-07-20'
+updatedAt: '2026-07-28'
 url: https://wiki.seeedstudio.com/cn/rebot_b601_rs_getting_started/
 ---
 
@@ -45,6 +45,14 @@ url: https://wiki.seeedstudio.com/cn/rebot_b601_rs_getting_started/
 reBot Arm项目已经在[github](https://github.com/Seeed-Projects/reBot-DevArm)上开源了，本文将带领你快速入门B601-RS，从组装到使用。
 本文的内容正在光速赶来，各位敬请期待。
 
+## 风险告知及免责声明
+
+<div style={{ display: "flex", justifyContent: "center", alignItems: "flex-start", gap: "16px" }}>
+    <img style={{ width: "calc(50% - 8px)", maxWidth: "420px", height: "auto" }}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/Chinese%20version%20statement.png" />
+    <img style={{ width: "calc(50% - 8px)", maxWidth: "420px", height: "auto" }}
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/English%20Version%20Statement.png" />
+</div>
 
 ## 关于电源
 
@@ -434,3 +442,28 @@ or
 ```bash
 DYLD_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
 ```
+
+#### 初始化 RS 电机控制参数
+
+:::warning 首次使用时请完成参数初始化
+
+reBot Arm B601-RS 的大多数示例使用 MIT 模式运行。原生 Position（`pos_vel`）模式会直接使用位置环增益 `loc_kp` 和最大速度 `vel_max`，其运动效果也与速度环增益 `spd_kp`、加速度参数 `acc_rad` 有关。如果未初始化 reBot Arm B601-RS 的推荐参数，或各关节保存的参数不一致，使用位置模式时可能出现响应、速度或加减速效果异常。
+
+请先在 [motorbridge-studio](https://motorbridge.github.io/motorbridge-studio/) 的“机械臂型号”中选择 `rebot-arm-robstride`，扫描并确认 1～7 号关节全部在线，并按照前文完成机械臂校零，然后再执行以下操作：
+
+1. 点击 **读取参数**，读取所有在线关节当前保存的参数。该操作只读取参数，不会修改电机中的数据。请等待页面提示“控制参数读取完成”，并保留当前参数作为记录。
+2. 点击 **套用默认模板**，确认页面提示“已套用 reBot Arm RobStride 默认参数模板（1～7 关节）”。此操作只将推荐值加载到页面中，尚未写入电机。
+
+<div align="center">
+  <img width={800} src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/b601_rs_motorbridge_read_params.png" alt="读取 B601-RS 电机参数并套用默认模板" />
+</div>
+
+3. 点击 **写入参数**，确认机械臂已安全支撑、周围无人员或障碍物，并在弹窗中确认写入。请勿在写入过程中断电或插拔电机线。
+
+<div align="center">
+  <img width={800} src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/b601_rs_motorbridge_write_params.png" alt="确认写入 B601-RS 电机参数" />
+</div>
+
+4. 写入完成后，MotorBridge Studio 会自动回读参数。页面显示“写入后回读校验一致”即表示初始化成功。
+
+:::


### PR DESCRIPTION
- Add Motor 1 to Motor 2 cable harness reminder in CN and EN getting started docs
- Include highlighted wiring image and hot-plugging safety note
- Update Pinocchio examples to use 7 motor inputs
- Clarify Ctrl+C returns the arm to zero position before exiting
- Add the B601 overview image to the top of the DM getting started docs
- Document B601-RS MotorBridge parameter initialization, template application, writing, and readback verification in CN and EN