### PR TITLE
docs: improve SenseCraft entry pages

### DIFF
--- a/sites/en/docs/Cloud.md
+++ b/sites/en/docs/Cloud.md
@@ -99,29 +99,31 @@ Cloud services are a vital component that enable processed data management from 
 <br />
 <br />
 
-### SenseCraft APP
+### SenseCraft App
 
 <div class="title_container">
     <div class="title_item" style={{textAlign: 'center'}}>
             <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>SenseCraft App</font></div>
-            <p>SenseCraft App is used on mobile phones to config, build, and manage sensors, and display data from SenseCraft Data Platform.</p>
+            <p>SenseCraft App is used on mobile phones to configure and manage sensors and display data from SenseCraft Data Platform.</p>
             <br/>
-            > <a href="/sensecraft-app/overview#download" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Download</font></span></a> / <a href="/sensecraft-app/overview#config" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Bind Devices</font></span></a> / <a href="/sensecraft-app/overview#account" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Account</font></span></a> / <a href="/sensecraft-app/overview#user" target="_blank"><span><font color={'FFFFFF'} size={"3"}>User</font></span></a>
+            > <a href="/sensecraft-app/overview#download" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Download</font></span></a> / <a href="/sensecraft-app/overview#device" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Bind Devices</font></span></a> / <a href="/sensecraft-app/overview#account" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Account</font></span></a> / <a href="/sensecraft-app/overview#user" target="_blank"><span><font color={'FFFFFF'} size={"3"}>User</font></span></a>
     </div>
 </div>
 
 <br />
 <br />
 
-### SenseCraft AI
+<a id="sensecraft-ai"></a>
+
+### AI Advisor
 
 <div class="title_container">
     <div class="title_item" style={{textAlign: 'center'}}>
-            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>SenseCraft AI</font></div>
-            <p>SenseCraft AI can be accessed on the SenseCraft Data Platform and SenseCraft App.</p>
+            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>AI Advisor</font></div>
+            <p>AI Advisor uses sensor data from SenseCraft Data Platform to provide recommendations for supported scenarios.</p>
             <br/>
-            > <a href="/sensecraft-data-platform/applications/ai-advisor" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Getting Started</font></span></a>
-            > <a href="/sensecraft-data-platform/applications/planting-advice" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Connecting XIAO ESP32-C3</font></span></a>
+            > <a href="/sensecraft-data-platform/applications/ai-advisor" target="_blank"><span><font color={'FFFFFF'} size={"3"}>AI Advisor</font></span></a>
+            > <a href="/sensecraft-data-platform/applications/planting-advice" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Planting Advice Example</font></span></a>
     </div>
 </div>
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_APP/overview.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_APP/overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
-description: SenseCraft App
-title: Overview
+description: Download SenseCraft App, connect supported devices, manage sensor data, configure device settings, and review events.
+title: SenseCraft App Overview
 keywords:
   - App
 image: https://files.seeedstudio.com/wiki/wiki-platform/S-tempor.png
@@ -17,12 +17,14 @@ url: https://wiki.seeedstudio.com/sensecraft-app/overview/
 ---
 
 :::tip note
-SenseCAP Mate App is officially renamed as `SenseCraft` App!
+SenseCAP Mate App was officially renamed to SenseCraft App.
 :::
 
-# Introduction and Usage
+<a id="introduction-and-usage"></a>
 
-SenseCraft APP is a powerful APP for data visualization and device management.
+# SenseCraft App Overview
+
+SenseCraft App is a mobile application for data visualization and device management.
 
 ## App Highlights
 
@@ -37,80 +39,80 @@ SenseCraft APP is a powerful APP for data visualization and device management.
 
 SenseCraft App is available in both iOS and Android versions.
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_1.png" alt="pir" width={600} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_1.png" alt="SenseCraft App download options" width={600} height="auto" /></p>
 
 ## Account
 
