### PR TITLE
docs: add UTM tracking to SenseCraft cloud links

### DIFF
--- a/sites/en/docs/Cloud_Chain/CodeCraft/0-codecraft-overview.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/0-codecraft-overview.md
@@ -24,7 +24,7 @@ Welcome to CodeCraft. This guide will help you quickly understand the platform, 
 ![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
-    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_home" target="_blank" rel="noopener noreferrer">
             <strong><span><font color={'FFFFFF'} size={"4"}>Try CodeCraft Now 🚀</font></span></strong>
     </a>
 </div>

--- a/sites/en/docs/Cloud_Chain/CodeCraft/1-quick-start-and-support.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/1-quick-start-and-support.md
@@ -21,7 +21,7 @@ updatedAt: '2026-07-08'
 ![CodeCraft Banner](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/1-quick-start-and-support/codecraft-banner.webp)
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
-    <a class="get_one_now_item" href="https://codecraft.seeed.cc" target="_blank" rel="noopener noreferrer">
+    <a class="get_one_now_item" href="https://codecraft.seeed.cc/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_home" target="_blank" rel="noopener noreferrer">
             <strong><span><font color={'FFFFFF'} size={"4"}>Try CodeCraft Now 🚀</font></span></strong>
     </a>
 </div>
@@ -155,8 +155,8 @@ CodeCraft memberships can be purchased through multiple channels. Pricing, promo
 
 | Purchase Path | Steps | Use Case |
 | :--- | :--- | :--- |
-| CodeCraft Home Purchase | 1. Visit https://codecraft.seeed.cc/pricing<br/>2. Select a plan<br/>3. Complete payment | Users comparing plans |
-| Workspace Upgrade | 1. Visit https://codecraft.seeed.cc/workspace<br/>2. Click Settings<br/>3. Go to Billing<br/>4. Purchase plan | Existing users upgrading |
+| CodeCraft Home Purchase | 1. Visit [https://codecraft.seeed.cc/pricing/](https://codecraft.seeed.cc/pricing?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_pricing)<br/>2. Select a plan<br/>3. Complete payment | Users comparing plans |
+| Workspace Upgrade | 1. Visit [https://codecraft.seeed.cc/workspace](https://codecraft.seeed.cc/workspace?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_workspace)<br/>2. Click Settings<br/>3. Go to Billing<br/>4. Purchase plan | Existing users upgrading |
 
 > Both methods activate the same membership under the same account.
 
@@ -173,7 +173,7 @@ CodeCraft memberships can be purchased through multiple channels. Pricing, promo
 
 If you obtain a redemption code from Taobao, official store, or promotions:
 
-1. Open https://codecraft.seeed.cc
+1. Open [https://codecraft.seeed.cc](https://codecraft.seeed.cc/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_home)
 2. Log in
 3. Enter workspace
 4. Click Settings
@@ -196,7 +196,7 @@ You can view subscription status, balance, redemption records, and usage in sett
 
 Steps:
 
-1. Open workspace: https://codecraft.seeed.cc/workspace
+1. Open workspace: [https://codecraft.seeed.cc/workspace](https://codecraft.seeed.cc/workspace?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_workspace)
 2. Click Settings
 3. Select Billing or Usage
 

--- a/sites/en/docs/Cloud_Chain/CodeCraft/2-creation-and-platform.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/2-creation-and-platform.md
@@ -28,7 +28,7 @@ CodeCraft is a web-based conversational programming platform. You do not need to
 
 The basic workflow is as follows:
 
-1. Visit https://codecraft.seeed.cc
+1. Visit [https://codecraft.seeed.cc](https://codecraft.seeed.cc/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_home)
 2. Log in to your account
 3. Select your development board
 4. Describe the functionality you want to implement
@@ -224,4 +224,4 @@ A: Please check whether the USB cable supports data transmission and ensure the 
 A: Check the workspace debugging information and ensure baud rate, hardware model, and sensor configuration are correct.
 
 **Q: Where can I find more project examples?**  
-A: Visit the SenseCraft AI Application Gallery: https://sensecraft.seeed.cc/ai/application
+A: Visit the SenseCraft AI Application Gallery: [https://sensecraft.seeed.cc/ai/application](https://sensecraft.seeed.cc/ai/application?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_app_square)

--- a/sites/en/docs/Cloud_Chain/CodeCraft/3-community-and-publishing.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/3-community-and-publishing.md
@@ -28,7 +28,7 @@ This document explains how to browse community projects in the Application Galle
 
 ## 3.1 Application Gallery & Community Projects
 
-In the SenseCraft AI [Application Gallery](https://sensecraft.seeed.cc/ai/application), you can complete the entire workflow from inspiration discovery to project publishing in one place.
+In the SenseCraft AI [Application Gallery](https://sensecraft.seeed.cc/ai/application?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_app_square), you can complete the entire workflow from inspiration discovery to project publishing in one place.
 
 ![CodeCraft Community Projects](https://files.seeedstudio.com/SenseCraft/sensecraft-wiki/codecraft/3-community-and-publishing/codecraft-community-EN.png)
 
@@ -89,7 +89,7 @@ Before publishing, prepare the following materials:
 
 ### 3.3.1 Go to SenseCraft AI
 
-Open the [SenseCraft AI Application Gallery](https://sensecraft.seeed.cc/ai/application). You can create a new application from scratch or clone an existing one for modification and republishing.
+Open the [SenseCraft AI Application Gallery](https://sensecraft.seeed.cc/ai/application?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_app_square). You can create a new application from scratch or clone an existing one for modification and republishing.
 
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Application_for_HomeAssistant.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Application_for_HomeAssistant.md
@@ -214,7 +214,7 @@ Finally, click the **Flash** button and wait for the programme to be uploaded su
 
 ### Step 6. Connect the Grove Vision AI V2 to the SenseCraft AI Model Assistant
 
-Access the Grove Vision AI V2 workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai)** > **`Models`** > **`Workspace`** > **`Grove Vision AI V2`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/36).
+Access the Grove Vision AI V2 workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home)** > **`Models`** > **`Workspace`** > **`Grove Vision AI V2`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/36).
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/grove_vision_ai_v2_workspace.png" style={{width:1000, height:'auto'}}/></div>
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Tool_Blocks.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Tool_Blocks.md
@@ -159,7 +159,7 @@ Compatible with **M1 Gate**, **Raspberry Pi 4 / 5**, **NVIDIA Jetson**, and **Se
 
 ### How it works with SenseCraft Fleet
 
-Container apps are managed on [**SenseCraft Fleet**](https://seeed-fleet.com) and deployed through [**SenseCraft AI**](https://sensecraft.seeed.cc/ai) (under **`Applications`**):
+Container apps are managed on [**SenseCraft Fleet**](https://seeed-fleet.com?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_fleet_home) and deployed through [**SenseCraft AI**](https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home) (under **`Applications`**):
 
 - **SenseCraft Fleet** is where container images live—you upload images, define their configuration schema, and bind your devices.
 - **SenseCraft AI** is where you pick an app from your library, choose a target device, configure it, and trigger deployment.
@@ -175,7 +175,7 @@ Apps are platform-specific—the image and target device must match:
 
 ### Configuration workflow
 
-**Select an app:** Choose from the app library on SenseCraft Fleet—the built-in catalog. If you prefer to upload your customized container app, you will need to add it through [**SenseCraft Fleet**](https://seeed-fleet.com).
+**Select an app:** Choose from the app library on SenseCraft Fleet—the built-in catalog. If you prefer to upload your customized container app, you will need to add it through [**SenseCraft Fleet**](https://seeed-fleet.com?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_fleet_home).
 
 **Configure the app:** Each app exposes the configuration items its author defined on SenseCraft Fleet. Typically you shouldn't need to configure anything, unless you have unique requirements.
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Overview.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Overview.md
@@ -22,7 +22,7 @@ url: https://wiki.seeedstudio.com/sensecraft-ai/overview/
 SenseCraft AI is an all-in-one platform designed to empower developers and creators in building and deploying AI projects with ease. The website offers a wide range of tools and features to streamline the AI development process, making it accessible to users with varying levels of expertise. In this wiki, we will explore the main sections of the SenseCraft AI website, providing an overview of their key features and functionalities.
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
-    <a class="get_one_now_item" href="https://sensecraft.seeed.cc/ai/#/home" target="_blank" rel="noopener noreferrer">
+    <a class="get_one_now_item" href="https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home" target="_blank" rel="noopener noreferrer">
             <strong><span><font color={'FFFFFF'} size={"4"}>One-Click Direct 🖱️</font></span></strong>
     </a>
 </div>
@@ -52,9 +52,9 @@ Lastly, the home page showcases the "Sharing Vision AI Models" feature, which en
 
 ## User Account
 
-[SenseCraft AI](https://sensecraft.seeed.cc/ai/#/model) is an open platform that allows users to browse all public AI models and Home pages without logging in. You need to sign up and sign in only when you need to deploy a model, or share your own model.
+[SenseCraft AI](https://sensecraft.seeed.cc/ai/model?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_model_library) is an open platform that allows users to browse all public AI models and Home pages without logging in. You need to sign up and sign in only when you need to deploy a model, or share your own model.
 
-[SenseCraft AI](https://sensecraft.seeed.cc/ai/#/model) and [SenseCraft Data Platform](https://sensecap.seeed.cc/portal/#/login) ( original SenseCAP Cloud Platform) are both software services provided by seeed studio for users, users only need to sign up for an account on any one of the platforms, and then they can use the same account to sign in on both platforms.
+[SenseCraft AI](https://sensecraft.seeed.cc/ai/model?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_model_library) and [SenseCraft Data Platform](https://sensecap.seeed.cc/portal/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_data_portal#/login) ( original SenseCAP Cloud Platform) are both software services provided by seeed studio for users, users only need to sign up for an account on any one of the platforms, and then they can use the same account to sign in on both platforms.
 
 ### Sign up
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_Via_GPIO.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_Via_GPIO.md
@@ -61,7 +61,7 @@ Before you begin, ensure that you have the following:
 
 ## Step 1. Access the XIAO ESP32S3 Sense Workspace and connect the device
 
-Access the XIAO ESP32S3 Sense workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai)** > **`Models`** > **`Workspace`** > **`XIAO ESP32S3 Sense`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/32).
+Access the XIAO ESP32S3 Sense workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home)** > **`Models`** > **`Workspace`** > **`XIAO ESP32S3 Sense`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/32).
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/xiao_esp32s3_sense_workspace.png" style={{width:1000, height:'auto'}}/></div>
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_Via_MQTT.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_Via_MQTT.md
@@ -46,7 +46,7 @@ Before you begin, ensure that you have the following:
 
 ## Step 1. Access the XIAO ESP32S3 Sense Workspace and connect the device
 
-Access the XIAO ESP32S3 Sense workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai)** > **`Models`** > **`Workspace`** > **`XIAO ESP32S3 Sense`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/32).
+Access the XIAO ESP32S3 Sense workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home)** > **`Models`** > **`Workspace`** > **`XIAO ESP32S3 Sense`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/32).
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/xiao_esp32s3_sense_workspace.png" style={{width:1000, height:'auto'}}/></div>
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_for_Grove_Vision_AI_V2.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_for_Grove_Vision_AI_V2.md
@@ -46,7 +46,7 @@ Before you begin, ensure that you have the following:
 
 ## Step 1. Access the Grove Vision AI V2 Workspace and connect the device
 
-Access the Grove Vision AI V2 workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai)** > **`Models`** > **`Workspace`** > **`Grove Vision AI V2`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/36).
+Access the Grove Vision AI V2 workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home)** > **`Models`** > **`Workspace`** > **`Grove Vision AI V2`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/36).
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/grove_vision_ai_v2_workspace.png" style={{width:1000, height:'auto'}}/></div>
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Abnormal_Vibration_Detection.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Abnormal_Vibration_Detection.md
@@ -42,7 +42,7 @@ The solution consists of 3 hardware modules.
 
 ### Software Setup
 
-1. Open your browser and visit <a href="https://sensecraft.seeed.cc/ai/home" target="_blank">**SenseCraft AI**</a>.
+1. Open your browser and visit <a href="https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home" target="_blank">**SenseCraft AI**</a>.
 2. Log in with your account (register if you don't have one).
 3. Enter the **XIAO ESP32S3 Sense** workspace and select **"Vibration"**.
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Classification.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Classification.md
@@ -31,7 +31,7 @@ The SenseCraft AI platform simplifies the classification process, allowing you t
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/img2/34.png" style={{width:1000, height:'auto'}}/></div>
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
-    <a class="get_one_now_item" href="https://sensecraft.seeed.cc/ai/#/training" target="_blank" rel="noopener noreferrer">
+    <a class="get_one_now_item" href="https://sensecraft.seeed.cc/ai/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_training#/training" target="_blank" rel="noopener noreferrer">
             <strong><span><font color={'FFFFFF'} size={"4"}>One-Click Direct 🖱️</font></span></strong>
     </a>
 </div><br />

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Using_a_model/Using_a_model_for_Grove_Vision_AI_V2.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Using_a_model/Using_a_model_for_Grove_Vision_AI_V2.md
@@ -60,7 +60,7 @@ Before getting started, ensure that you have the following:
 Open your web browser and navigate to the SenseCraft AI model repository.
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
-    <a class="get_one_now_item" href="https://sensecraft.seeed.cc/ai/#/model" target="_blank" rel="noopener noreferrer">
+    <a class="get_one_now_item" href="https://sensecraft.seeed.cc/ai/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_model_library#/model" target="_blank" rel="noopener noreferrer">
             <strong><span><font color={'FFFFFF'} size={"4"}>One-Click Direct 🖱️</font></span></strong>
     </a>
 </div><br />

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Using_a_model/Using_a_model_for_XIAO_ESP32S3_Sense.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Using_a_model/Using_a_model_for_XIAO_ESP32S3_Sense.md
@@ -51,7 +51,7 @@ Before getting started, ensure that you have the following:
 Open your web browser and navigate to the SenseCraft AI model repository.
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
-    <a class="get_one_now_item" href="https://sensecraft.seeed.cc/ai/#/model" target="_blank" rel="noopener noreferrer">
+    <a class="get_one_now_item" href="https://sensecraft.seeed.cc/ai/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_model_library#/model" target="_blank" rel="noopener noreferrer">
             <strong><span><font color={'FFFFFF'} size={"4"}>One-Click Direct 🖱️</font></span></strong>
     </a>
 </div><br />

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Grove_Vision_AI_v2_Workspace.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Grove_Vision_AI_v2_Workspace.md
@@ -62,7 +62,7 @@ If you need to replace the device's currently running model, the SenseCrfat AI p
 If you need to push the inference results from the device to your own MQTT service or the Sensecraft Data platform, please configure Wi-Fi and MQTT. Next, we will use the Sensecraft Data platform as an example.
 
 1. Enter a valid 2.4G Wi-Fi.
-2. Access the [SenseCraft Data platform](https://sensecap.seeed.cc/portal/#/login) and log in.
+2. Access the [SenseCraft Data platform](https://sensecap.seeed.cc/portal/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_data_portal#/login) and log in.
 
 :::note
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Toolkit_for_reComputer_Jetson.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Toolkit_for_reComputer_Jetson.md
@@ -169,9 +169,9 @@ The device info, more info please check the follow table <br />
 
 #### **Bind to SenseCraft AI platform**
 
-SenseCraft AI for Jetson is designed for edge AI. AI inference and video stream processing is done locally on the device. Only if you need to download more AI models do you need to bind the device to the [SenseCraft AI platform](https://sensecraft.seeed.cc/ai) — you can remove the device once downloaded.
+SenseCraft AI for Jetson is designed for edge AI. AI inference and video stream processing is done locally on the device. Only if you need to download more AI models do you need to bind the device to the [SenseCraft AI platform](https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home) — you can remove the device once downloaded.
 
-1. Visit [SenseCraft AI](https://sensecraft.seeed.cc/ai).<br />
+1. Visit [SenseCraft AI](https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home).<br />
 2. Register with a valid email address. The SenseCraft AI account is the same as the SenseCAP Cloud account; if you already have one, you can log in directly.
 
 ![](https://files.seeedstudio.com/wiki/SenseCraft_AI/img/49.png)
@@ -183,7 +183,7 @@ SenseCraft AI for Jetson is designed for edge AI. AI inference and video stream 
 
 5. Back to device‘s SenseCraft AI application. Click "Bind to SenseCraft AI platform",and then application will display bind code and temporary name.
 
-- Bind Code: enter the correct and valid bind code on the [SenseCraft AI platform](https://sensecraft.seeed.cc/ai) to finish binding the device.<br />
+- Bind Code: enter the correct and valid bind code on the [SenseCraft AI platform](https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home) to finish binding the device.<br />
 - Temporary Name: if the bind code is duplicated then you need to enter the correct temporay name.
 
 ![](https://files.seeedstudio.com/wiki/SenseCraft_AI/img/51.png)

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Using_XIAO_ESP32S3_Sense_as_an_AI_Sensor.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Using_XIAO_ESP32S3_Sense_as_an_AI_Sensor.md
@@ -47,7 +47,7 @@ Before proceeding, ensure that you have the following:
 
 ## Step 1. Access the XIAO ESP32S3 Sense Workspace and connect the device
 
-Access the XIAO ESP32S3 Sense workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai)** > **`Models`** > **`Workspace`** > **`XIAO ESP32S3 Sense`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/32).
+Access the XIAO ESP32S3 Sense workspace via **[`SenseCraft AI`](https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home)** > **`Models`** > **`Workspace`** > **`XIAO ESP32S3 Sense`**, or use the [direct link to the workspace](https://sensecraft.seeed.cc/ai/device/local/32).
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/xiao_esp32s3_sense_workspace.png" style={{width:1000, height:'auto'}}/></div>
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Dashboard_Registration.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Dashboard_Registration.md
@@ -23,7 +23,7 @@ The SenseCAP M1 dashboard is designed to help you monitor your Hotspot and give 
 **Dashboard Registration**
 ==========================
 
-1. Visit [**https://status.sensecapmx.cloud/**](https://status.sensecapmx.cloud/)
+1. Visit [**https://status.sensecapmx.cloud/**](https://status.sensecapmx.cloud?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecap_mx_dashboard)
 2. Click the "**Register**" button below.  
     1. You will have the option to create an account OR register/login with your Discord Account.
 3. Enter the details required to begin creating your account.
@@ -37,7 +37,7 @@ The SenseCAP M1 dashboard is designed to help you monitor your Hotspot and give 
 **Dashboard Login**
 ===================
 
-1. Visit [**https://status.sensecapmx.cloud/**](https://status.sensecapmx.cloud/)
+1. Visit [**https://status.sensecapmx.cloud/**](https://status.sensecapmx.cloud?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecap_mx_dashboard)
 2. Enter the credentials you created during the registration process OR login with your Discord account details (whichever you've selected during the registration process)
 3. Congratulations, you've successfully logged in.
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Hotspot_Registration.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Hotspot_Registration.md
@@ -21,7 +21,7 @@ url: https://wiki.seeedstudio.com/sensecraft-blockchain/blockchain-dashboard/hot
 **How To Register Hotspots With Helium Wallet**
 ===============================================
 
--  Please login to the SenseCAP Dashboard by visiting [**https://status.sensecapmx.cloud/**](https://status.sensecapmx.cloud/)
+-  Please login to the SenseCAP Dashboard by visiting [**https://status.sensecapmx.cloud/**](https://status.sensecapmx.cloud?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecap_mx_dashboard)
 -  Ensure your "Helium APP" is the latest version and login to your Helium wallet.
 
 You can download the latest version by visiting the [**Android Store**](https://play.google.com/store/apps/details?id=com.helium.wallet&hl=en_US) or the [**iOS Store**](https://apps.apple.com/app/id1450463605).
@@ -57,7 +57,7 @@ If your wallet was successfully linked, you will see the message below. **You ar
 
 ![SenseCAP Hotspot Registration 5](https://www.sensecapmx.com/wp-content/uploads/2022/07/image-6-1.png)
 
-- Log-in to the dashboard ⇒ [**https://status.sensecapmx.cloud/**](https://status.sensecapmx.cloud/)
+- Log-in to the dashboard ⇒ [**https://status.sensecapmx.cloud/**](https://status.sensecapmx.cloud?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecap_mx_dashboard)
 - Enter the credentials you created during registration and log in
 - Navigate to “Hotspot” on the left menu column
 - Click "Add new Hotspot"

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/Applications/AI_Advisor.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/Applications/AI_Advisor.md
@@ -35,7 +35,7 @@ url: https://wiki.seeedstudio.com/sensecraft-data-platform/applications/ai-advis
 
 **SenseCraft AI Advisor** is an AI-powered feature that helps you make the most of your sensor data and unlock actionable insights. By connecting your SenseCraft sensors to the SenseCraft platform, you can easily collect and analyze data on environmental factors such as temperature, humidity, light, and air quality. Our AI Advisor leverages this data to provide suggestions and recommendations that can help you optimize operations, reduce costs, and improve efficiency.
 
-Whether you're looking to monitor air quality, optimize crop growth, or improve farm management, SenseCraft AI Advisor is designed to assist your decision-making. The AI Advisor is available on the [SenseCraft Data Platform](https://sensecap.seeed.cc/portal/#/login) and the [SenseCAP Mate APP](http://sensecap-mate-download.seeed.cc/), enabling users to access insights anytime, anywhere.
+Whether you're looking to monitor air quality, optimize crop growth, or improve farm management, SenseCraft AI Advisor is designed to assist your decision-making. The AI Advisor is available on the [SenseCraft Data Platform](https://sensecap.seeed.cc/portal/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_data_portal#/login) and the [SenseCAP Mate APP](http://sensecap-mate-download.seeed.cc/), enabling users to access insights anytime, anywhere.
 
 <div align="center"><img width={1000} src="https://files.seeedstudio.com/wiki/SenseCAP_AI/1.png"/></div>
 
@@ -103,7 +103,7 @@ SenseCraft AI Advisor currently analyzes the following measurements and device t
 
 ## SenseCraft Data Platform
 
-1. Login to [SenseCraft Data Platform (Global)](https://sensecap.seeed.cc/portal/#/login) or [SenseCraft Data Platform (China)](http://sensecap.seeed.cn/portal/#/login)
+1. Login to [SenseCraft Data Platform (Global)](https://sensecap.seeed.cc/portal/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_data_portal#/login) or [SenseCraft Data Platform (China)](http://sensecap.seeed.cn/portal/#/login)
 2. Bind your SenseCraft sensor by entering the sensor's SN and code
 
 <div align="center"><img width={1000} src="https://files.seeedstudio.com/wiki/SenseCAP_AI/5.png"/></div>

--- a/sites/en/docs/Cloud_Chain/SenseCraft_HMI/sensecraft_hmi_overview.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_HMI/sensecraft_hmi_overview.md
@@ -16,7 +16,7 @@ url: https://wiki.seeedstudio.com/sensecraft_hmi_overview/
 
 ## Introduction
 
-[SenseCraft HMI](https://sensecraft.seeed.cc/hmi) is Seeed Studio's powerful cloud-based interface design platform that enables you to create professional visual interfaces for screen-based devices without coding. With an intuitive drag-and-drop editor, pre-built templates, and AI-powered design capabilities, SenseCraft HMI makes it easy to transform your hardware into beautiful information displays, dashboards, digital signage, and control panels.
+[SenseCraft HMI](https://sensecraft.seeed.cc/hmi/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_hmi_home) is Seeed Studio's powerful cloud-based interface design platform that enables you to create professional visual interfaces for screen-based devices without coding. With an intuitive drag-and-drop editor, pre-built templates, and AI-powered design capabilities, SenseCraft HMI makes it easy to transform your hardware into beautiful information displays, dashboards, digital signage, and control panels.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/23.png" style={{width:1000, height:'auto'}}/></div>
 
@@ -40,7 +40,7 @@ url: https://wiki.seeedstudio.com/sensecraft_hmi_overview/
 
 To begin using SenseCraft HMI:
 
-1. **Access the Platform**: Visit [SenseCraft HMI](https://sensecraft.seeed.cc/hmi)
+1. **Access the Platform**: Visit [SenseCraft HMI](https://sensecraft.seeed.cc/hmi/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_hmi_home)
 
 2. **Create an Account**: Sign up for a free SenseCraft account if you don't already have one
 
@@ -118,7 +118,7 @@ Latest updates and version history of the SenseCraft HMI platform.
 
 ## Resources
 
-- [SenseCraft HMI Platform](https://sensecraft.seeed.cc/hmi)
+- [SenseCraft HMI Platform](https://sensecraft.seeed.cc/hmi/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_hmi_home)
 - [Compatible Devices - reTerminal E Series](https://wiki.seeedstudio.com/reterminal_e10xx_main_page/)
 
 ## Tech Support & Product Discussion


### PR DESCRIPTION
Fixes #5283

## Summary

Add referral UTM tracking to mapped SenseCraft and Cloud product entry links in the English Wiki source.

## Changes

- Updated 39 external link destinations across 21 English documents.
- Applied context-specific `utm_content` values for:
  - CodeCraft Home, Workspace, and Pricing
  - SenseCraft AI Home, Model Library, App Square, and Training
  - SenseCraft Data Portal
  - SenseCraft Fleet Home
  - SenseCraft HMI Home
  - SenseCAP MX Dashboard
- Preserved existing visible text, functional query parameters, and legacy hash routes.
- Replaced obsolete generic SenseCraft AI `/ai` destinations with the mapped `/ai/home` entry where applicable.

## Scope and non-goals

- Only `sites/en/docs/Cloud_Chain/**` is modified.
- No localized source files are modified; localization remains with the repository's post-merge translation workflow.
- No slugs, aliases, headings, sidebars, navigation, assets, or product copy are changed.
- Links in Network, Sensor, Edge, Solutions, Topics, weekly Wiki, and general Getting Started documents are intentionally excluded even when they reference SenseCraft.

## Validation

- `git diff --check` — passed
- Changed-path scope check — 21/21 files under `sites/en/docs/Cloud_Chain/**`
- UTM structure check — 39 destinations; all four required parameters occur exactly once
- Query/fragment ordering check — passed
- UTM Map semantic review — all 21 pages passed per-page review
- Markdown lint delta — no new errors relative to `origin/docusaurus-version`
- External target sampling — all distinct tagged destinations returned HTTP 200

The repository's full multilingual Docusaurus builds are left to the normal PR CI gates.
