### PR TITLE
docs: correct MeshTracker X1 battery type

### DIFF
--- a/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X1/x1_intro.md
+++ b/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X1/x1_intro.md
@@ -107,7 +107,7 @@ A highly integrated, card-sized form factor optimized around a high-capacity 110
 
 |Item|Parameter|s
 | :- | :- |
-|**Battery Capacity**|Rechargeable LCD battery, 1100mAh|
+|**Battery Capacity**|Rechargeable LCO,battery, 1100mAh|
 |**Battery Life Monitoring**|Periodic uplink battery level|
 |**Charging Protocol**|USB Type-C|
 |**Device Power Input**|5V, 0.55A|


### PR DESCRIPTION
## Summary

- correct the MeshTracker X1 battery chemistry label from LCD to LCO

## Verification

- confirmed the final diff contains only the requested one-line documentation change
- ran `git diff --check`