-SenseCraft supports device configuration and remote management. To use the SenseCAP Portal platform and other functions, please register an account.
+SenseCraft supports device configuration and remote management. To use SenseCraft Data Platform (formerly SenseCAP Portal) and other functions, register an account.
 
 :::tip Note
-Please select `Global` of Server Location. You can also create an account via the <a href="http://sensecap.seeed.cc">SenseCAP Portal</a>
+Select `Global` as the Server Location. You can also create an account through <a href="https://sensecap.seeed.cc">SenseCraft Data Platform</a>.
 :::
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/login-page.PNG" alt="pir" width={300} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/login-page.PNG" alt="SenseCraft App account login screen" width={300} height="auto" /></p>
 
 ## Device
 
 - On the device page, you can add new devices by clicking the `+` in the upper right corner.
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/add-new.png" alt="pir" width={500} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/add-new.png" alt="Add a new device in SenseCraft App" width={500} height="auto" /></p>
 
 - Click the target device to view the data.
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/data.png" alt="pir" width={500} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/data.png" alt="View device measurements in SenseCraft App" width={500} height="auto" /></p>
 
 - Click the bell icon in the upper right corner to enter the message center.
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/message-center.png" alt="pir" width={500} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/message-center.png" alt="Open the SenseCraft App message center" width={500} height="auto" /></p>
 
 ## MALL
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/MAll.PNG" alt="pir" width={300} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/MAll.PNG" alt="SenseCraft App mall page" width={300} height="auto" /></p>
 
 ## Event
 
 Add Events to get notification.
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/add-event.PNG" alt="pir" width={300} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/add-event.PNG" alt="Create an event alert in SenseCraft App" width={300} height="auto" /></p>
 
 1. Click the Add icon or Add Event button to create an Event alert, Add Event page Conditions to add condition options, and click the Add button to select a device.
 
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_2.png" style={{width:1000, height:'auto'}}/></div>
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_2.png" alt="Select a device when creating an event" style={{width:1000, height:'auto'}}/></div>
 
 2. Select the device, select the type of measurement, set the alarm conditions, select the conditions such as greater than or less than drag the progress bar to set the value, click on the next step.
 
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_3.png" style={{width:1000, height:'auto'}}/></div>
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_3.png" alt="Configure an event measurement and threshold" style={{width:1000, height:'auto'}}/></div>
 
 3. Add Event page Back to normal actions device back to normal, select whether to send a notification, click Save, enter Event name, click Submit to add an Event alarm successfully return to Event list.
 
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_4.png" style={{width:1000, height:'auto'}}/></div>
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_4.png" alt="Configure event recovery actions and notifications" style={{width:1000, height:'auto'}}/></div>
 
 4. Device page, click Message Center to view alarm messages, showing Device warning device triggered alarm push messages, System notification system messages.
 
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_5.png" style={{width:1000, height:'auto'}}/></div>
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_5.png" alt="View event notifications in the message center" style={{width:1000, height:'auto'}}/></div>
 
 5. Click the alarm message, the device triggers the condition item, push the alarm message, click to view the alarm details. Return to the alarm list status changes to read, click the edit button to select the message, you can read, delete and other operations.
 
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_6.png" style={{width:1000, height:'auto'}}/></div>
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_6.png" alt="View and manage an event alarm message" style={{width:1000, height:'auto'}}/></div>
 
 6. Toggle system messages, click to view system push message details.
 
-<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_7.png" style={{width:1000, height:'auto'}}/></div>
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/sensecap_mate_app/mate_app_7.png" alt="View a system notification in SenseCraft App" style={{width:1000, height:'auto'}}/></div>
 
 ## User
 
 Account details and settings, app version, etc.
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/user-page.PNG" alt="pir" width={300} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/user-page.PNG" alt="SenseCraft App user settings page" width={300} height="auto" /></p>
 
 **Delete Account**
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/delete.png" alt="pir" width={600} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/delete.png" alt="Delete a SenseCraft account" width={600} height="auto" /></p>
 
 ## Bluetooth Configuration
 
 Select the corresponding product for quick binding.
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/configuration.png" alt="pir" width={500} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/configuration.png" alt="Select a device for Bluetooth configuration" width={500} height="auto" /></p>
 
 ## Template
 
