### PR TITLE
docs: refresh updatedAt for merged Cloud pages

### DIFF
--- a/sites/en/docs/Cloud_Chain/CodeCraft/0-codecraft-overview.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/0-codecraft-overview.md
@@ -14,7 +14,7 @@ last_update:
   author: Shihan Gao
 url: https://wiki.seeedstudio.com/codecraft/codecraft-overview/
 createdAt: '2026-06-29'
-updatedAt: '2026-07-08'
+updatedAt: '2026-08-04'
 ---
 
 # CodeCraft User Guide

--- a/sites/en/docs/Cloud_Chain/CodeCraft/1-quick-start-and-support.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/1-quick-start-and-support.md
@@ -13,7 +13,7 @@ last_update:
   author: Shihan Gao
 url: https://wiki.seeedstudio.com/codecraft/quick-start-and-support/
 createdAt: '2026-06-29'
-updatedAt: '2026-07-08'
+updatedAt: '2026-08-04'
 ---
 
 # CodeCraft Quick Start & Support

--- a/sites/en/docs/Cloud_Chain/CodeCraft/2-creation-and-platform.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/2-creation-and-platform.md
@@ -13,7 +13,7 @@ last_update:
   author: Shihan Gao
 url: https://wiki.seeedstudio.com/codecraft/creation-and-platform/
 createdAt: '2026-06-29'
-updatedAt: '2026-06-29'
+updatedAt: '2026-08-04'
 ---
 
 # CodeCraft Creation & Platform

--- a/sites/en/docs/Cloud_Chain/CodeCraft/3-community-and-publishing.md
+++ b/sites/en/docs/Cloud_Chain/CodeCraft/3-community-and-publishing.md
@@ -13,7 +13,7 @@ last_update:
   author: Shihan Gao
 url: https://wiki.seeedstudio.com/codecraft/community-and-publishing/
 createdAt: '2026-06-29'
-updatedAt: '2026-06-29'
+updatedAt: '2026-08-04'
 ---
 
 # CodeCraft Community & Publishing

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Application_for_HomeAssistant.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Application_for_HomeAssistant.md
@@ -13,7 +13,7 @@ last_update:
   date: 01/10/2024
   author: Citric
 createdAt: '2024-01-11'
-updatedAt: '2026-05-07'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/application/application-for-homeassistant/
 ---
 # Connect Grove Vision AI V2 to Home Assistant

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Tool_Blocks.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Application/Tool_Blocks.md
@@ -11,7 +11,7 @@ last_update:
   date: 03/30/2026
   author: Rida
 createdAt: '2026-03-30'
-updatedAt: '2026-05-07'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/application/tool-blocks/
 ---
 # Using Tool Blocks

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Overview.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Overview.md
@@ -10,7 +10,7 @@ last_update:
   date: 11/28/2024
   author: Citric
 createdAt: '2024-11-28'
-updatedAt: '2026-05-07'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/overview/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_Via_GPIO.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_Via_GPIO.md
@@ -10,7 +10,7 @@ last_update:
   date: 12/04/2024
   author: Citric
 createdAt: '2024-12-05'
-updatedAt: '2026-05-07'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-output-gpio-xiao/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_Via_MQTT.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_Via_MQTT.md
@@ -10,7 +10,7 @@ last_update:
   date: 12/04/2024
   author: Citric
 createdAt: '2024-11-27'
-updatedAt: '2026-05-07'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-output-mqtt-xiao/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_for_Grove_Vision_AI_V2.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Model_Output/Model_Output_for_Grove_Vision_AI_V2.md
@@ -10,7 +10,7 @@ last_update:
   date: 12/04/2024
   author: Citric
 createdAt: '2024-11-27'
-updatedAt: '2026-05-07'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-output-grove-vision-ai/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Abnormal_Vibration_Detection.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Abnormal_Vibration_Detection.md
@@ -8,7 +8,7 @@ last_update:
   date: 01/06/2026
   author: jancee
 createdAt: '2025-08-14'
-updatedAt: '2026-01-06'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/workspace/abnormal-vibration-detection/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Classification.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Classification.md
@@ -10,7 +10,7 @@ last_update:
   date: 12/03/2024
   author: Citric
 createdAt: '2024-11-27'