@@ -130,11 +132,11 @@ There are two ways to add a new template.
 6. Tap `Confirm` to save the template. <br />
 7. Return to the Template page, you can see `Save successful`. <br />
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/add_new_template1.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/add_new_template1.png" alt="Open the template page from Bluetooth configuration" width={800} height="auto" /></p>
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/add_new_template2.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/add_new_template2.png" alt="Add a new device configuration template" width={800} height="auto" /></p>
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/add_new_template3.png" alt="pir" width={300} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/add_new_template3.png" alt="Confirm a new device configuration template" width={300} height="auto" /></p>
 
 **Method 2** <br />
 
@@ -146,7 +148,7 @@ There are two ways to add a new template.
 6. Enter a Template Name. <br />
 7. Tap `Confirm` to save. <br />
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/add_new_template4.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/add_new_template4.png" alt="Save Bluetooth configuration settings as a template" width={800} height="auto" /></p>
 
 ### Download Template
 
@@ -155,7 +157,7 @@ There are two ways to add a new template.
 3. Select `Download Template`. <br />
 4. Save the file to your mobile device storage. <br />
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/downlaod_template.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/downlaod_template.png" alt="Download a device configuration template" width={800} height="auto" /></p>
 
 ### Import Template
 
@@ -166,7 +168,7 @@ There are two ways to add a new template.
 5. Tap the `file` icon. <br />
 6. In the system file manager, select the configuration file with the `“.seeed”` extension. <br />
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/import_template.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/import_template.png" alt="Import a Seeed device configuration template" width={800} height="auto" /></p>
 
 ### Apply Preset Template
 
@@ -176,6 +178,6 @@ There are two ways to add a new template.
 4. On the Preset Template page, select the desired template. <br />
 5. Return to the Settings page and tap `Send` to apply the configuration. <br />
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/apply_template.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/apply_template.png" alt="Choose a preset device configuration template" width={800} height="auto" /></p>
 
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/apply_template2.png" alt="pir" width={600} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/introduction/App_Template/apply_template2.png" alt="Apply a preset template to a device" width={600} height="auto" /></p>

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/API/HTTP_API/Quick_Start.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/API/HTTP_API/Quick_Start.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-description: HTTP API Quickstart
+description: Get a SenseCraft Data Platform API access key and make your first HTTP API request.
 title: HTTP API Quickstart
 keywords:
   - HTTP API
@@ -17,36 +17,40 @@ url: https://wiki.seeedstudio.com/sensecraft-data-platform/api/http-api/quick-st
 ---
 
 ## Prerequisite
-  if you do not have an account, please register for the SenseCAP Portal.
+
+If you do not have an account, register for SenseCraft Data Platform (formerly SenseCAP Portal) on the service for your region:
+
   - [China Station](https://sensecap.seeed.cn)
-  - [China Station](https://sensecap.seeed.cc)
+  - [Global Station](https://sensecap.seeed.cc)
 
 :::note
-   LoRaWAN devices are used with Global Station
+LoRaWAN devices are used with the Global Station.
 :::
 
 ## Get an Access Key
 
-1. Login the SenseCAP Portal.
-2. Navigate to “Security/Access API keys”
-3. Click “Create Access Key”
-4. Click “API ID”, and get the “API ID” and “Access API keys” after entering the password.
+1. Log in to SenseCraft Data Platform.
+2. Navigate to `Security` → `Access API keys`.
+3. Click `Create Access Key`.
+4. Enter your password, then copy the `API ID` and `Access API Key`.
 
-![](https://files.seeedstudio.com/wiki/SenseCAP/SenseCAP_API/1.png)
+![Access API keys page in SenseCraft Data Platform](https://files.seeedstudio.com/wiki/SenseCAP/SenseCAP_API/1.png)
 
-![](https://files.seeedstudio.com/wiki/SenseCAP/SenseCAP_API/2.png)
+![API ID and Access API Key dialog](https://files.seeedstudio.com/wiki/SenseCAP/SenseCAP_API/2.png)
 
 
 ## Get all the Device Groups
-Use curl to make an HTTP request.The following example calls the API to get all the Device Groups under the account.
+Use curl to make an HTTP request. The following example gets all device groups under the account.
 
 - username = API ID
 - password = Access API keys
 
+```bash
 curl --user "username":"password" \
-     https://sensecap.seeed.cc/openapi/list_groups
+  https://sensecap.seeed.cc/openapi/list_groups
+```
 
-You should replace and with the one you got before. The command will output like the following
+Replace `username` and `password` with the API ID and Access API Key obtained above. The command returns a response similar to the following:
 
 ```cpp
 {

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/API/SenseCraft_Data_Platform_API.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/API/SenseCraft_Data_Platform_API.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-description: SenseCAP API Introduction
+description: Choose the SenseCraft Data Platform API for device management, historical data access, or real-time device message subscriptions.
 title: SenseCraft Data Platform API Introduction
 keywords:
   - Cloud and Chain
@@ -18,13 +18,19 @@ url: https://wiki.seeedstudio.com/sensecraft-data-platform/sensecraft-data-platf
 
 # SenseCraft Data Platform API Introduction
 
+![SenseCraft Data Platform API overview](https://sensecap-docs.seeed.cc/images/open_api/introduction.png)
 
-=============================
+The SenseCraft Data Platform API, formerly documented as the SenseCAP API, enables applications to manage supported IoT devices and access their data.
 
-![](https://sensecap-docs.seeed.cc/images/open_api/introduction.png)
+## Choose an API
 
-SenseCAP API is for users to manage IoT devices and data. It combines three types of API methods: HTTP protocol, MQTT protocol, and Websocket protocol.
+| Goal | API | Start here |
+| --- | --- | --- |
+| Manage devices and groups, or retrieve current and historical data | HTTP API | [HTTP API Quickstart](/sensecraft-data-platform/api/http-api/quick-start/) |
+| Review HTTP request, response, and authentication details | HTTP API | [HTTP API Access Guide](/sensecraft-data-platform/api/http-api/http-api-access-guide/) |
+| Subscribe to real-time device messages | Data OpenStream API | [Data OpenStream API Quickstart](/sensecraft-data-platform/api/data-openstream-api/data_openstream_api_quickstart/) |
+| Review connection details, topics, and the publish-subscribe model | Data OpenStream API | [Data OpenStream API Reference](/sensecraft-data-platform/api/data-openstream-api/data_openstream_api_reference/) |
 
-*   With HTTP API, users can manage LoRa and NB-IoT devices, to get RAW data or historical data.
-*   With MQTT API, users can subscribe to the sensor’s real-time measurement data through the MQTT protocol.
-*   With Websocket API, users can get real-time measurement data of sensors through Websocket protocol.
+The Data OpenStream API supports MQTT and MQTT over WebSocket for real-time message subscriptions. Use the Data OpenStream API Reference for the current host, port, authentication, and topic details.
+
+See [API Pricing for SenseCraft Data Platform](/sensecraft-fee/sensecraft-data-platform-api-pricing/) for billing rules and examples.


### PR DESCRIPTION
## Summary

Fixes #5278.

This PR addresses high-priority SenseCraft documentation issues on four existing English pages without changing any public route:

- Corrects the Global/China station label and improves the HTTP API quickstart.
- Separates Data Platform AI Advisor content from the SenseCraft AI platform on the Cloud entry page.
- Repairs the SenseCraft App device-section anchor.
- Improves SenseCraft App naming, metadata, HTTPS account link, and image alt text.
- Expands the Data Platform API introduction with links to the currently documented HTTP and Data OpenStream paths.

## Exact changes

### Cloud

- Renames the Data Platform application section from `SenseCraft AI` to `AI Advisor`.
- Updates its description and link labels to match the linked pages.
- Changes `Bind Devices` from the nonexistent `#config` fragment to the existing `#device` heading.
- Preserves the former `/Cloud/#sensecraft-ai` deep link with an explicit compatibility anchor after renaming the visible section.
- Normalizes `SenseCraft APP` to `SenseCraft App`.

### SenseCraft App overview

- Uses a descriptive page title and metadata description.
- Preserves the former `#introduction-and-usage` H1 fragment with an explicit compatibility anchor.
- Clarifies the former SenseCAP Mate App name.
- Normalizes product casing and updates the account link to HTTPS.
- Uses the current SenseCraft Data Platform name while retaining the former name for migration context.
- Replaces missing or generic image alt text with task-specific descriptions.
- Leaves all unverified `coming soon` feature claims unchanged for product-owner review.

### HTTP API quickstart

- Corrects `sensecap.seeed.cc` from `China Station` to `Global Station`.
- Updates product naming and account instructions.
- Repairs the incomplete credential-replacement sentence.
- Formats the curl request as a Bash code block.
- Adds descriptive image alt text.

### Data Platform API introduction

- Uses the current product name while retaining the former SenseCAP API name as migration context.
- Adds a concise API selection table.
- Links to the existing HTTP API, Data OpenStream API, and pricing pages.
- Does not declare MQTT, WebSocket, or any legacy interface deprecated.

## URL compatibility

No file was moved or renamed. No frontmatter `slug`, `aliases`, or `url` field was changed.

| Public route | Before | After | Compatibility mechanism |
| --- | --- | --- | --- |
| `https://wiki.seeedstudio.com/Cloud/` | 200 | unchanged route | Existing `/Cloud` slug retained |
| `https://wiki.seeedstudio.com/Cloud/#sensecraft-ai` | existing deep link | retained | Explicit compatibility anchor |
| `https://wiki.seeedstudio.com/sensecraft-app/overview/` | 200 | unchanged route | Existing slug retained |
| `https://wiki.seeedstudio.com/sensecraft-app/overview/#introduction-and-usage` | existing deep link | retained | Explicit compatibility anchor |
| `https://wiki.seeedstudio.com/sensecraft_app/` | 200 | unchanged alias | Existing alias retained |
| `https://wiki.seeedstudio.com/sensecraft-data-platform/api/http-api/quick-start/` | 200 | unchanged route | Existing slug retained |
| `https://wiki.seeedstudio.com/Cloud_Chain/SenseCAP_API/HTTP_API/Quick_Start/` | 200 | unchanged alias | Existing alias retained |
| `https://wiki.seeedstudio.com/sensecraft-data-platform/sensecraft-data-platform-api/sensecraft-data-platform-api/` | 200 | unchanged route | Existing slug retained |
| `https://wiki.seeedstudio.com/Cloud_Chain/SenseCAP_API/SenseCAP_API_Introduction/` | 200 | unchanged alias | Existing alias retained |

All new internal link targets were checked against the currently deployed Wiki and returned HTTP 200 before submission.

## Validation

- `npx --yes @lint-md/cli <four changed files>` — passed
- `node --check sites/en/sidebars.js` — passed
- `git diff --check` — passed
- Frontmatter route-field comparison against `origin/docusaurus-version` — all `slug`, `aliases`, and `url` values unchanged
- Current canonical and legacy alias HTTP checks — all returned 200
- New internal API link target checks — all returned 200
- SenseCraft App image audit — zero images without alt text and zero remaining `alt="pir"`

This is a sparse documentation checkout, so the repository's full multilingual Docusaurus CI builds remain the authoritative build validation.

## Translation

The PR changes user-visible English wording and metadata. A maintainer may trigger `/translate all` after reviewing the source changes. Translation should be handled through the repository's separate translation PR workflow.

## Non-goals

- No URL normalization, route migration, page deletion, or sidebar restructuring.
- No product-pricing changes.
- No removal of unverified `coming soon` claims.
- No declaration that older MQTT or WebSocket interfaces are deprecated.