-updatedAt: '2025-08-18'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-training-classification/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Using_a_model/Using_a_model_for_Grove_Vision_AI_V2.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Using_a_model/Using_a_model_for_Grove_Vision_AI_V2.md
@@ -10,7 +10,7 @@ last_update:
   date: 12/02/2024
   author: Citric
 createdAt: '2024-12-02'
-updatedAt: '2025-09-02'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-pretrained-models-for-grove-vision-ai-v2/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Using_a_model/Using_a_model_for_XIAO_ESP32S3_Sense.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Using_a_model/Using_a_model_for_XIAO_ESP32S3_Sense.md
@@ -10,7 +10,7 @@ last_update:
   date: 12/02/2024
   author: Citric
 createdAt: '2024-12-02'
-updatedAt: '2025-09-02'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-pretrained-models-for-xiao/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Grove_Vision_AI_v2_Workspace.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Grove_Vision_AI_v2_Workspace.md
@@ -14,7 +14,7 @@ last_update:
   date: 08/22/2024
   author: Frank
 createdAt: '2024-08-21'
-updatedAt: '2025-09-04'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/grove-vision-ai-v2-workspace/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Toolkit_for_reComputer_Jetson.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Toolkit_for_reComputer_Jetson.md
@@ -14,7 +14,7 @@ last_update:
   date: 08/16/2024
   author: Frank
 createdAt: '2024-08-21'
-updatedAt: '2026-05-07'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-jetson/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Using_XIAO_ESP32S3_Sense_as_an_AI_Sensor.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Workspace/Using_XIAO_ESP32S3_Sense_as_an_AI_Sensor.md
@@ -10,7 +10,7 @@ last_update:
   date: 12/04/2024
   author: Citric
 createdAt: '2024-11-27'
-updatedAt: '2026-05-07'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-output-libraries-xiao/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Dashboard_Registration.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Dashboard_Registration.md
@@ -12,7 +12,7 @@ last_update:
   date: 02/14/2023
   author: Matthew
 createdAt: '2023-02-24'
-updatedAt: '2026-03-23'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-blockchain/blockchain-dashboard/dashboard-registration/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Hotspot_Registration.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Blockchain/Blockchain_Dashboard/Hotspot_Registration.md
@@ -12,7 +12,7 @@ last_update:
   date: 06/06/2025
   author: Matthew
 createdAt: '2023-02-24'
-updatedAt: '2025-09-04'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-blockchain/blockchain-dashboard/hotspot-registration/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/Applications/AI_Advisor.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/Applications/AI_Advisor.md
@@ -25,7 +25,7 @@ last_update:
   date: 06/06/2025
   author: Jancee
 createdAt: '2023-06-19'
-updatedAt: '2025-09-02'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft-data-platform/applications/ai-advisor/
 ---
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_HMI/sensecraft_hmi_overview.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_HMI/sensecraft_hmi_overview.md
@@ -8,7 +8,7 @@ last_update:
   date: 07/21/2025
   author: Citric
 createdAt: '2025-07-25'
-updatedAt: '2025-12-22'
+updatedAt: '2026-08-04'
 url: https://wiki.seeedstudio.com/sensecraft_hmi_overview/
 ---
 


### PR DESCRIPTION
Fixes #5289

## Summary

Follow up on merged PR #5284 by refreshing the frontmatter modification date for every English document changed by that PR.

## Changes

- Updated `updatedAt` to `2026-08-04` in exactly 21 English `Cloud_Chain` documents.
- Preserved every `createdAt` value.
- Made no link, copy, heading, route, alias, asset, localization, or other metadata changes.

## Validation

- Changed paths exactly match the 21 English documents from PR #5284.
- Metadata coverage: 21/21 files contain exactly one `updatedAt: '2026-08-04'`.
- Complete diff inspection: 42 changed content lines, all of them `updatedAt` replacements.
- `createdAt` and all unrelated frontmatter fields remain unchanged.
- `git diff --check` passed.
- No localized files or paths outside `sites/en/docs/Cloud_Chain/**` changed.

The repository's GitHub Actions builds remain the publication gate.
