### PR TITLE
docs: add reSpeaker Clip firmware SDK guides

### DIFF
--- a/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_basic_sdk_guide.md
+++ b/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_basic_sdk_guide.md
@@ -1,5 +1,5 @@
 ---
-description: Systematic guide to the reSpeaker Clip Basic SDK — transports, communication protocols, recording state machine, file model, end-to-end data flow, and the Python SDK as the primary reference implementation with CLI and Web tools.
+description: "Systematic guide to the reSpeaker Clip Basic SDK — transports, communication protocols, recording state machine, file model, end-to-end data flow, and the Python SDK as the primary reference implementation with CLI and Web tools."
 title: reSpeaker Clip Basic SDK Guide
 keywords:
   - reSpeaker clip
@@ -37,7 +37,7 @@ This guide covers:
 - **End-to-end data flow** — from connect to downloaded audio output.
 - **Reference implementations** — Python SDK (`clip` package), CLI tools, and a Web interface.
 
-The Basic SDK focuses on using the device's current capabilities from the host side. It does not include cloud transcription, AI summarization, account management, or mobile app services by themselves. Those workflows should be built on top of the downloaded audio files or integrated with another service. For modifying device-side behavior, protocols, audio processing, or firmware internals, refer to the [Firmware SDK documentation](#basic-sdk-and-firmware-sdk).
+The Basic SDK focuses on using the device's current capabilities from the host side. It does not include cloud transcription, AI summarization, account management, or mobile app services by themselves. Those workflows should be built on top of the downloaded audio files or integrated with another service.
 
 ## Where This Guide Fits
 
@@ -53,7 +53,28 @@ This guide focuses on application-side development:
 - understanding AT commands, GATT, and file-transfer protocols;
 - integrating these capabilities through Python, CLI, or Web tools.
 
-For modifying device-side behavior, protocols, audio processing, or firmware internals, refer to the [Firmware SDK documentation](#basic-sdk-and-firmware-sdk).
+## Basic SDK and Firmware SDK
+
+The reSpeaker Clip SDK is split into two layers:
+
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/reSpeaker_Clip/respeaker_clip_basic_firmware.png" alt="Basic SDK vs Firmware SDK" width={900} height="auto" /></p>
+
+The concepts introduced in this guide (transports, protocols, state machine, data flow) are implemented on the device side by the firmware. The table below maps each Basic SDK concept to its Firmware SDK counterpart:
+
+| Basic SDK concept | Firmware SDK counterpart |
+| --- | --- |
+| BLE / Wi-Fi transport | BLE and UDP service device-side implementation |
+| AT Command | AT Server and command registration |
+| GATT | GATT service and characteristics |
+| Recording state machine | Device recording states and event handling |
+| File transfer | Storage, chunking, CRC, and sync implementation |
+| Audio data flow | PDM -> DSP -> Opus -> file pipeline |
+
+If your goal is to add new AT commands, change GATT services, modify the recording state machine, or alter the audio processing chain, use the Firmware SDK:
+
+- [Getting Started with the reSpeaker Clip Firmware SDK](/respeaker_clip_firmware_quick_start/) covers environment setup, build, flash, and smoke testing.
+- [reSpeaker Clip Firmware Development Guide](/respeaker_clip_firmware_development_guide/) explains the firmware architecture, protocol internals, update and recovery paths, validation, production release, and AI-assisted development.
+- [Customization: Add a Custom AT Command](/respeaker_clip_customization_at_command/) walks through adding and validating a new AT command.
 
 ## Installation
 
@@ -152,6 +173,21 @@ Transport choice matters:
 
 ## Core Concepts
 
+This section describes the host-side view used by the Basic SDK. For the
+device-side implementation details, see the matching Firmware Development Guide
+sections:
+
+| Basic SDK topic | Detailed firmware explanation |
+| --- | --- |
+| Transports | [Communication Protocol](/respeaker_clip_firmware_development_guide/#communication-protocol) |
+| Recording modes | [Recording Modes](/respeaker_clip_firmware_development_guide/#recording-modes) |
+| Device state | [Event and State Model](/respeaker_clip_firmware_development_guide/#event-and-state-model) |
+| File format and sessions | [Session, Chunking, and Storage Model](/respeaker_clip_firmware_development_guide/#session-chunking-and-storage-model) |
+| AT command protocol | [AT Command Grammar](/respeaker_clip_firmware_development_guide/#at-command-grammar), [JSON Response Contract](/respeaker_clip_firmware_development_guide/#json-response-contract), and [Registered Command Reference](/respeaker_clip_firmware_development_guide/#registered-command-reference) |
+| GATT characteristics | [BLE GATT Service](/respeaker_clip_firmware_development_guide/#ble-gatt-service) |
+| File transfer and resume | [UDP Frame Types](/respeaker_clip_firmware_development_guide/#udp-frame-types) and [Session and File Addressing](/respeaker_clip_firmware_development_guide/#session-and-file-addressing) |
+| End-to-end data flow | [System Architecture](/respeaker_clip_firmware_development_guide/#system-architecture) and [Audio Pipeline](/respeaker_clip_firmware_development_guide/#audio-pipeline) |
+
 ### Transports
 
 | Transport | Class | Use case | Notes |
@@ -232,25 +268,6 @@ Each file is verified with CRC32. Only verified files should be treated as succe
 ### Data Flow
 
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/reSpeaker_Clip/respeaker_clip_data_flow.png" alt="reSpeaker Clip data flow" width={900} height="auto" /></p>
-
-## Basic SDK and Firmware SDK
-
-The reSpeaker Clip SDK is split into two layers:
-
-<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/reSpeaker_Clip/respeaker_clip_basic_firmware.png" alt="Basic SDK vs Firmware SDK" width={900} height="auto" /></p>
-
-The concepts introduced in this guide (transports, protocols, state machine, data flow) are implemented on the device side by the firmware. The table below maps each Basic SDK concept to its Firmware SDK counterpart:
-
-| Basic SDK concept | Firmware SDK counterpart |
-| --- | --- |
-| BLE / Wi-Fi transport | BLE and UDP service device-side implementation |
-| AT Command | AT Server and command registration |
-| GATT | GATT service and characteristics |
-| Recording state machine | Device recording states and event handling |
-| File transfer | Storage, chunking, CRC, and sync implementation |
-| Audio data flow | PDM → DSP → Opus → file pipeline |
-
-If your goal is to add new AT commands, change GATT services, modify the recording state machine, or alter the audio processing chain, you need the Firmware SDK. The Firmware SDK documentation (firmware architecture, environment setup, build, flashing, and secondary development) is not yet available and will be published as soon as possible.
 
 ## Complete Example
 

--- a/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_customization_at_command.md
+++ b/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_customization_at_command.md
@@ -1,0 +1,389 @@
+---
+description: "A concrete, end-to-end walkthrough of adding a new AT command to the Clip"
+title: "Customization: Add a Custom AT Command"
+keywords:
+  - reSpeaker clip
+  - firmware
+  - sdk
+  - add
+  - a
+  - custom
+  - at
+image: https://files.seeedstudio.com/wiki/reSpeaker_Clip/clip-banner.jpg
+slug: /respeaker_clip_customization_at_command
+sku: 100020126
+last_update:
+  date: 07/27/2026
+  author: Ray
+createdAt: '2026-07-27'
+updatedAt: '2026-07-27'
+url: https://wiki.seeedstudio.com/respeaker_clip_customization_at_command/
+---
+
+# Customization: Add a Custom AT Command
+
+A concrete, end-to-end walkthrough of adding a **new** AT command to the Clip
+firmware. We add a trivial-but-real command, `AT+ECHO=<msg>`, that replies:
+
+```json
+{"ok":true,"data":{"echo":"<msg>"}}\n
+```
+
+The same recipe scales to real commands that touch config, storage, audio, or
+the event system.
+
+## AI prompt
+
+You can copy this prompt into an AI coding agent to reproduce the same
+customization workflow in the firmware repository:
+
+```text
+You are working in the reSpeaker Clip firmware repository.
+
+Use the repository Skill before editing:
+1. Read `skills/clip-dev/SKILL.md` completely and follow it for firmware AT
+   command development, build, flash, and validation.
+2. For AT protocol work, also read the referenced BLE/AT guidance from that
+   Skill when needed.
+3. If the new command requires a Python SDK API or CLI support, read
+   `skills/clip-sdk/SKILL.md` and update `sdk/` plus `docs/protocol.md`
+   according to that Skill.
+
+Task:
+Add a new AT command named `ECHO` to the Clip firmware.
+
+Expected behavior:
+- `AT+ECHO=hello` returns `{"ok":true,"data":{"echo":"hello"}}`
+- `AT+ECHO=` returns `{"ok":false,"msg":"Missing message"}`
+- `AT+ECHO` returns `{"ok":false,"msg":"Use AT+ECHO=<msg>"}`
+
+Implementation constraints:
+- Modify `applications/clip/src/at_commands.c`.
+- Add a `cmd_echo_handler(struct at_cmd_ctx *ctx, char *response, size_t len)`.
+- Use `create_json_response(...)` so the response format matches existing
+  commands.
+- Register the command in `at_commands_register()` with
+  `AT_CMD_SET | AT_CMD_EXEC`.
+- Keep the example minimal. It may use `%s` for the demo response, but document
+  that real free-form string commands must validate or escape JSON-sensitive
+  input first.
+- Do not change BLE, UDP, or USB transport code unless the source proves it is
+  necessary.
+
+Validation:
+- Build a pristine firmware image for `clip/nrf5340/cpuapp`.
+- If hardware is available, flash the image and test `AT+ECHO=hello`,
+  `AT+ECHO=`, and bare `AT+ECHO` over at least one transport.
+- Also check representative existing commands such as `AT+GSTAT`, `AT+MODE?`,
+  and `AT+VERSION`.
+- Report exactly what was tested and do not claim hardware validation unless it
+  actually ran on a device.
+```
+
+## 1. Goal
+
+Add `AT+ECHO=<msg>` so that:
+
+```
+AT+ECHO=hello     -> {"ok":true,"data":{"echo":"hello"}}
+AT+ECHO=          -> {"ok":false,"msg":"Missing message"}
+AT+ECHO           -> {"ok":false,"msg":"Use AT+ECHO=<msg>"}
+```
+
+It is intentionally minimal: one SET command with a small EXEC usage hint, no
+side effects, verifiable on all three transports. `ECHO` does not collide with
+any registered command (see the registry in `at_commands_register()` below).
+
+## 2. Current data flow
+
+An inbound AT line travels through these layers (function names are real):
+
+```
+transport (BLE / UDP / USB CDC)
+  -> at_server_submit_cmd()            applications/clip/src/at_server.c
+  -> at_server_thread_func()           dequeues from its k_msgq
+  -> parse_command()                   splits name / args / type (SET|TEST|EXEC)
+  -> cmd->handler(&ctx, buf, len)       matched in the cmd_registry
+  -> create_json_response(...)          builds {"ok":..,"msg":..,"data":..}
+  -> SEND_RESPONSE()                    routes the buffer back to the
+                                        transport the command arrived on
+```
+
+Two points matter for the customizer:
+
+- **Parsing is shared.** `parse_command()` (at_server.c) owns the `AT+NAME=args`
+  grammar and the `=`, `?` type detection. You never parse the `AT+` prefix
+  yourself — your handler receives `ctx->args` already split out.
+- **Responses are auto-routed.** The `SEND_RESPONSE()` macro in
+  `at_server.c` dispatches by the command's originating transport:
+  `TRANSPORT_TYPE_USB` -> `usb_cdc_send_response()`,
+  `TRANSPORT_TYPE_UDP` -> `transport_udp_send_response()`,
+  otherwise -> `transport_send_to(item->transport_type, ...)`. Your handler
+  only fills the response buffer; it does **no** transport work, and the same
+  JSON goes out identically over BLE, UDP, and USB.
+
+## 3. Extension point: the registration pattern
+
+Everything below is quoted from real source. The contract lives in
+`applications/clip/include/at_server.h`.
+
+### 3.1 The handler signature
+
+From `at_server.h`:
+
+```c
+typedef int (*at_cmd_handler_t)(struct at_cmd_ctx *ctx, char *response, size_t len);
+```
+
+The context your handler receives (`at_server.h`):
+
+```c
+struct at_cmd_ctx {
+    const char *name;           /* Command name (e.g., "ECHO") */
+    uint8_t type;               /* Command type (SET/QUERY/EXEC) */
+    const char *args;           /* Arguments string */
+    uint8_t transport_type;     /* Transport type for response */
+};
+```
+
+`ctx->type` is one of `AT_CMD_TYPE_TEST` (0), `AT_CMD_TYPE_SET` (1),
+`AT_CMD_TYPE_EXEC` (2) — also `AT_CMD_TYPE_READ` (3, same as TEST). Args live
+in `ctx->args` (already past the `=`). A real handler using exactly this shape
+is `cmd_mode_handler` (at_commands.c:422):
+
+```c
+static int cmd_mode_handler(struct at_cmd_ctx *ctx, char *response, size_t len)
+{
+    if (ctx->type == AT_CMD_TYPE_SET) {
+        if (!ctx->args || strlen(ctx->args) == 0) {
+            return create_json_response(false, "Missing mode value", NULL, response, len);
+        }
+        /* ...validate, mutate state... */
+        char data[32];
+        snprintf(data, sizeof(data), "{\"mode\":\"%s\"}", mode_str);
+        return create_json_response(true, NULL, data, response, len);
+    } else {
+        /* AT+MODE? */
+        char data[32];
+        snprintf(data, sizeof(data), "{\"mode\":\"%s\"}", mode_str);
+        return create_json_response(true, NULL, data, response, len);
+    }
+}
+```
+
+### 3.2 The `create_json_response` helper
+
+From `at_commands.c` (the static helper every handler uses):
+
+```c
+static int create_json_response(bool success, const char *message,
+                                const char *data, char *response, size_t len);
+```
+
+Behavior (read from its body):
+
+- Emits `{"ok":true` or `{"ok":false`.
+- If `message` is non-NULL, appends `,"msg":"<message>"`.
+- If `data` is non-NULL, appends `,"data":<data>` **verbatim** — `data` must
+  be a **complete JSON object** you formatted yourself (e.g. `{"echo":"hello"}`),
+  **not** a bare value or a format string. This is the common gotcha.
+- Closes with `}\n` and returns the total length; returns `AT_ERR_NOMEM` on
+  truncation. The server thread treats `ret < 0` as an error and substitutes
+  `at_server_err_msg(-ret)`.
+
+So the response shape is fixed: success -> `{"ok":true,...,"data":{...}}`,
+failure -> `{"ok":false,...,"msg":"..."}`. There are no numeric error codes and
+no `error` field (see [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md)).
+
+### 3.3 The command struct and registration
+
+From `at_server.h`:
+
+```c
+struct at_command {
+    const char *name;           /* Command name */
+    uint8_t flags;              /* Supported operations */
+    at_cmd_handler_t handler;   /* Command handler */
+};
+```
+
+Flags (bitmask; `at_server.h`):
+
+```c
+#define AT_CMD_SET    (1 << 0)  /* Supports AT+CMD=... */
+#define AT_CMD_QUERY  (1 << 1)  /* Supports AT+CMD?      */
+#define AT_CMD_EXEC   (1 << 2)  /* Supports AT+CMD       */
+```
+
+Registration (at_server.c) — note the registry is capped at 32 commands:
+
+```c
+int at_server_register_cmd(const struct at_command *cmd);
+```
+
+A real registration block, exactly as it appears in `at_commands.c:1769`:
+
+```c
+/* GSTAT - Get device status */
+static const struct at_command gstat_cmd = {
+    .name = "GSTAT",
+    .flags = AT_CMD_EXEC,
+    .handler = cmd_gstat_handler,
+};
+err = at_server_register_cmd(&gstat_cmd);
+if (err) return err;
+```
+
+## 4. Files to modify
+
+Only one source file: `applications/clip/src/at_commands.c`.
+
+### 4.1 Add the handler
+
+Place it among the other `static int cmd_*_handler(...)` definitions (the
+existing handlers sit above `at_commands_register()`). Modeled on
+`cmd_mode_handler`:
+
+```c
+/* ECHO Command Handler - customization example.
+ * AT+ECHO=<msg> -> {"ok":true,"data":{"echo":"<msg>"}} */
+static int cmd_echo_handler(struct at_cmd_ctx *ctx, char *response, size_t len)
+{
+    if (ctx->type != AT_CMD_TYPE_SET) {
+        return create_json_response(false, "Use AT+ECHO=<msg>", NULL, response, len);
+    }
+    if (!ctx->args || strlen(ctx->args) == 0) {
+        return create_json_response(false, "Missing message", NULL, response, len);
+    }
+
+    char data[160];
+    int n = snprintf(data, sizeof(data), "{\"echo\":\"%s\"}", ctx->args);
+    if (n < 0 || n >= (int)sizeof(data)) {
+        return AT_ERR_NOMEM;
+    }
+    return create_json_response(true, NULL, data, response, len);
+}
+```
+
+> **Gotcha for real commands:** `ctx->args` is raw user input. Interpolating it
+> with `%s` (as the trivial example does) lets a `"` in the message break the
+> JSON. For any command that accepts free-form strings, validate/escape the
+> input first. The shipped commands that use `%s` (e.g. `MODE`, `LOG`) do so
+> only against a fixed enumeration they already checked.
+
+### 4.2 Register it
+
+Inside `at_commands_register(void)` (at_commands.c:1761) — the single init
+function that registers every command and is itself called once from
+`main.c` (`at_commands_register()` at main.c:286). Add the block alongside the
+others (e.g. right after the `LOG` block near at_commands.c:2030):
+
+```c
+/* ECHO - echo a message back (customization example) */
+static const struct at_command echo_cmd = {
+    .name = "ECHO",
+    .flags = AT_CMD_SET | AT_CMD_EXEC,
+    .handler = cmd_echo_handler,
+};
+err = at_server_register_cmd(&echo_cmd);
+if (err) return err;
+```
+
+`AT_CMD_EXEC` is required because the handler intentionally returns a friendly
+usage message for bare `AT+ECHO`. If the registration only uses `AT_CMD_SET`,
+the dispatcher rejects `AT+ECHO` before the handler can run. Because the server
+auto-routes the response (Section 2), no BLE/UDP/USB code changes are needed.
+
+## 5. Compatibility impact
+
+Adding a command is **additive** — existing commands and their JSON shapes are
+untouched. Keep the response contract intact:
+
+- Success: `{"ok":true,"data":{...}}`
+- Failure: `{"ok":false,"msg":"..."}`
+- No numeric error codes, no request ID, no `error` field. (See
+  [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md).)
+
+If the new command should also be reachable from the host tooling, you need
+**Python SDK parity**, not just firmware. Per the `skills/clip-sdk/` rule, read
+the current `at_commands.c` registrations before changing the SDK, and treat
+`docs/protocol.md` + firmware source as the protocol contract — update both the
+SDK (in `sdk/`) and `protocol.md` when the firmware contract changes. Do not
+emulate removed legacy commands (`BITRATE`, `COMPLEXITY`, `NOISE`, `AGC`,
+`DEREVERB`, `PURGE`).
+
+## 6. Build
+
+Source the NCS v3.3.0 environment, set the module path as an env var (Kconfig
+discovery runs before CMake), then build:
+
+```sh
+source ~/ncs/v3.3.0/zephyr/zephyr-env.sh
+export ZEPHYR_EXTRA_MODULES=$(pwd)
+
+west build --build-dir build-clip --pristine --board clip/nrf5340/cpuapp applications/clip
+```
+
+Per `CLAUDE.md`, the project builds with **zero warnings** — fix any compiler
+warning before committing. (The handler above introduces none.)
+
+## 7. On-device verify
+
+Flash (note: `west flash --reset` does not work on this board — reset
+separately):
+
+```sh
+west flash --build-dir build-clip && nrfutil device reset
+minicom -D /dev/ttyACM0 -b 921600
+```
+
+Then exercise the command on each transport and confirm the JSON is identical:
+
+**BLE** (interactive shell — `clip-cli.py terminal` opens an AT prompt over BLE):
+
+```sh
+python applications/clip/tests/tools/clip-cli.py terminal
+# at the prompt:
+AT+ECHO=hello      -> {"ok":true,"data":{"echo":"hello"}}
+AT+ECHO           -> {"ok":false,"msg":"Use AT+ECHO=<msg>"}
+AT+ECHO=          -> {"ok":false,"msg":"Missing message"}
+```
+
+**UDP** (WiFi AP mode — send `AT+WIFI=on` over BLE first, then join the returned
+SSID/password and target `192.168.4.1:8089`):
+
+```sh
+python applications/clip/tests/tools/udp_terminal.py
+AT+ECHO=hello
+```
+
+**USB CDC** (open the CDC-ACM serial port; USB must be enabled first via
+`AT+USB=on` over BLE, or hold the user button while plugging in):
+
+```sh
+AT+ECHO=hello
+```
+
+The response string must match byte-for-byte across all three. Also confirm no
+existing command regressed — e.g. `AT+GSTAT`, `AT+MODE?`, `AT+VERSION`.
+
+## 8. Recovery
+
+If the new build misbehaves, recover over USB serial DFU (1200-baud trigger
+into MCUboot recovery, PID `0x8069`), BLE OTA, or a programmer — see
+[usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md). The bootloader partition is never touched by an app
+OTA; the signature is verified by MCUboot.
+
+## Related
+
+- Source: [at_commands.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_commands.c) (handlers + `at_commands_register()`),
+  [at_server.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_server.c) (`parse_command`,
+  `at_server_register_cmd`, `SEND_RESPONSE`), [at_server.h](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/include/at_server.h)
+  (struct/flag/typedef contract).
+- Protocol: [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md) (AT command spec + response contract),
+  [architecture.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/architecture.md) (transport/event system).
+- Python parity: [skills/clip-sdk/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-sdk/) (SDK source in `sdk/`,
+  command-registration/protocol-doc rules), [skills/clip-dev/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/)
+  (firmware-dev skill — audio/build/ble-at/storage/wifi-udp/mcuboot/power/display/hardware references).
+- Build/flash/power/pitfalls: [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md), [custom_app_guide.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/custom_app_guide.md),
+  [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md).

--- a/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_customization_at_command.md
+++ b/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_customization_at_command.md
@@ -22,20 +22,17 @@ url: https://wiki.seeedstudio.com/respeaker_clip_customization_at_command/
 
 # Customization: Add a Custom AT Command
 
-A concrete, end-to-end walkthrough of adding a **new** AT command to the Clip
-firmware. We add a trivial-but-real command, `AT+ECHO=<msg>`, that replies:
+A concrete, end-to-end walkthrough of adding a **new** AT command to the Clip firmware. We add a trivial-but-real command, `AT+ECHO=<msg>`, that replies:
 
 ```json
 {"ok":true,"data":{"echo":"<msg>"}}\n
 ```
 
-The same recipe scales to real commands that touch config, storage, audio, or
-the event system.
+The same recipe scales to real commands that touch config, storage, audio, or the event system.
 
 ## AI prompt
 
-You can copy this prompt into an AI coding agent to reproduce the same
-customization workflow in the firmware repository:
+You can copy this prompt into an AI coding agent to reproduce the same customization workflow in the firmware repository:
 
 ```text
 You are working in the reSpeaker Clip firmware repository.
@@ -90,9 +87,7 @@ AT+ECHO=          -> {"ok":false,"msg":"Missing message"}
 AT+ECHO           -> {"ok":false,"msg":"Use AT+ECHO=<msg>"}
 ```
 
-It is intentionally minimal: one SET command with a small EXEC usage hint, no
-side effects, verifiable on all three transports. `ECHO` does not collide with
-any registered command (see the registry in `at_commands_register()` below).
+It is intentionally minimal: one SET command with a small EXEC usage hint, no side effects, verifiable on all three transports. `ECHO` does not collide with any registered command (see the registry in `at_commands_register()` below).
 
 ## 2. Current data flow
 
@@ -111,21 +106,12 @@ transport (BLE / UDP / USB CDC)
 
 Two points matter for the customizer:
 
-- **Parsing is shared.** `parse_command()` (at_server.c) owns the `AT+NAME=args`
-  grammar and the `=`, `?` type detection. You never parse the `AT+` prefix
-  yourself — your handler receives `ctx->args` already split out.
-- **Responses are auto-routed.** The `SEND_RESPONSE()` macro in
-  `at_server.c` dispatches by the command's originating transport:
-  `TRANSPORT_TYPE_USB` -> `usb_cdc_send_response()`,
-  `TRANSPORT_TYPE_UDP` -> `transport_udp_send_response()`,
-  otherwise -> `transport_send_to(item->transport_type, ...)`. Your handler
-  only fills the response buffer; it does **no** transport work, and the same
-  JSON goes out identically over BLE, UDP, and USB.
+- **Parsing is shared.** `parse_command()` (at_server.c) owns the `AT+NAME=args` grammar and the `=`, `?` type detection. You never parse the `AT+` prefix yourself — your handler receives `ctx->args` already split out.
+- **Responses are auto-routed.** The `SEND_RESPONSE()` macro in `at_server.c` dispatches by the command's originating transport: `TRANSPORT_TYPE_USB` -> `usb_cdc_send_response()`, `TRANSPORT_TYPE_UDP` -> `transport_udp_send_response()`, otherwise -> `transport_send_to(item->transport_type, ...)`. Your handler only fills the response buffer; it does **no** transport work, and the same JSON goes out identically over BLE, UDP, and USB.
 
 ## 3. Extension point: the registration pattern
 
-Everything below is quoted from real source. The contract lives in
-`applications/clip/include/at_server.h`.
+Everything below is quoted from real source. The contract lives in `applications/clip/include/at_server.h`.
 
 ### 3.1 The handler signature
 
@@ -146,10 +132,7 @@ struct at_cmd_ctx {
 };
 ```
 
-`ctx->type` is one of `AT_CMD_TYPE_TEST` (0), `AT_CMD_TYPE_SET` (1),
-`AT_CMD_TYPE_EXEC` (2) — also `AT_CMD_TYPE_READ` (3, same as TEST). Args live
-in `ctx->args` (already past the `=`). A real handler using exactly this shape
-is `cmd_mode_handler` (at_commands.c:422):
+`ctx->type` is one of `AT_CMD_TYPE_TEST` (0), `AT_CMD_TYPE_SET` (1), `AT_CMD_TYPE_EXEC` (2) — also `AT_CMD_TYPE_READ` (3, same as TEST). Args live in `ctx->args` (already past the `=`). A real handler using exactly this shape is `cmd_mode_handler` (at_commands.c:422):
 
 ```c
 static int cmd_mode_handler(struct at_cmd_ctx *ctx, char *response, size_t len)
@@ -184,16 +167,10 @@ Behavior (read from its body):
 
 - Emits `{"ok":true` or `{"ok":false`.
 - If `message` is non-NULL, appends `,"msg":"<message>"`.
-- If `data` is non-NULL, appends `,"data":<data>` **verbatim** — `data` must
-  be a **complete JSON object** you formatted yourself (e.g. `{"echo":"hello"}`),
-  **not** a bare value or a format string. This is the common gotcha.
-- Closes with `}\n` and returns the total length; returns `AT_ERR_NOMEM` on
-  truncation. The server thread treats `ret < 0` as an error and substitutes
-  `at_server_err_msg(-ret)`.
+- If `data` is non-NULL, appends `,"data":<data>` **verbatim** — `data` must be a **complete JSON object** you formatted yourself (e.g. `{"echo":"hello"}`), **not** a bare value or a format string. This is the common gotcha.
+- Closes with `}\n` and returns the total length; returns `AT_ERR_NOMEM` on truncation. The server thread treats `ret < 0` as an error and substitutes `at_server_err_msg(-ret)`.
 
-So the response shape is fixed: success -> `{"ok":true,...,"data":{...}}`,
-failure -> `{"ok":false,...,"msg":"..."}`. There are no numeric error codes and
-no `error` field (see [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md)).
+So the response shape is fixed: success -> `{"ok":true,...,"data":{...}}`, failure -> `{"ok":false,...,"msg":"..."}`. There are no numeric error codes and no `error` field (see [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md)).
 
 ### 3.3 The command struct and registration
 
@@ -240,9 +217,7 @@ Only one source file: `applications/clip/src/at_commands.c`.
 
 ### 4.1 Add the handler
 
-Place it among the other `static int cmd_*_handler(...)` definitions (the
-existing handlers sit above `at_commands_register()`). Modeled on
-`cmd_mode_handler`:
+Place it among the other `static int cmd_*_handler(...)` definitions (the existing handlers sit above `at_commands_register()`). Modeled on `cmd_mode_handler`:
 
 ```c
 /* ECHO Command Handler - customization example.
@@ -265,18 +240,11 @@ static int cmd_echo_handler(struct at_cmd_ctx *ctx, char *response, size_t len)
 }
 ```
 
-> **Gotcha for real commands:** `ctx->args` is raw user input. Interpolating it
-> with `%s` (as the trivial example does) lets a `"` in the message break the
-> JSON. For any command that accepts free-form strings, validate/escape the
-> input first. The shipped commands that use `%s` (e.g. `MODE`, `LOG`) do so
-> only against a fixed enumeration they already checked.
+> **Gotcha for real commands:** `ctx->args` is raw user input. Interpolating it with `%s` (as the trivial example does) lets a `"` in the message break the JSON. For any command that accepts free-form strings, validate/escape the input first. The shipped commands that use `%s` (e.g. `MODE`, `LOG`) do so only against a fixed enumeration they already checked.
 
 ### 4.2 Register it
 
-Inside `at_commands_register(void)` (at_commands.c:1761) — the single init
-function that registers every command and is itself called once from
-`main.c` (`at_commands_register()` at main.c:286). Add the block alongside the
-others (e.g. right after the `LOG` block near at_commands.c:2030):
+Inside `at_commands_register(void)` (at_commands.c:1761) — the single init function that registers every command and is itself called once from `main.c` (`at_commands_register()` at main.c:286). Add the block alongside the others (e.g. right after the `LOG` block near at_commands.c:2030):
 
 ```c
 /* ECHO - echo a message back (customization example) */
@@ -289,33 +257,21 @@ err = at_server_register_cmd(&echo_cmd);
 if (err) return err;
 ```
 
-`AT_CMD_EXEC` is required because the handler intentionally returns a friendly
-usage message for bare `AT+ECHO`. If the registration only uses `AT_CMD_SET`,
-the dispatcher rejects `AT+ECHO` before the handler can run. Because the server
-auto-routes the response (Section 2), no BLE/UDP/USB code changes are needed.
+`AT_CMD_EXEC` is required because the handler intentionally returns a friendly usage message for bare `AT+ECHO`. If the registration only uses `AT_CMD_SET`, the dispatcher rejects `AT+ECHO` before the handler can run. Because the server auto-routes the response (Section 2), no BLE/UDP/USB code changes are needed.
 
 ## 5. Compatibility impact
 
-Adding a command is **additive** — existing commands and their JSON shapes are
-untouched. Keep the response contract intact:
+Adding a command is **additive** — existing commands and their JSON shapes are untouched. Keep the response contract intact:
 
 - Success: `{"ok":true,"data":{...}}`
 - Failure: `{"ok":false,"msg":"..."}`
-- No numeric error codes, no request ID, no `error` field. (See
-  [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md).)
+- No numeric error codes, no request ID, no `error` field. (See [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md).)
 
-If the new command should also be reachable from the host tooling, you need
-**Python SDK parity**, not just firmware. Per the `skills/clip-sdk/` rule, read
-the current `at_commands.c` registrations before changing the SDK, and treat
-`docs/protocol.md` + firmware source as the protocol contract — update both the
-SDK (in `sdk/`) and `protocol.md` when the firmware contract changes. Do not
-emulate removed legacy commands (`BITRATE`, `COMPLEXITY`, `NOISE`, `AGC`,
-`DEREVERB`, `PURGE`).
+If the new command should also be reachable from the host tooling, you need **Python SDK parity**, not just firmware. Per the `skills/clip-sdk/` rule, read the current `at_commands.c` registrations before changing the SDK, and treat `docs/protocol.md` + firmware source as the protocol contract — update both the SDK (in `sdk/`) and `protocol.md` when the firmware contract changes. Do not emulate removed legacy commands (`BITRATE`, `COMPLEXITY`, `NOISE`, `AGC`, `DEREVERB`, `PURGE`).
 
 ## 6. Build
 
-Source the NCS v3.3.0 environment, set the module path as an env var (Kconfig
-discovery runs before CMake), then build:
+Source the NCS v3.3.0 environment, set the module path as an env var (Kconfig discovery runs before CMake), then build:
 
 ```sh
 source ~/ncs/v3.3.0/zephyr/zephyr-env.sh
@@ -324,13 +280,11 @@ export ZEPHYR_EXTRA_MODULES=$(pwd)
 west build --build-dir build-clip --pristine --board clip/nrf5340/cpuapp applications/clip
 ```
 
-Per `CLAUDE.md`, the project builds with **zero warnings** — fix any compiler
-warning before committing. (The handler above introduces none.)
+Per `CLAUDE.md`, the project builds with **zero warnings** — fix any compiler warning before committing. (The handler above introduces none.)
 
 ## 7. On-device verify
 
-Flash (note: `west flash --reset` does not work on this board — reset
-separately):
+Flash (note: `west flash --reset` does not work on this board — reset separately):
 
 ```sh
 west flash --build-dir build-clip && nrfutil device reset
@@ -349,41 +303,42 @@ AT+ECHO           -> {"ok":false,"msg":"Use AT+ECHO=<msg>"}
 AT+ECHO=          -> {"ok":false,"msg":"Missing message"}
 ```
 
-**UDP** (WiFi AP mode — send `AT+WIFI=on` over BLE first, then join the returned
-SSID/password and target `192.168.4.1:8089`):
+**UDP** (WiFi AP mode — send `AT+WIFI=on` over BLE first, then join the returned SSID/password and target `192.168.4.1:8089`):
 
 ```sh
 python applications/clip/tests/tools/udp_terminal.py
 AT+ECHO=hello
 ```
 
-**USB CDC** (open the CDC-ACM serial port; USB must be enabled first via
-`AT+USB=on` over BLE, or hold the user button while plugging in):
+**USB CDC** (open the CDC-ACM serial port; USB must be enabled first via `AT+USB=on` over BLE, or hold the user button while plugging in):
 
 ```sh
 AT+ECHO=hello
 ```
 
-The response string must match byte-for-byte across all three. Also confirm no
-existing command regressed — e.g. `AT+GSTAT`, `AT+MODE?`, `AT+VERSION`.
+The response string must match byte-for-byte across all three. Also confirm no existing command regressed — e.g. `AT+GSTAT`, `AT+MODE?`, `AT+VERSION`.
 
 ## 8. Recovery
 
-If the new build misbehaves, recover over USB serial DFU (1200-baud trigger
-into MCUboot recovery, PID `0x8069`), BLE OTA, or a programmer — see
-[usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md). The bootloader partition is never touched by an app
-OTA; the signature is verified by MCUboot.
+If the new build misbehaves, recover over USB serial DFU (1200-baud trigger into MCUboot recovery, PID `0x8069`), BLE OTA, or a programmer — see [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md). The bootloader partition is never touched by an app OTA; the signature is verified by MCUboot.
 
 ## Related
 
-- Source: [at_commands.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_commands.c) (handlers + `at_commands_register()`),
-  [at_server.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_server.c) (`parse_command`,
-  `at_server_register_cmd`, `SEND_RESPONSE`), [at_server.h](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/include/at_server.h)
-  (struct/flag/typedef contract).
-- Protocol: [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md) (AT command spec + response contract),
-  [architecture.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/architecture.md) (transport/event system).
-- Python parity: [skills/clip-sdk/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-sdk/) (SDK source in `sdk/`,
-  command-registration/protocol-doc rules), [skills/clip-dev/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/)
-  (firmware-dev skill — audio/build/ble-at/storage/wifi-udp/mcuboot/power/display/hardware references).
-- Build/flash/power/pitfalls: [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md), [custom_app_guide.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/custom_app_guide.md),
-  [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md).
+- Source: [at_commands.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_commands.c) (handlers + `at_commands_register()`), [at_server.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_server.c) (`parse_command`, `at_server_register_cmd`, `SEND_RESPONSE`), [at_server.h](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/include/at_server.h) (struct/flag/typedef contract).
+- Protocol: [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md) (AT command spec + response contract), [architecture.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/architecture.md) (transport/event system).
+- Python parity: [skills/clip-sdk/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-sdk/) (SDK source in `sdk/`, command-registration/protocol-doc rules), [skills/clip-dev/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/) (firmware-dev skill — audio/build/ble-at/storage/wifi-udp/mcuboot/power/display/hardware references).
+- Build/flash/power/pitfalls: [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md), [custom_app_guide.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/custom_app_guide.md), [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md).
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="button_tech_support_container">
+<a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+<a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+</div>
+
+<div class="button_tech_support_container">
+<a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+<a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+</div>

--- a/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_firmware_development_guide.md
+++ b/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_firmware_development_guide.md
@@ -1,0 +1,641 @@
+---
+description: "The comprehensive reference for the reSpeaker Clip device-side firmware: system architecture, the AT/GATT/UDP protocol, build profiles, firmware update and recovery, validation and debugging, and production release — each fact in one place."
+title: reSpeaker Clip Firmware Development Guide
+keywords:
+  - reSpeaker clip
+  - firmware
+  - sdk
+  - development
+  - guide
+  - architecture
+  - protocol
+image: https://files.seeedstudio.com/wiki/reSpeaker_Clip/clip-banner.jpg
+slug: /respeaker_clip_firmware_development_guide
+aliases:
+  - /respeaker_clip_firmware_architecture
+  - /respeaker_clip_firmware_protocol
+  - /respeaker_clip_firmware_update_recovery
+  - /respeaker_clip_firmware_validation
+  - /respeaker_clip_firmware_production_release
+sku: 100020126
+last_update:
+  date: 07/28/2026
+  author: Ray
+createdAt: '2026-07-28'
+updatedAt: '2026-07-28'
+url: https://wiki.seeedstudio.com/respeaker_clip_firmware_development_guide/
+---
+
+# reSpeaker Clip Firmware Development Guide
+
+The comprehensive reference for the reSpeaker Clip device-side firmware: how it
+is put together, the AT/GATT/UDP protocol it speaks, how it is built, updated,
+recovered, validated, and shipped. For the build-to-smoke-test path from a clean
+machine, see [Getting Started with the reSpeaker Clip Firmware SDK](./respeaker_clip_firmware_quick_start.md);
+for full build/flash/power/pitfalls, see [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md).
+
+The checked-out firmware source is authoritative; this guide summarizes it.
+When they disagree, the source wins.
+
+## Introduction
+
+The Firmware SDK is an event-driven Zephyr RTOS application on the Nordic
+nRF5340 (application core + network core) with a PDM microphone array, BLE,
+Wi-Fi AP (nRF7002), USB, SD storage, and an OLED. It is for developers
+modifying device-side behavior. This guide covers the design and the operational
+reference (protocol, update, validation, production) in one place so that each
+fact has exactly one home — cross-references point back here rather than
+duplicating.
+
+## System Architecture
+
+### Layered Architecture
+
+The firmware is organized in five layers, each depending only on the layer below:
+
+| Layer | Responsibility | Key source |
+|-------|----------------|------------|
+| **App / event** | State machine, UI, button, the single place side effects happen | `clip_event.c`, `display.c`, `button.c`, `main.c` |
+| **Service / transport-transfer-config** | Moving bytes (BLE/UDP/USB), file transfer engine, persistent config | `transport.c`, `transport_ble.c`, `transport_udp.c`, `usb_cdc.c`, `transfer.c`, `config.c` |
+| **Processing / audio** | PDM capture → DSP → Opus → framed file writes | `audio.c`, `storage.c` |
+| **HAL / drivers** | Board devices: OLED, PMIC, mic/regulators, SPI flash, SD, WiFi/BLE radio | `boards/seeed/clip/`, `drivers/`, `battery.c`, `haptic.c` |
+| **Zephyr kernel** | Threads, message queues, semaphores, mutexes, power management | NCS v3.3.0 |
+
+The invariant: **the app layer is the only place that mutates state and triggers
+side effects.** Button presses and AT commands do not start the mic or write the
+SD card directly — they post an event, and `clip_event.c` decides whether it is
+legal in the current state and executes it.
+
+A request flows: `button ISR` / `AT command` → `clip_post_event[_sync]()` →
+`[k_msgq]` → `clip_event_process()` (main thread) → `execute_transition()` →
+side effects (`audio_*`, `storage_*`, `display_*`, `haptic_*`, `ble_notify_*`).
+Buttons post async (`K_NO_WAIT`, ISR-safe); AT commands post sync (block on a
+per-event semaphore so `AT+START` can return the session id synchronously).
+
+### Event and State Model
+
+The dispatcher in `clip_event.c` is a table-driven state machine:
+
+- `clip_post_event(event)` — async, non-blocking, ISR-safe; drops if the 8-slot
+  queue is full.
+- `clip_post_event_sync(event, &info)` — blocking; returns `OK`/`INVALID`/
+  `BUSY`/`ERROR` through `info`.
+
+States: `UNINITIALIZED → IDLE → RECORDING → TRANSMITTING / WIFI_SYNC → IDLE`,
+plus `PAUSED`, `ERROR`, `OTA`. `transition_table[current_state][event]` returns
+a next state, `TRANS_SAME` (stay, e.g. `MARK`), or `TRANS_INVALID` (reject). Two
+pre-gated rejections: `START` while `WIFI_SYNC` ("WiFi blocked"), `START` while
+USB MSC exposes the SD ("USB blocked" — mounting over USB while writing would
+corrupt FAT). State is committed only in `execute_transition()` via
+`atomic_set(&g_state, new)` — the one place state changes.
+
+Notable side effects: `START` calls `storage_ensure_mounted()`, refuses if full,
+then `audio_start_recording(AUDIO_MODE_MERGE)`. `STOP` waits ≤5 s for the audio
+thread to flush/close; if the SD is busy, stop commits `IDLE` anyway so the
+machine never deadlocks in `RECORDING` (the recording tail may be cut).
+`POWER_OFF_EXEC` cancels any active transfer (bounded wait), stops a recording,
+saves fuel-gauge state, puts the PMIC into ship mode.
+
+### Thread Model
+
+Five application threads (Zephyr priorities: lower number = higher priority,
+preemptible at 0+; Bluetooth RX runs higher still):
+
+| Thread | Pri | Stack | Role |
+|--------|-----|-------|------|
+| **Main** | (main) | — | Event loop `clip_event_wait()`→`clip_event_process()`, UI, time. Waits `K_FOREVER` idle or `K_MSEC(1000)` recording. |
+| **Audio** `audio_rec` | 0 | 32768 | PDM read → DSP → Opus → storage. Highest-priority app thread (20 ms Opus deadline is hard). |
+| **Transfer** | 5 | 16384 | File transfer engine: reads SD, sends via transport, retransmits. |
+| **UDP server** | 5 | 4096 | Wi-Fi UDP socket server (port 8089). |
+| **AT server** | 7 | 4096 | Parses AT on BLE/UDP/USB, posts sync events, sends JSON. |
+
+Synchronization pattern: **volatile/atomic flags** for "should I stop?"
+(`transfer_cancel_requested`, `pause_requested`), **semaphores** for "are you
+done?" (`stop_done_sem`, `file_closed_sem`, `transfer_trigger_sem`), **mutexes**
+for data structures (`audio_state_mutex`, `sd_lifecycle_mutex`,
+`session_json_mutex`, `transport_lock`), **one message queue** for the
+producer→consumer path that matters (`clip_ev_msgq`, events → main). A
+`k_mem_slab` of 32 × 1280 B buffers gives 640 ms of DMIC queue depth to absorb
+scheduling jitter (including BT RX preemption).
+
+## Audio and Recording Architecture
+
+### Audio Pipeline
+
+Per 20 ms frame: `dmic_read()` (L+R stereo, 1280 B) → `process_pcm_frame()`
+(merge + DSP, mode-dependent) → `opus_encode()` (≤4000 B packet) →
+`storage_write_frame()` (2-byte length-prefixed, 4 KiB buffered writes).
+
+Constants (`audio.h`): 16 kHz, 16-bit, 2-channel PDM; 20 ms frames → 320
+samples/frame, 1280 B/block; 32 DMIC buffers (640 ms queue).
+
+### Recording Modes
+
+> Older docs describe `MODE_NORMAL` as **stereo**. That is wrong. Both modes
+> record **mono**.
+
+- **Both modes** record mono via an L+R merge. `clip_event.c` hardcodes
+  `audio_start_recording(AUDIO_MODE_MERGE)`. `MODE_NORMAL` is not stereo — the
+  name is legacy.
+- **`MODE_NORMAL`** (default): delay-aligned L+R merge → hand-rolled 100 Hz
+  high-pass → integer AGC (envelope + gain computer + smoother) → soft limiter.
+  **No SpeexDSP.**
+- **`MODE_ENHANCED`**: the same merge + hand-rolled DSP, **plus SpeexDSP** noise
+  suppression + dereverberation, gated on `mode == ENHANCED && noise_suppress > 0`
+  (`audio.c:506`). SpeexDSP AGC is *not* used (the build is `FIXED_POINT`; a
+  float FFT AGC would cost ~15 ms/frame; the integer AGC replaces it).
+- The merge step cross-correlates L vs R over lags \{−1, 0, +1\} (2.85 cm mic
+  spacing → ≤1 sample ITD at 16 kHz) and delay-aligns before summing, preventing
+  comb filtering. The AGC is a classic compressor: ~30 ms attack / ~300 ms
+  release, target ≈−14.7 dBFS, gain clamped ±12/24 dB, soft limiter (knee −2
+  dBFS, hard limit −0.5 dBFS).
+- Opus: `OPUS_APPLICATION_AUDIO` (preserves fricatives better than VOIP for STT),
+  VBR unconstrained, voice signal hint, 16-bit depth, DTX/FEC/packet-loss off.
+  Bitrate/complexity are **per-mode Kconfig** (`CLIP_NORMAL_*`/`CLIP_ENHANCED_*`),
+  not runtime-settable. Encoder + SpeexDSP state are cached, reinitialized only
+  when parameters change.
+- Set the mode with `AT+MODE=normal|enhanced` (persisted) or `AT+START
+  mode=enhanced` (session-only, not persisted).
+
+### Session, Chunking, and Storage Model
+
+Each recording is one **session** with a 14-digit `session_id`:
+`YYYYMMDDHHMMSS` (UTC) when the clock is synced, else `0` + 13 uptime digits.
+The 14-digit form is enforced everywhere (`validate_session_id`) because the
+storage layout shards it into path components.
+
+A session is a directory tree: `session.json` (metadata: id, duration, files,
+synced, size, channels, sample_rate, mode), `marks.bin` (binary bookmarks:
+"BMRK" magic + count + offsets), and chunk files `0/0001.opus`, `0/0002.opus` …
+`1/0101.opus` (group = (file_index−1)/100, 100 files per subdir). Opus files are
+**length-prefixed frame streams** (2-byte LE length + packet, not OGG); a 4 KiB
+write buffer coalesces frames before `fs_write`.
+
+Segment chunking: **300 s per segment when not syncing**
+(`CLIP_AUDIO_SEGMENT_DURATION_NO_SYNC`), **60 s during an active transfer**
+(`CLIP_AUDIO_SEGMENT_DURATION_SYNC`) — when recording *while* transferring
+(continuous mode), the transfer thread can only read a closed file, so 60 s caps
+the client's wait for the next file; if sync starts mid-file and the current
+file already exceeds 60 s, the engine slices immediately (`audio.c:868`). Each
+`PAUSE`/`RESUME` cycle also opens a new file. `session.json`'s `synced` field
+tracks acknowledged files so a download resumes from the first unsynced file.
+
+**Storage:** microSD (FAT32, `/SD:`) holds recordings under `/SD:/REC/` in a
+bucket layout sharding the session id (`/SD:/REC/<YYYYMMDD>/<HH>/<MM>/<SS>/…`).
+External 8 MiB SPI flash (LittleFS, ~6.8 MiB) holds settings (`/lfs/settings/run`)
+and OTA slots — separate from the SD so corrupt settings or an interrupted OTA
+never take recordings down. The SD is **lazily remounted** via
+`storage_ensure_mounted()` and **idle power-gated** after `CLIP_SD_IDLE_DELAY_MS`
+(45 s) when genuinely idle (checked under lock to close the TOCTOU with a
+recording/transfer starting mid-check).
+
+### Power Management
+
+Battery device (170 mAh "240" cell, NPM1300 + nRF Fuel Gauge); idle current is
+the dominant constraint. Production build at the 3V3 rail:
+
+| Source | Behavior | Cost |
+|--------|----------|------|
+| nRF5340 main + radio regulators | DCDC (`NRF5X_REG_MODE_DCDC`) | ~500–600 µA vs LDO |
+| SD card | Idle power-gated after 45 s | ~0 when idle |
+| Debug UART console | UARTE stays enabled between prints | **~570 µA** leak |
+| BLE slow advertising | ~1 s interval | ~0.1 mA averaged |
+| nRF70 QSPI | `CONFIG_NRF70_QSPI_LOW_POWER` when WiFi unused | minimal |
+
+**Production idle ≈ 170 µA.** The largest leak after the regulators and SD were
+fixed is the **debug UART console** (~570 µA); the `production` snippet disables
+the console + UART log backend (`CONFIG_CONSOLE=n`, `CONFIG_UART_CONSOLE=n`,
+`CONFIG_LOG_BACKEND_UART=n`), which is what reaches ~170 µA. `CONFIG_PM_DEVICE_RUNTIME=y`
+auto-suspends UART/I2C/SPI drivers when idle. Recording/transfer briefly raise
+current (CPU boost to 128 MHz, reference-counted; mic + SD rail on; released on
+completion).
+
+## Communication Protocol
+
+### BLE GATT Service
+
+| Characteristic | UUID (suffix of `6E40xxxx-B5A3-F393-E0A9-E50E24DCCA9E`) | Role |
+|---|---|---|
+| Service | `0001` | The reSpeaker Clip service |
+| Command Receive | `0002` | Host writes AT commands here |
+| Response Send | `0003` | Device notifies JSON responses |
+| File Data | `0004` | Device notifies binary file-transfer frames |
+| Audio Visualization | `0005` | Device notifies recording energy levels |
+
+### AT Command Grammar
+
+| Type | Format | Example | Notes |
+|---|---|---|---|
+| EXEC | `AT+XX` | `AT+GSTAT` | Action / default read |
+| SET | `AT+XX=<value>` | `AT+MODE=enhanced` | Set a parameter / act with args |
+| READ | `AT+XX?` | `AT+MODE?` | Query current value |
+
+Parsing is shared: `parse_command()` (in `at_server.c`) owns the `AT+NAME=args`
+grammar and the `=`/`?` type detection; handlers receive `ctx->args` already
+split (past the `=`). `AT+LIST?2&10` is a paginated read.
+
+### JSON Response Contract
+
+- Success: `{"ok":true,"data":{...}}`
+- Failure: `{"ok":false,"msg":"..."}`
+- **No numeric error codes, no `error` field, no request ID.** Failures use
+  `msg`. The same JSON goes out identically over BLE, UDP, and USB (routed by the
+  command's originating transport via the `SEND_RESPONSE()` macro — your handler
+  only fills the response buffer).
+
+### Registered Command Reference
+
+The registered commands live in `applications/clip/src/at_commands.c` (the
+`.name = "..."` table). Verified set:
+
+| Group | Commands |
+|---|---|
+| Device status | `GSTAT`, `BATT`, `DEVICE`, `VERSION` |
+| Recording | `START`, `STOP`, `PAUSE`, `RESUME`, `MARK` |
+| File management | `LIST`, `MARKS`, `DOWNLOAD`, `CANCEL`, `DELETE` |
+| Config | `MODE`, `AUTODEL`, `BRIGHTNESS`, `TIME`, `NAME` |
+| Connectivity | `WIFI`, `WIFICFG`, `USB`, `PAIR`, `DFU` |
+| Maintenance | `LOG`, `STORAGE`, `FORMAT`, `REBOOT`, `POWEROFF`, `FACTORY` |
+
+**Removed legacy — do not document as available:** `BITRATE`, `COMPLEXITY`,
+`NOISE`, `AGC`, `DEREVERB`, `PURGE`. Noise suppression / dereverb are boot-time
+Kconfig defaults (`CLIP_DEFAULT_NOISE`, `CLIP_DEFAULT_DEREVERB`), persisted in
+`config.c`, but have **no runtime AT command**; AGC is hand-rolled, always-on,
+not configurable. When you change an AT response, command, or transfer frame,
+update `docs/protocol.md` and `sdk/` in the same change.
+
+### UDP Frame Types
+
+Wi-Fi UDP file transfer uses a binary frame protocol (port 8089) with per-frame
+CRC32:
+
+| Type | Value | Structure |
+|---|---|---|
+| `DATA` | `0x01` | type(1) + seq(2) + len(2) + data |
+| `FILE_ACK` | `0x03` | type(1) + status(1) + received_count(2) + crc32(4) |
+| `FILE_START` | `0x10` | type(1) + fn_len(1) + filename + file_size(4) |
+| `FILE_END` | `0x11` | type(1) + crc32(4) |
+| `TRANSFER_DONE` | `0x12` | type(1) + sid_len(1) + session_id + file_count(4) |
+| `AT_RESP` | `0x20` | AT response carried over UDP |
+| `HEARTBEAT` | `0x30` | keepalive |
+
+**BLE has no per-frame CRC** (the link layer guarantees delivery) — only the
+full-file CRC32 in `FILE_END` for end-to-end check. UDP has per-frame CRC32 +
+`FILE_ACK` with a **selective-repeat bitmap NACK**: the client reports which
+frames it is missing as a bitmap and the engine resends only those, paced by
+`CLIP_UDP_REPAIR_PACE_US` (halves each retry round). A repair-pace that fails
+falls back to whole-file retransmit; `TRANSFER_MAX_FILE_RETRIES` (10) caps
+attempts before `ERROR`.
+
+### Session and File Addressing
+
+Host-visible session ids are exactly 14 decimal digits `YYYYMMDDHHMMSS`; physical
+FAT paths are never exposed in the protocol. `AT+DOWNLOAD` accepts `session` or
+`session:NNNN.opus`. Validate user-controlled arguments before storage, path, or
+transfer access.
+
+## Firmware Configuration and Build Profiles
+
+### Stock and Development Builds
+
+The default (no-snippet) debug build keeps the UART console on and writes logs to
+`/SD:/LOG` (rotating 64 KiB files) at INF level (`CONFIG_LOG_BACKEND_FS=y`).
+Build:
+
+```sh
+source ~/ncs/v3.3.0/zephyr/zephyr-env.sh
+export ZEPHYR_EXTRA_MODULES=$PWD   # env var, not -D — Kconfig discovery runs before CMake
+west build --build-dir build-clip --board clip/nrf5340/cpuapp applications/clip
+# pristine (required after MCUboot/devicetree/sysbuild/partition changes):
+west build --build-dir build-clip --pristine --board clip/nrf5340/cpuapp applications/clip
+```
+
+Every app builds as a **sysbuild** (MCUboot + app core + net-core radio) by
+default; the board supplies the glue. Key `prj.conf` / devicetree / Kconfig
+knobs: feature switches, log levels, BLE/Wi-Fi/FS config; GPIO/I2C/SPI/PDM/PMIC/
+OLED mappings; buffer sizes, thread stacks, power policy.
+
+### Production Build
+
+Console + UART log off, idle ≈170 µA:
+
+```sh
+west build --build-dir build-clip-prod --board clip/nrf5340/cpuapp applications/clip \
+  -- -DSNIPPET_ROOT=$(pwd)/applications/clip -DSNIPPET=production
+```
+
+`SNIPPET_ROOT` must be absolute. The `production` snippet lives in
+`applications/clip/snippets/production/`. The project builds with **zero
+warnings** — fix every compiler warning before committing.
+
+## Firmware Update and Recovery
+
+### Update Method Selection
+
+| Scenario | Recommended | Package |
+|---|---|---|
+| End-user upgrade (enclosed device) | App BLE OTA or USB serial DFU | `*-signed.bin` / `*-ota.zip` |
+| Serial recovery (no app) | mcumgr serial | `*-signed.bin` |
+| Dev debug | `west flash` / J-Link | `merged.hex` |
+| Production flash | J-Link / programmer | full `merged.hex` + `merged_CPUNET.hex` |
+| App-core-only tweak | mcumgr serial | `*-signed.bin` (a `single.zip` is not yet shipped) |
+
+### USB Serial DFU
+
+The app keeps USB off by default — send `AT+USB=on` over BLE first (samples with
+default CDC auto-enable USB, or hold the user button while plugging in). Open the
+CDC-ACM port at **1200 baud** to trigger MCUboot serial recovery; a new port
+appears with **PID `0x8069`** (running app `0x0069`; the `0x8000` bit marks
+bootloader; both Seeed VID `0x2886`). Upload + reset:
+
+```sh
+nrfutil mcu-manager serial image-upload --firmware clip-<version>-signed.bin --serial-port /dev/ttyACMx
+nrfutil mcu-manager serial reset     --serial-port /dev/ttyACMx
+```
+
+MCUboot verifies the RSA signature and boots the new app; the bootloader
+partition is never touched.
+
+### BLE OTA
+
+```sh
+nrfutil mcu-manager ble image-upload --firmware clip-<version>-ota.zip --address <BLE-MAC>
+```
+
+Or use nRF Connect Device Manager / SenseCraft Voice on a phone.
+
+### J-Link
+
+For dev/production/when USB+BLE recovery fails:
+
+```sh
+nrfutil device program --firmware clip-<version>-merged.hex --serial-number <JLINK-SN>
+nrfutil device reset --serial-number <JLINK-SN>
+```
+
+### Package Manifest
+
+Each release should carry a manifest so users don't guess package ranges from
+filenames:
+
+```yaml
+firmware_version:
+hardware_revision:
+ncs_version:        # v3.3.0
+bootloader_version: # mcuboot
+app_core_version:
+net_core_version:
+package_type:       # debug | production
+included_partitions: # [mcuboot, app, netcore]
+upgrade_method:     # serial-dfu | ble-ota | programmer
+sha256:
+rollback_supported:
+```
+
+### Recovery Decision Tree
+
+```mermaid
+flowchart TD
+    A["Upgrade failed"] --> B{"App boots?"}
+    B -->|"yes"| C["Check version, retry OTA"]
+    B -->|"no"| D{"Enters recovery?"}
+    D -->|"yes"| E["USB serial DFU"]
+    D -->|"no"| F["J-Link full recovery"]
+    E --> G["Reboot + verify"]
+    F --> G
+```
+
+### Reset Command Matrix
+
+| Method | Command | When |
+|---|---|---|
+| mcumgr serial reset | `nrfutil mcu-manager serial reset --serial-port …` | After serial DFU |
+| BLE mcumgr reset | `nrfutil mcu-manager ble reset --address …` | After BLE OTA |
+| J-Link reset | `nrfutil device reset --serial-number <JLINK-SN>` | Dev/production |
+| west runner reset | `west flash --build-dir … && nrfutil device reset` | Dev — note `west flash --reset` does NOT work here |
+
+`--recover` erases **both cores** (clears the b0n access-port lock) — use only
+when net-core AP is locked, never routinely.
+
+### Safety Rules
+
+Never, unprepared: full-chip erase; UICR modify; overwrite the bootloader;
+partition-table change; flash a wrong-hardware-revision merged image; recover a
+production device without backing up its config.
+
+## Validation and Debugging
+
+### Regression Matrix by Change Type
+
+| Change | Must test |
+|---|---|
+| Audio pipeline | SNR, STOI, WER; buffer overflow; CPU; real-time (20 ms deadline) |
+| Opus | Decode; frame format; file size; transfer compat |
+| AT / GATT | Old commands; response format; error paths; Python SDK |
+| Filesystem | Long recording; power-loss; space-full; CRC |
+| BLE / Wi-Fi | Connect; fragmentation; resume; timeout |
+| Power | Idle; recording; Wi-Fi; wake |
+| Firmware update | OTA; recovery; version readback; rollback |
+
+### Audio Quality Metrics
+
+SNR (signal vs noise clarity), STOI (intelligibility), WER (ASR error rate — the
+business metric), THD (DSP/hardware distortion). Test scenarios: quiet
+near/far, office, café, car, street; both Normal and Enhanced; cover Chinese,
+English, digit sequences, silence.
+
+> **PESQ/STOI need a clean reference + alignment.** Do not compute them on
+> arbitrary field recordings and claim a conclusion — without a matched
+> reference, the number is not meaningful.
+
+### Serial, Logging, Storage, and Timing Debug
+
+```sh
+minicom -D /dev/ttyACM0 -b 921600   # ttyACM1 if a J-Link also connected
+```
+
+Log levels: `AT+LOG=off|info|debug` (debug default: info). `CONFIG_LOG_BACKEND_FS=y`
+writes to `/SD:/LOG` (rotating 64 KiB) for post-mortem; `AT+LOG=off` lets the SD
+idle power-gate. The audio thread prints DWT cycle-counter stats (`enc avg/min/max`,
+`dsp`) every 500 frames (10 s). Known pitfalls (`CLAUDE.md`): `%llu` not supported
+on nRF5340 (use `%u` + cast); UDP `sendto()` returns success even on silent TX
+drops; FAT directory order is not chronological; corrupt `/lfs/settings/run`
+blocks `settings_load` (watchdog wipes + reboots after 3 s).
+
+### Host-side Test Tools
+
+```sh
+python applications/clip/tests/tools/clip-cli.py status        # BLE default; --transport wifi
+python applications/clip/tests/tools/clip-cli.py record --duration 5
+python applications/clip/tests/tools/clip-cli.py list
+python applications/clip/tests/tools/clip-cli.py sync --session <id>
+python applications/clip/tests/tools/clip-cli.py terminal      # interactive AT shell
+python applications/clip/tests/tools/udp_sync.py --session <id>
+python applications/clip/tests/tools/decode_opus.py <file>.opus out.wav
+```
+
+**"Build passes" is not "hardware verified."** A clean compile says nothing about
+on-device behavior.
+
+## Production Release
+
+### Release Artifacts and Manifest
+
+Manual export today (tag-triggered `scripts/build_release.sh` +
+`.github/workflows/release.yml` are **not yet implemented**). Debug and
+production each produce four artifacts:
+
+| Artifact | Use |
+|---|---|
+| `merged.hex` | App-core full image (programmer / J-Link) |
+| `merged_CPUNET.hex` | Network-core full image |
+| `dfu_application.zip` (release name `*-ota.zip`) | mcumgr OTA package (BLE / USB serial) |
+| `clip/zephyr/zephyr.signed.bin` (release name `*-signed.bin`) | MCUboot-signed app image (USB serial DFU) |
+
+A `single.zip` (app-core-only) is **not yet shipped** — until `build_release.sh`
+lands, use `*-signed.bin` for app-only updates. Publish: add
+`docs/release_notes/v$VERSION.md`, commit, `git tag vX.Y.Z && git push origin
+vX.Y.Z` → CI builds the GitHub Release.
+
+### Signing Keys
+
+`boards/seeed/clip/sysbuild/root-rsa-2048.pem` is a **copy of the MCUboot
+default key**. Anyone with the public source can sign images for your devices.
+**Generate your own key for production** and keep the private half secret;
+rotate by replacing the key and re-flashing the bootloader.
+
+### CI
+
+`.github/workflows/firmware.yml` builds the clip app on push/PR to `main`
+(compilation check; applies the MCUboot patches + `west build`).
+`mobile-ci.yml` (analyze + unit tests, on PR) and `mobile-verify.yml` (debug APK
+/ iOS smoke, push + manual) cover `mobile/`.
+
+### Factory Programming and Test Firmware
+
+Each test image is a standalone sysbuild under `tests/<name>`, built like
+`west build --build-dir build-test --pristine --board clip/nrf5340/cpuapp
+tests/clip`. Tests **opt out of MCUboot** (factory/cert firmware, flashed
+directly via J-Link) via `SB_CONFIG_BOOTLOADER_NONE=y`:
+
+| Test | Purpose |
+|---|---|
+| `tests/clip` | Multi-image hardware test suite (hosts the `lfxo`/`hfxo` crystal-tuning shell) |
+| `tests/dtm` | BLE Direct Test Mode (RF conformance; 2-wire UART @19200) |
+| `tests/wifi_radio` | nRF70 Wi-Fi radio test (TX/RX, tone, IQ, FICR) |
+| `tests/otp` | nRF70 OTP programming (factory) |
+| `tests/re` | Reference-board bring-up |
+
+Mass flash uses `nrfutil device program --firmware …-merged.hex --serial-number
+<JLINK-SN>`.
+
+### Compatibility Rules
+
+- Keep the AT response shape: `{"ok":true,"data":{...}}` /
+  `{"ok":false,"msg":"..."}`. No numeric error codes, no `error` field.
+- Don't break the file format (length-prefixed Opus, `session.json` schema).
+- Update `docs/protocol.md` **and** `sdk/` whenever an AT response, command, or
+  transfer frame changes.
+- Don't auto-execute a full-chip erase; don't auto-flash a production device.
+- The firmware source is the source of truth.
+
+### NCS v3.2.1 to v3.3.0 Migration
+
+`main` migrated to **v3.3.0-only Kconfig** (e.g. the WPA3
+`..._WPA3_IMPLEMENTATION_NONE` choice) and will no longer build against NCS
+v3.2.1. The `ncs/v3.3.0` branch is an older diverged line (~12 commits behind
+`main`); local `master` is only the ancient initial import. Target NCS v3.3.0.
+
+## AI-Assisted Development
+
+The repo ships a firmware-dev skill at
+[`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/SKILL.md)
+for AI agents (Claude Code, etc.) that work on this firmware. It encodes the
+project's real constraints so an agent does not re-derive them — and does not
+guess facts that are easy to get wrong. **Use it; do not duplicate its rules
+into the docs.**
+
+For a complete, copyable example of AI-assisted AT command customization, see
+[Customization: Add a Custom AT Command](/respeaker_clip_customization_at_command/).
+That article shows how to prompt an AI agent to load the repository skill, add
+`AT+ECHO`, build the firmware, and validate the command on-device.
+
+**What the skill provides** — `SKILL.md` plus nine references under
+`skills/clip-dev/references/` (`audio`, `build-flash`, `ble-at`, `storage`,
+`wifi-udp`, `mcuboot`, `power`, `display`, `hardware`):
+
+- active NCS version, board sysbuild defaults, build/flash commands;
+- the **current AT command set** (registered in `at_commands.c`) and the
+  response contract `{"ok":true,"data":...}` / `{"ok":false,"msg":...}`;
+- the audio pipeline truth — both modes are mono L+R merge; **runtime commands
+  for bitrate, codec complexity, AGC, noise suppression, and dereverb do not
+  exist**;
+- power constraints (console leak, the `production` snippet, SD idle gating);
+- a firmware workflow: confirm the contract in source before editing docs or
+  clients, validate user-controlled args, flash only the requested image,
+  update `docs/protocol.md` + `sdk/` whenever an AT response changes.
+
+**How to load it.** In Claude Code the skill is auto-discovered; otherwise
+point the agent at the file:
+
+```
+@clip-dev
+Analyze how to add distinct haptic patterns for recording start vs stop.
+Give the modification plan first; do not edit code yet.
+```
+
+**Standard task template** — fill this in before asking an agent to change
+firmware:
+
+```markdown
+## Goal
+<device behavior to implement>
+
+## Baseline
+- Firmware commit/tag: v0.0.9
+- NCS version: v3.3.0
+- Board target: clip/nrf5340/cpuapp
+- Build config: debug | production
+
+## Constraints
+- Keep which AT/GATT interfaces compatible
+- New protocol fields allowed? (yes/no)
+- File format changes allowed? (yes/no)
+- Devicetree/Kconfig changes allowed? (yes/no)
+- MCUboot / partition table / signing key edits forbidden
+
+## Acceptance criteria
+- Firmware builds (pristine, zero new warnings)
+- Basic-SDK regression passes
+- Expected serial log
+- On-device behavior
+- RAM/Flash delta
+- Power or real-time constraint
+```
+
+**Safety rules the skill enforces.** Do not guess files, functions, Kconfig, or
+board targets — search the real source first. Do not infer a public interface
+from an internal module name. Do not modify MCUboot, the partition table, or
+signing keys without explicit confirmation. Do not auto-erase the whole chip or
+flash a production device. Do not break existing AT responses or file formats.
+"Build passes" is not "hardware verified" — claim only what was actually tested
+on a device. For audio/protocol changes, report CPU, buffer, flash, RAM, and
+output-format impact; for protocol changes, update the Python `sdk/` and
+`docs/protocol.md` in the same change.
+
+## Related Resources
+
+- [Getting Started with the reSpeaker Clip Firmware SDK](./respeaker_clip_firmware_quick_start.md) — build-to-smoke-test path
+- [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md) — full build/flash/power/pitfalls reference
+- [`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/) — firmware AI development skill
+- Source: [clip_event.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/clip_event.c) (state machine),
+  [audio.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/audio.c) (DSP/Opus),
+  [at_commands.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_commands.c) (AT registry),
+  [at_server.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_server.c) (parse/route),
+  [transfer.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/transfer.c) (transfer engine),
+  [transport.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/transport.c) (transport abstraction),
+  [storage.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/storage.c) (sessions/SD lifecycle),
+  [main.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/main.c) (init order)
+- [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md),
+  [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md),
+  [udp_protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/udp_protocol.md)

--- a/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_firmware_development_guide.md
+++ b/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_firmware_development_guide.md
@@ -11,12 +11,6 @@ keywords:
   - protocol
 image: https://files.seeedstudio.com/wiki/reSpeaker_Clip/clip-banner.jpg
 slug: /respeaker_clip_firmware_development_guide
-aliases:
-  - /respeaker_clip_firmware_architecture
-  - /respeaker_clip_firmware_protocol
-  - /respeaker_clip_firmware_update_recovery
-  - /respeaker_clip_firmware_validation
-  - /respeaker_clip_firmware_production_release
 sku: 100020126
 last_update:
   date: 07/28/2026
@@ -28,24 +22,13 @@ url: https://wiki.seeedstudio.com/respeaker_clip_firmware_development_guide/
 
 # reSpeaker Clip Firmware Development Guide
 
-The comprehensive reference for the reSpeaker Clip device-side firmware: how it
-is put together, the AT/GATT/UDP protocol it speaks, how it is built, updated,
-recovered, validated, and shipped. For the build-to-smoke-test path from a clean
-machine, see [Getting Started with the reSpeaker Clip Firmware SDK](./respeaker_clip_firmware_quick_start.md);
-for full build/flash/power/pitfalls, see [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md).
+The comprehensive reference for the reSpeaker Clip device-side firmware: how it is put together, the AT/GATT/UDP protocol it speaks, how it is built, updated, recovered, validated, and shipped. For the build-to-smoke-test path from a clean machine, see [Getting Started with the reSpeaker Clip Firmware SDK](./respeaker_clip_firmware_quick_start.md); for full build/flash/power/pitfalls, see [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md).
 
-The checked-out firmware source is authoritative; this guide summarizes it.
-When they disagree, the source wins.
+The checked-out firmware source is authoritative; this guide summarizes it. When they disagree, the source wins.
 
 ## Introduction
 
-The Firmware SDK is an event-driven Zephyr RTOS application on the Nordic
-nRF5340 (application core + network core) with a PDM microphone array, BLE,
-Wi-Fi AP (nRF7002), USB, SD storage, and an OLED. It is for developers
-modifying device-side behavior. This guide covers the design and the operational
-reference (protocol, update, validation, production) in one place so that each
-fact has exactly one home — cross-references point back here rather than
-duplicating.
+The Firmware SDK is an event-driven Zephyr RTOS application on the Nordic nRF5340 (application core + network core) with a PDM microphone array, BLE, Wi-Fi AP (nRF7002), USB, SD storage, and an OLED. It is for developers modifying device-side behavior. This guide covers the design and the operational reference (protocol, update, validation, production) in one place so that each fact has exactly one home — cross-references point back here rather than duplicating.
 
 ## System Architecture
 
@@ -61,45 +44,24 @@ The firmware is organized in five layers, each depending only on the layer below
 | **HAL / drivers** | Board devices: OLED, PMIC, mic/regulators, SPI flash, SD, WiFi/BLE radio | `boards/seeed/clip/`, `drivers/`, `battery.c`, `haptic.c` |
 | **Zephyr kernel** | Threads, message queues, semaphores, mutexes, power management | NCS v3.3.0 |
 
-The invariant: **the app layer is the only place that mutates state and triggers
-side effects.** Button presses and AT commands do not start the mic or write the
-SD card directly — they post an event, and `clip_event.c` decides whether it is
-legal in the current state and executes it.
+The invariant: **the app layer is the only place that mutates state and triggers side effects.** Button presses and AT commands do not start the mic or write the SD card directly — they post an event, and `clip_event.c` decides whether it is legal in the current state and executes it.
 
-A request flows: `button ISR` / `AT command` → `clip_post_event[_sync]()` →
-`[k_msgq]` → `clip_event_process()` (main thread) → `execute_transition()` →
-side effects (`audio_*`, `storage_*`, `display_*`, `haptic_*`, `ble_notify_*`).
-Buttons post async (`K_NO_WAIT`, ISR-safe); AT commands post sync (block on a
-per-event semaphore so `AT+START` can return the session id synchronously).
+A request flows: `button ISR` / `AT command` → `clip_post_event[_sync]()` → `[k_msgq]` → `clip_event_process()` (main thread) → `execute_transition()` → side effects (`audio_*`, `storage_*`, `display_*`, `haptic_*`, `ble_notify_*`). Buttons post async (`K_NO_WAIT`, ISR-safe); AT commands post sync (block on a per-event semaphore so `AT+START` can return the session id synchronously).
 
 ### Event and State Model
 
 The dispatcher in `clip_event.c` is a table-driven state machine:
 
-- `clip_post_event(event)` — async, non-blocking, ISR-safe; drops if the 8-slot
-  queue is full.
-- `clip_post_event_sync(event, &info)` — blocking; returns `OK`/`INVALID`/
-  `BUSY`/`ERROR` through `info`.
+- `clip_post_event(event)` — async, non-blocking, ISR-safe; drops if the 8-slot queue is full.
+- `clip_post_event_sync(event, &info)` — blocking; returns `OK`/`INVALID`/ `BUSY`/`ERROR` through `info`.
 
-States: `UNINITIALIZED → IDLE → RECORDING → TRANSMITTING / WIFI_SYNC → IDLE`,
-plus `PAUSED`, `ERROR`, `OTA`. `transition_table[current_state][event]` returns
-a next state, `TRANS_SAME` (stay, e.g. `MARK`), or `TRANS_INVALID` (reject). Two
-pre-gated rejections: `START` while `WIFI_SYNC` ("WiFi blocked"), `START` while
-USB MSC exposes the SD ("USB blocked" — mounting over USB while writing would
-corrupt FAT). State is committed only in `execute_transition()` via
-`atomic_set(&g_state, new)` — the one place state changes.
+States: `UNINITIALIZED → IDLE → RECORDING → TRANSMITTING / WIFI_SYNC → IDLE`, plus `PAUSED`, `ERROR`, `OTA`. `transition_table[current_state][event]` returns a next state, `TRANS_SAME` (stay, e.g. `MARK`), or `TRANS_INVALID` (reject). Two pre-gated rejections: `START` while `WIFI_SYNC` ("WiFi blocked"), `START` while USB MSC exposes the SD ("USB blocked" — mounting over USB while writing would corrupt FAT). State is committed only in `execute_transition()` via `atomic_set(&g_state, new)` — the one place state changes.
 
-Notable side effects: `START` calls `storage_ensure_mounted()`, refuses if full,
-then `audio_start_recording(AUDIO_MODE_MERGE)`. `STOP` waits ≤5 s for the audio
-thread to flush/close; if the SD is busy, stop commits `IDLE` anyway so the
-machine never deadlocks in `RECORDING` (the recording tail may be cut).
-`POWER_OFF_EXEC` cancels any active transfer (bounded wait), stops a recording,
-saves fuel-gauge state, puts the PMIC into ship mode.
+Notable side effects: `START` calls `storage_ensure_mounted()`, refuses if full, then `audio_start_recording(AUDIO_MODE_MERGE)`. `STOP` waits ≤5 s for the audio thread to flush/close; if the SD is busy, stop commits `IDLE` anyway so the machine never deadlocks in `RECORDING` (the recording tail may be cut). `POWER_OFF_EXEC` cancels any active transfer (bounded wait), stops a recording, saves fuel-gauge state, puts the PMIC into ship mode.
 
 ### Thread Model
 
-Five application threads (Zephyr priorities: lower number = higher priority,
-preemptible at 0+; Bluetooth RX runs higher still):
+Five application threads (Zephyr priorities: lower number = higher priority, preemptible at 0+; Bluetooth RX runs higher still):
 
 | Thread | Pri | Stack | Role |
 |--------|-----|-------|------|
@@ -109,90 +71,40 @@ preemptible at 0+; Bluetooth RX runs higher still):
 | **UDP server** | 5 | 4096 | Wi-Fi UDP socket server (port 8089). |
 | **AT server** | 7 | 4096 | Parses AT on BLE/UDP/USB, posts sync events, sends JSON. |
 
-Synchronization pattern: **volatile/atomic flags** for "should I stop?"
-(`transfer_cancel_requested`, `pause_requested`), **semaphores** for "are you
-done?" (`stop_done_sem`, `file_closed_sem`, `transfer_trigger_sem`), **mutexes**
-for data structures (`audio_state_mutex`, `sd_lifecycle_mutex`,
-`session_json_mutex`, `transport_lock`), **one message queue** for the
-producer→consumer path that matters (`clip_ev_msgq`, events → main). A
-`k_mem_slab` of 32 × 1280 B buffers gives 640 ms of DMIC queue depth to absorb
-scheduling jitter (including BT RX preemption).
+Synchronization pattern: **volatile/atomic flags** for "should I stop?" (`transfer_cancel_requested`, `pause_requested`), **semaphores** for "are you done?" (`stop_done_sem`, `file_closed_sem`, `transfer_trigger_sem`), **mutexes** for data structures (`audio_state_mutex`, `sd_lifecycle_mutex`, `session_json_mutex`, `transport_lock`), **one message queue** for the producer→consumer path that matters (`clip_ev_msgq`, events → main). A `k_mem_slab` of 32 × 1280 B buffers gives 640 ms of DMIC queue depth to absorb scheduling jitter (including BT RX preemption).
 
 ## Audio and Recording Architecture
 
 ### Audio Pipeline
 
-Per 20 ms frame: `dmic_read()` (L+R stereo, 1280 B) → `process_pcm_frame()`
-(merge + DSP, mode-dependent) → `opus_encode()` (≤4000 B packet) →
-`storage_write_frame()` (2-byte length-prefixed, 4 KiB buffered writes).
+Per 20 ms frame: `dmic_read()` (L+R stereo, 1280 B) → `process_pcm_frame()` (merge + DSP, mode-dependent) → `opus_encode()` (≤4000 B packet) → `storage_write_frame()` (2-byte length-prefixed, 4 KiB buffered writes).
 
-Constants (`audio.h`): 16 kHz, 16-bit, 2-channel PDM; 20 ms frames → 320
-samples/frame, 1280 B/block; 32 DMIC buffers (640 ms queue).
+Constants (`audio.h`): 16 kHz, 16-bit, 2-channel PDM; 20 ms frames → 320 samples/frame, 1280 B/block; 32 DMIC buffers (640 ms queue).
 
 ### Recording Modes
 
-> Older docs describe `MODE_NORMAL` as **stereo**. That is wrong. Both modes
-> record **mono**.
+> Older docs describe `MODE_NORMAL` as **stereo**. That is wrong. Both modes record **mono**.
 
-- **Both modes** record mono via an L+R merge. `clip_event.c` hardcodes
-  `audio_start_recording(AUDIO_MODE_MERGE)`. `MODE_NORMAL` is not stereo — the
-  name is legacy.
-- **`MODE_NORMAL`** (default): delay-aligned L+R merge → hand-rolled 100 Hz
-  high-pass → integer AGC (envelope + gain computer + smoother) → soft limiter.
-  **No SpeexDSP.**
-- **`MODE_ENHANCED`**: the same merge + hand-rolled DSP, **plus SpeexDSP** noise
-  suppression + dereverberation, gated on `mode == ENHANCED && noise_suppress > 0`
-  (`audio.c:506`). SpeexDSP AGC is *not* used (the build is `FIXED_POINT`; a
-  float FFT AGC would cost ~15 ms/frame; the integer AGC replaces it).
-- The merge step cross-correlates L vs R over lags \{−1, 0, +1\} (2.85 cm mic
-  spacing → ≤1 sample ITD at 16 kHz) and delay-aligns before summing, preventing
-  comb filtering. The AGC is a classic compressor: ~30 ms attack / ~300 ms
-  release, target ≈−14.7 dBFS, gain clamped ±12/24 dB, soft limiter (knee −2
-  dBFS, hard limit −0.5 dBFS).
-- Opus: `OPUS_APPLICATION_AUDIO` (preserves fricatives better than VOIP for STT),
-  VBR unconstrained, voice signal hint, 16-bit depth, DTX/FEC/packet-loss off.
-  Bitrate/complexity are **per-mode Kconfig** (`CLIP_NORMAL_*`/`CLIP_ENHANCED_*`),
-  not runtime-settable. Encoder + SpeexDSP state are cached, reinitialized only
-  when parameters change.
-- Set the mode with `AT+MODE=normal|enhanced` (persisted) or `AT+START
-  mode=enhanced` (session-only, not persisted).
+- **Both modes** record mono via an L+R merge. `clip_event.c` hardcodes `audio_start_recording(AUDIO_MODE_MERGE)`. `MODE_NORMAL` is not stereo — the name is legacy.
+- **`MODE_NORMAL`** (default): delay-aligned L+R merge → hand-rolled 100 Hz high-pass → integer AGC (envelope + gain computer + smoother) → soft limiter. **No SpeexDSP.**
+- **`MODE_ENHANCED`**: the same merge + hand-rolled DSP, **plus SpeexDSP** noise suppression + dereverberation, gated on `mode == ENHANCED && noise_suppress > 0` (`audio.c:506`). SpeexDSP AGC is *not* used (the build is `FIXED_POINT`; a float FFT AGC would cost ~15 ms/frame; the integer AGC replaces it).
+- The merge step cross-correlates L vs R over lags \{−1, 0, +1\} (2.85 cm mic spacing → ≤1 sample ITD at 16 kHz) and delay-aligns before summing, preventing comb filtering. The AGC is a classic compressor: ~30 ms attack / ~300 ms release, target ≈−14.7 dBFS, gain clamped ±12/24 dB, soft limiter (knee −2 dBFS, hard limit −0.5 dBFS).
+- Opus: `OPUS_APPLICATION_AUDIO` (preserves fricatives better than VOIP for STT), VBR unconstrained, voice signal hint, 16-bit depth, DTX/FEC/packet-loss off. Bitrate/complexity are **per-mode Kconfig** (`CLIP_NORMAL_*`/`CLIP_ENHANCED_*`), not runtime-settable. Encoder + SpeexDSP state are cached, reinitialized only when parameters change.
+- Set the mode with `AT+MODE=normal|enhanced` (persisted) or `AT+START mode=enhanced` (session-only, not persisted).
 
 ### Session, Chunking, and Storage Model
 
-Each recording is one **session** with a 14-digit `session_id`:
-`YYYYMMDDHHMMSS` (UTC) when the clock is synced, else `0` + 13 uptime digits.
-The 14-digit form is enforced everywhere (`validate_session_id`) because the
-storage layout shards it into path components.
+Each recording is one **session** with a 14-digit `session_id`: `YYYYMMDDHHMMSS` (UTC) when the clock is synced, else `0` + 13 uptime digits. The 14-digit form is enforced everywhere (`validate_session_id`) because the storage layout shards it into path components.
 
-A session is a directory tree: `session.json` (metadata: id, duration, files,
-synced, size, channels, sample_rate, mode), `marks.bin` (binary bookmarks:
-"BMRK" magic + count + offsets), and chunk files `0/0001.opus`, `0/0002.opus` …
-`1/0101.opus` (group = (file_index−1)/100, 100 files per subdir). Opus files are
-**length-prefixed frame streams** (2-byte LE length + packet, not OGG); a 4 KiB
-write buffer coalesces frames before `fs_write`.
+A session is a directory tree: `session.json` (metadata: id, duration, files, synced, size, channels, sample_rate, mode), `marks.bin` (binary bookmarks: "BMRK" magic + count + offsets), and chunk files `0/0001.opus`, `0/0002.opus` … `1/0101.opus` (group = (file_index−1)/100, 100 files per subdir). Opus files are **length-prefixed frame streams** (2-byte LE length + packet, not OGG); a 4 KiB write buffer coalesces frames before `fs_write`.
 
-Segment chunking: **300 s per segment when not syncing**
-(`CLIP_AUDIO_SEGMENT_DURATION_NO_SYNC`), **60 s during an active transfer**
-(`CLIP_AUDIO_SEGMENT_DURATION_SYNC`) — when recording *while* transferring
-(continuous mode), the transfer thread can only read a closed file, so 60 s caps
-the client's wait for the next file; if sync starts mid-file and the current
-file already exceeds 60 s, the engine slices immediately (`audio.c:868`). Each
-`PAUSE`/`RESUME` cycle also opens a new file. `session.json`'s `synced` field
-tracks acknowledged files so a download resumes from the first unsynced file.
+Segment chunking: **300 s per segment when not syncing** (`CLIP_AUDIO_SEGMENT_DURATION_NO_SYNC`), **60 s during an active transfer** (`CLIP_AUDIO_SEGMENT_DURATION_SYNC`) — when recording *while* transferring (continuous mode), the transfer thread can only read a closed file, so 60 s caps the client's wait for the next file; if sync starts mid-file and the current file already exceeds 60 s, the engine slices immediately (`audio.c:868`). Each `PAUSE`/`RESUME` cycle also opens a new file. `session.json`'s `synced` field tracks acknowledged files so a download resumes from the first unsynced file.
 
-**Storage:** microSD (FAT32, `/SD:`) holds recordings under `/SD:/REC/` in a
-bucket layout sharding the session id (`/SD:/REC/<YYYYMMDD>/<HH>/<MM>/<SS>/…`).
-External 8 MiB SPI flash (LittleFS, ~6.8 MiB) holds settings (`/lfs/settings/run`)
-and OTA slots — separate from the SD so corrupt settings or an interrupted OTA
-never take recordings down. The SD is **lazily remounted** via
-`storage_ensure_mounted()` and **idle power-gated** after `CLIP_SD_IDLE_DELAY_MS`
-(45 s) when genuinely idle (checked under lock to close the TOCTOU with a
-recording/transfer starting mid-check).
+**Storage:** microSD (FAT32, `/SD:`) holds recordings under `/SD:/REC/` in a bucket layout sharding the session id (`/SD:/REC/<YYYYMMDD>/<HH>/<MM>/<SS>/…`). External 8 MiB SPI flash (LittleFS, ~6.8 MiB) holds settings (`/lfs/settings/run`) and OTA slots — separate from the SD so corrupt settings or an interrupted OTA never take recordings down. The SD is **lazily remounted** via `storage_ensure_mounted()` and **idle power-gated** after `CLIP_SD_IDLE_DELAY_MS` (45 s) when genuinely idle (checked under lock to close the TOCTOU with a recording/transfer starting mid-check).
 
 ### Power Management
 
-Battery device (170 mAh "240" cell, NPM1300 + nRF Fuel Gauge); idle current is
-the dominant constraint. Production build at the 3V3 rail:
+Battery device (170 mAh "240" cell, NPM1300 + nRF Fuel Gauge); idle current is the dominant constraint. Production build at the 3V3 rail:
 
 | Source | Behavior | Cost |
 |--------|----------|------|
@@ -202,13 +114,7 @@ the dominant constraint. Production build at the 3V3 rail:
 | BLE slow advertising | ~1 s interval | ~0.1 mA averaged |
 | nRF70 QSPI | `CONFIG_NRF70_QSPI_LOW_POWER` when WiFi unused | minimal |
 
-**Production idle ≈ 170 µA.** The largest leak after the regulators and SD were
-fixed is the **debug UART console** (~570 µA); the `production` snippet disables
-the console + UART log backend (`CONFIG_CONSOLE=n`, `CONFIG_UART_CONSOLE=n`,
-`CONFIG_LOG_BACKEND_UART=n`), which is what reaches ~170 µA. `CONFIG_PM_DEVICE_RUNTIME=y`
-auto-suspends UART/I2C/SPI drivers when idle. Recording/transfer briefly raise
-current (CPU boost to 128 MHz, reference-counted; mic + SD rail on; released on
-completion).
+**Production idle ≈ 170 µA.** The largest leak after the regulators and SD were fixed is the **debug UART console** (~570 µA); the `production` snippet disables the console + UART log backend (`CONFIG_CONSOLE=n`, `CONFIG_UART_CONSOLE=n`, `CONFIG_LOG_BACKEND_UART=n`), which is what reaches ~170 µA. `CONFIG_PM_DEVICE_RUNTIME=y` auto-suspends UART/I2C/SPI drivers when idle. Recording/transfer briefly raise current (CPU boost to 128 MHz, reference-counted; mic + SD rail on; released on completion).
 
 ## Communication Protocol
 
@@ -230,23 +136,17 @@ completion).
 | SET | `AT+XX=<value>` | `AT+MODE=enhanced` | Set a parameter / act with args |
 | READ | `AT+XX?` | `AT+MODE?` | Query current value |
 
-Parsing is shared: `parse_command()` (in `at_server.c`) owns the `AT+NAME=args`
-grammar and the `=`/`?` type detection; handlers receive `ctx->args` already
-split (past the `=`). `AT+LIST?2&10` is a paginated read.
+Parsing is shared: `parse_command()` (in `at_server.c`) owns the `AT+NAME=args` grammar and the `=`/`?` type detection; handlers receive `ctx->args` already split (past the `=`). `AT+LIST?2&10` is a paginated read.
 
 ### JSON Response Contract
 
 - Success: `{"ok":true,"data":{...}}`
 - Failure: `{"ok":false,"msg":"..."}`
-- **No numeric error codes, no `error` field, no request ID.** Failures use
-  `msg`. The same JSON goes out identically over BLE, UDP, and USB (routed by the
-  command's originating transport via the `SEND_RESPONSE()` macro — your handler
-  only fills the response buffer).
+- **No numeric error codes, no `error` field, no request ID.** Failures use `msg`. The same JSON goes out identically over BLE, UDP, and USB (routed by the command's originating transport via the `SEND_RESPONSE()` macro — your handler only fills the response buffer).
 
 ### Registered Command Reference
 
-The registered commands live in `applications/clip/src/at_commands.c` (the
-`.name = "..."` table). Verified set:
+The registered commands live in `applications/clip/src/at_commands.c` (the `.name = "..."` table). Verified set:
 
 | Group | Commands |
 |---|---|
@@ -257,17 +157,11 @@ The registered commands live in `applications/clip/src/at_commands.c` (the
 | Connectivity | `WIFI`, `WIFICFG`, `USB`, `PAIR`, `DFU` |
 | Maintenance | `LOG`, `STORAGE`, `FORMAT`, `REBOOT`, `POWEROFF`, `FACTORY` |
 
-**Removed legacy — do not document as available:** `BITRATE`, `COMPLEXITY`,
-`NOISE`, `AGC`, `DEREVERB`, `PURGE`. Noise suppression / dereverb are boot-time
-Kconfig defaults (`CLIP_DEFAULT_NOISE`, `CLIP_DEFAULT_DEREVERB`), persisted in
-`config.c`, but have **no runtime AT command**; AGC is hand-rolled, always-on,
-not configurable. When you change an AT response, command, or transfer frame,
-update `docs/protocol.md` and `sdk/` in the same change.
+**Removed legacy — do not document as available:** `BITRATE`, `COMPLEXITY`, `NOISE`, `AGC`, `DEREVERB`, `PURGE`. Noise suppression / dereverb are boot-time Kconfig defaults (`CLIP_DEFAULT_NOISE`, `CLIP_DEFAULT_DEREVERB`), persisted in `config.c`, but have **no runtime AT command**; AGC is hand-rolled, always-on, not configurable. When you change an AT response, command, or transfer frame, update `docs/protocol.md` and `sdk/` in the same change.
 
 ### UDP Frame Types
 
-Wi-Fi UDP file transfer uses a binary frame protocol (port 8089) with per-frame
-CRC32:
+Wi-Fi UDP file transfer uses a binary frame protocol (port 8089) with per-frame CRC32:
 
 | Type | Value | Structure |
 |---|---|---|
@@ -279,28 +173,17 @@ CRC32:
 | `AT_RESP` | `0x20` | AT response carried over UDP |
 | `HEARTBEAT` | `0x30` | keepalive |
 
-**BLE has no per-frame CRC** (the link layer guarantees delivery) — only the
-full-file CRC32 in `FILE_END` for end-to-end check. UDP has per-frame CRC32 +
-`FILE_ACK` with a **selective-repeat bitmap NACK**: the client reports which
-frames it is missing as a bitmap and the engine resends only those, paced by
-`CLIP_UDP_REPAIR_PACE_US` (halves each retry round). A repair-pace that fails
-falls back to whole-file retransmit; `TRANSFER_MAX_FILE_RETRIES` (10) caps
-attempts before `ERROR`.
+**BLE has no per-frame CRC** (the link layer guarantees delivery) — only the full-file CRC32 in `FILE_END` for end-to-end check. UDP has per-frame CRC32 + `FILE_ACK` with a **selective-repeat bitmap NACK**: the client reports which frames it is missing as a bitmap and the engine resends only those, paced by `CLIP_UDP_REPAIR_PACE_US` (halves each retry round). A repair-pace that fails falls back to whole-file retransmit; `TRANSFER_MAX_FILE_RETRIES` (10) caps attempts before `ERROR`.
 
 ### Session and File Addressing
 
-Host-visible session ids are exactly 14 decimal digits `YYYYMMDDHHMMSS`; physical
-FAT paths are never exposed in the protocol. `AT+DOWNLOAD` accepts `session` or
-`session:NNNN.opus`. Validate user-controlled arguments before storage, path, or
-transfer access.
+Host-visible session ids are exactly 14 decimal digits `YYYYMMDDHHMMSS`; physical FAT paths are never exposed in the protocol. `AT+DOWNLOAD` accepts `session` or `session:NNNN.opus`. Validate user-controlled arguments before storage, path, or transfer access.
 
 ## Firmware Configuration and Build Profiles
 
 ### Stock and Development Builds
 
-The default (no-snippet) debug build keeps the UART console on and writes logs to
-`/SD:/LOG` (rotating 64 KiB files) at INF level (`CONFIG_LOG_BACKEND_FS=y`).
-Build:
+The default (no-snippet) debug build keeps the UART console on and writes logs to `/SD:/LOG` (rotating 64 KiB files) at INF level (`CONFIG_LOG_BACKEND_FS=y`). Build:
 
 ```sh
 source ~/ncs/v3.3.0/zephyr/zephyr-env.sh
@@ -310,10 +193,7 @@ west build --build-dir build-clip --board clip/nrf5340/cpuapp applications/clip
 west build --build-dir build-clip --pristine --board clip/nrf5340/cpuapp applications/clip
 ```
 
-Every app builds as a **sysbuild** (MCUboot + app core + net-core radio) by
-default; the board supplies the glue. Key `prj.conf` / devicetree / Kconfig
-knobs: feature switches, log levels, BLE/Wi-Fi/FS config; GPIO/I2C/SPI/PDM/PMIC/
-OLED mappings; buffer sizes, thread stacks, power policy.
+Every app builds as a **sysbuild** (MCUboot + app core + net-core radio) by default; the board supplies the glue. Key `prj.conf` / devicetree / Kconfig knobs: feature switches, log levels, BLE/Wi-Fi/FS config; GPIO/I2C/SPI/PDM/PMIC/ OLED mappings; buffer sizes, thread stacks, power policy.
 
 ### Production Build
 
@@ -324,9 +204,7 @@ west build --build-dir build-clip-prod --board clip/nrf5340/cpuapp applications/
   -- -DSNIPPET_ROOT=$(pwd)/applications/clip -DSNIPPET=production
 ```
 
-`SNIPPET_ROOT` must be absolute. The `production` snippet lives in
-`applications/clip/snippets/production/`. The project builds with **zero
-warnings** — fix every compiler warning before committing.
+`SNIPPET_ROOT` must be absolute. The `production` snippet lives in `applications/clip/snippets/production/`. The project builds with **zero warnings** — fix every compiler warning before committing.
 
 ## Firmware Update and Recovery
 
@@ -342,19 +220,14 @@ warnings** — fix every compiler warning before committing.
 
 ### USB Serial DFU
 
-The app keeps USB off by default — send `AT+USB=on` over BLE first (samples with
-default CDC auto-enable USB, or hold the user button while plugging in). Open the
-CDC-ACM port at **1200 baud** to trigger MCUboot serial recovery; a new port
-appears with **PID `0x8069`** (running app `0x0069`; the `0x8000` bit marks
-bootloader; both Seeed VID `0x2886`). Upload + reset:
+The app keeps USB off by default — send `AT+USB=on` over BLE first (samples with default CDC auto-enable USB, or hold the user button while plugging in). Open the CDC-ACM port at **1200 baud** to trigger MCUboot serial recovery; a new port appears with **PID `0x8069`** (running app `0x0069`; the `0x8000` bit marks bootloader; both Seeed VID `0x2886`). Upload + reset:
 
 ```sh
 nrfutil mcu-manager serial image-upload --firmware clip-<version>-signed.bin --serial-port /dev/ttyACMx
 nrfutil mcu-manager serial reset     --serial-port /dev/ttyACMx
 ```
 
-MCUboot verifies the RSA signature and boots the new app; the bootloader
-partition is never touched.
+MCUboot verifies the RSA signature and boots the new app; the bootloader partition is never touched.
 
 ### BLE OTA
 
@@ -375,8 +248,7 @@ nrfutil device reset --serial-number <JLINK-SN>
 
 ### Package Manifest
 
-Each release should carry a manifest so users don't guess package ranges from
-filenames:
+Each release should carry a manifest so users don't guess package ranges from filenames:
 
 ```yaml
 firmware_version:
@@ -414,14 +286,11 @@ flowchart TD
 | J-Link reset | `nrfutil device reset --serial-number <JLINK-SN>` | Dev/production |
 | west runner reset | `west flash --build-dir … && nrfutil device reset` | Dev — note `west flash --reset` does NOT work here |
 
-`--recover` erases **both cores** (clears the b0n access-port lock) — use only
-when net-core AP is locked, never routinely.
+`--recover` erases **both cores** (clears the b0n access-port lock) — use only when net-core AP is locked, never routinely.
 
 ### Safety Rules
 
-Never, unprepared: full-chip erase; UICR modify; overwrite the bootloader;
-partition-table change; flash a wrong-hardware-revision merged image; recover a
-production device without backing up its config.
+Never, unprepared: full-chip erase; UICR modify; overwrite the bootloader; partition-table change; flash a wrong-hardware-revision merged image; recover a production device without backing up its config.
 
 ## Validation and Debugging
 
@@ -439,14 +308,9 @@ production device without backing up its config.
 
 ### Audio Quality Metrics
 
-SNR (signal vs noise clarity), STOI (intelligibility), WER (ASR error rate — the
-business metric), THD (DSP/hardware distortion). Test scenarios: quiet
-near/far, office, café, car, street; both Normal and Enhanced; cover Chinese,
-English, digit sequences, silence.
+SNR (signal vs noise clarity), STOI (intelligibility), WER (ASR error rate — the business metric), THD (DSP/hardware distortion). Test scenarios: quiet near/far, office, café, car, street; both Normal and Enhanced; cover Chinese, English, digit sequences, silence.
 
-> **PESQ/STOI need a clean reference + alignment.** Do not compute them on
-> arbitrary field recordings and claim a conclusion — without a matched
-> reference, the number is not meaningful.
+> **PESQ/STOI need a clean reference + alignment.** Do not compute them on arbitrary field recordings and claim a conclusion — without a matched reference, the number is not meaningful.
 
 ### Serial, Logging, Storage, and Timing Debug
 
@@ -454,13 +318,7 @@ English, digit sequences, silence.
 minicom -D /dev/ttyACM0 -b 921600   # ttyACM1 if a J-Link also connected
 ```
 
-Log levels: `AT+LOG=off|info|debug` (debug default: info). `CONFIG_LOG_BACKEND_FS=y`
-writes to `/SD:/LOG` (rotating 64 KiB) for post-mortem; `AT+LOG=off` lets the SD
-idle power-gate. The audio thread prints DWT cycle-counter stats (`enc avg/min/max`,
-`dsp`) every 500 frames (10 s). Known pitfalls (`CLAUDE.md`): `%llu` not supported
-on nRF5340 (use `%u` + cast); UDP `sendto()` returns success even on silent TX
-drops; FAT directory order is not chronological; corrupt `/lfs/settings/run`
-blocks `settings_load` (watchdog wipes + reboots after 3 s).
+Log levels: `AT+LOG=off|info|debug` (debug default: info). `CONFIG_LOG_BACKEND_FS=y` writes to `/SD:/LOG` (rotating 64 KiB) for post-mortem; `AT+LOG=off` lets the SD idle power-gate. The audio thread prints DWT cycle-counter stats (`enc avg/min/max`, `dsp`) every 500 frames (10 s). Known pitfalls (`CLAUDE.md`): `%llu` not supported on nRF5340 (use `%u` + cast); UDP `sendto()` returns success even on silent TX drops; FAT directory order is not chronological; corrupt `/lfs/settings/run` blocks `settings_load` (watchdog wipes + reboots after 3 s).
 
 ### Host-side Test Tools
 
@@ -474,16 +332,13 @@ python applications/clip/tests/tools/udp_sync.py --session <id>
 python applications/clip/tests/tools/decode_opus.py <file>.opus out.wav
 ```
 
-**"Build passes" is not "hardware verified."** A clean compile says nothing about
-on-device behavior.
+**"Build passes" is not "hardware verified."** A clean compile says nothing about on-device behavior.
 
 ## Production Release
 
 ### Release Artifacts and Manifest
 
-Manual export today (tag-triggered `scripts/build_release.sh` +
-`.github/workflows/release.yml` are **not yet implemented**). Debug and
-production each produce four artifacts:
+Manual export today (tag-triggered `scripts/build_release.sh` + `.github/workflows/release.yml` are **not yet implemented**). Debug and production each produce four artifacts:
 
 | Artifact | Use |
 |---|---|
@@ -492,31 +347,19 @@ production each produce four artifacts:
 | `dfu_application.zip` (release name `*-ota.zip`) | mcumgr OTA package (BLE / USB serial) |
 | `clip/zephyr/zephyr.signed.bin` (release name `*-signed.bin`) | MCUboot-signed app image (USB serial DFU) |
 
-A `single.zip` (app-core-only) is **not yet shipped** — until `build_release.sh`
-lands, use `*-signed.bin` for app-only updates. Publish: add
-`docs/release_notes/v$VERSION.md`, commit, `git tag vX.Y.Z && git push origin
-vX.Y.Z` → CI builds the GitHub Release.
+A `single.zip` (app-core-only) is **not yet shipped** — until `build_release.sh` lands, use `*-signed.bin` for app-only updates. Publish: add `docs/release_notes/v$VERSION.md`, commit, `git tag vX.Y.Z && git push origin vX.Y.Z` → CI builds the GitHub Release.
 
 ### Signing Keys
 
-`boards/seeed/clip/sysbuild/root-rsa-2048.pem` is a **copy of the MCUboot
-default key**. Anyone with the public source can sign images for your devices.
-**Generate your own key for production** and keep the private half secret;
-rotate by replacing the key and re-flashing the bootloader.
+`boards/seeed/clip/sysbuild/root-rsa-2048.pem` is a **copy of the MCUboot default key**. Anyone with the public source can sign images for your devices. **Generate your own key for production** and keep the private half secret; rotate by replacing the key and re-flashing the bootloader.
 
 ### CI
 
-`.github/workflows/firmware.yml` builds the clip app on push/PR to `main`
-(compilation check; applies the MCUboot patches + `west build`).
-`mobile-ci.yml` (analyze + unit tests, on PR) and `mobile-verify.yml` (debug APK
-/ iOS smoke, push + manual) cover `mobile/`.
+`.github/workflows/firmware.yml` builds the clip app on push/PR to `main` (compilation check; applies the MCUboot patches + `west build`). `mobile-ci.yml` (analyze + unit tests, on PR) and `mobile-verify.yml` (debug APK / iOS smoke, push + manual) cover `mobile/`.
 
 ### Factory Programming and Test Firmware
 
-Each test image is a standalone sysbuild under `tests/<name>`, built like
-`west build --build-dir build-test --pristine --board clip/nrf5340/cpuapp
-tests/clip`. Tests **opt out of MCUboot** (factory/cert firmware, flashed
-directly via J-Link) via `SB_CONFIG_BOOTLOADER_NONE=y`:
+Each test image is a standalone sysbuild under `tests/<name>`, built like `west build --build-dir build-test --pristine --board clip/nrf5340/cpuapp tests/clip`. Tests **opt out of MCUboot** (factory/cert firmware, flashed directly via J-Link) via `SB_CONFIG_BOOTLOADER_NONE=y`:
 
 | Test | Purpose |
 |---|---|
@@ -531,52 +374,31 @@ Mass flash uses `nrfutil device program --firmware …-merged.hex --serial-numbe
 
 ### Compatibility Rules
 
-- Keep the AT response shape: `{"ok":true,"data":{...}}` /
-  `{"ok":false,"msg":"..."}`. No numeric error codes, no `error` field.
+- Keep the AT response shape: `{"ok":true,"data":{...}}` / `{"ok":false,"msg":"..."}`. No numeric error codes, no `error` field.
 - Don't break the file format (length-prefixed Opus, `session.json` schema).
-- Update `docs/protocol.md` **and** `sdk/` whenever an AT response, command, or
-  transfer frame changes.
+- Update `docs/protocol.md` **and** `sdk/` whenever an AT response, command, or transfer frame changes.
 - Don't auto-execute a full-chip erase; don't auto-flash a production device.
 - The firmware source is the source of truth.
 
 ### NCS v3.2.1 to v3.3.0 Migration
 
-`main` migrated to **v3.3.0-only Kconfig** (e.g. the WPA3
-`..._WPA3_IMPLEMENTATION_NONE` choice) and will no longer build against NCS
-v3.2.1. The `ncs/v3.3.0` branch is an older diverged line (~12 commits behind
-`main`); local `master` is only the ancient initial import. Target NCS v3.3.0.
+`main` migrated to **v3.3.0-only Kconfig** (e.g. the WPA3 `..._WPA3_IMPLEMENTATION_NONE` choice) and will no longer build against NCS v3.2.1. The `ncs/v3.3.0` branch is an older diverged line (~12 commits behind `main`); local `master` is only the ancient initial import. Target NCS v3.3.0.
 
 ## AI-Assisted Development
 
-The repo ships a firmware-dev skill at
-[`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/SKILL.md)
-for AI agents (Claude Code, etc.) that work on this firmware. It encodes the
-project's real constraints so an agent does not re-derive them — and does not
-guess facts that are easy to get wrong. **Use it; do not duplicate its rules
-into the docs.**
+The repo ships a firmware-dev skill at [`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/SKILL.md) for AI agents (Claude Code, etc.) that work on this firmware. It encodes the project's real constraints so an agent does not re-derive them — and does not guess facts that are easy to get wrong. **Use it; do not duplicate its rules into the docs.**
 
-For a complete, copyable example of AI-assisted AT command customization, see
-[Customization: Add a Custom AT Command](/respeaker_clip_customization_at_command/).
-That article shows how to prompt an AI agent to load the repository skill, add
-`AT+ECHO`, build the firmware, and validate the command on-device.
+For a complete, copyable example of AI-assisted AT command customization, see [Customization: Add a Custom AT Command](/respeaker_clip_customization_at_command/). That article shows how to prompt an AI agent to load the repository skill, add `AT+ECHO`, build the firmware, and validate the command on-device.
 
-**What the skill provides** — `SKILL.md` plus nine references under
-`skills/clip-dev/references/` (`audio`, `build-flash`, `ble-at`, `storage`,
-`wifi-udp`, `mcuboot`, `power`, `display`, `hardware`):
+**What the skill provides** — `SKILL.md` plus nine references under `skills/clip-dev/references/` (`audio`, `build-flash`, `ble-at`, `storage`, `wifi-udp`, `mcuboot`, `power`, `display`, `hardware`):
 
 - active NCS version, board sysbuild defaults, build/flash commands;
-- the **current AT command set** (registered in `at_commands.c`) and the
-  response contract `{"ok":true,"data":...}` / `{"ok":false,"msg":...}`;
-- the audio pipeline truth — both modes are mono L+R merge; **runtime commands
-  for bitrate, codec complexity, AGC, noise suppression, and dereverb do not
-  exist**;
+- the **current AT command set** (registered in `at_commands.c`) and the response contract `{"ok":true,"data":...}` / `{"ok":false,"msg":...}`;
+- the audio pipeline truth — both modes are mono L+R merge; **runtime commands for bitrate, codec complexity, AGC, noise suppression, and dereverb do not exist**;
 - power constraints (console leak, the `production` snippet, SD idle gating);
-- a firmware workflow: confirm the contract in source before editing docs or
-  clients, validate user-controlled args, flash only the requested image,
-  update `docs/protocol.md` + `sdk/` whenever an AT response changes.
+- a firmware workflow: confirm the contract in source before editing docs or clients, validate user-controlled args, flash only the requested image, update `docs/protocol.md` + `sdk/` whenever an AT response changes.
 
-**How to load it.** In Claude Code the skill is auto-discovered; otherwise
-point the agent at the file:
+**How to load it.** In Claude Code the skill is auto-discovered; otherwise point the agent at the file:
 
 ```
 @clip-dev
@@ -584,8 +406,7 @@ Analyze how to add distinct haptic patterns for recording start vs stop.
 Give the modification plan first; do not edit code yet.
 ```
 
-**Standard task template** — fill this in before asking an agent to change
-firmware:
+**Standard task template** — fill this in before asking an agent to change firmware:
 
 ```markdown
 ## Goal
@@ -613,29 +434,26 @@ firmware:
 - Power or real-time constraint
 ```
 
-**Safety rules the skill enforces.** Do not guess files, functions, Kconfig, or
-board targets — search the real source first. Do not infer a public interface
-from an internal module name. Do not modify MCUboot, the partition table, or
-signing keys without explicit confirmation. Do not auto-erase the whole chip or
-flash a production device. Do not break existing AT responses or file formats.
-"Build passes" is not "hardware verified" — claim only what was actually tested
-on a device. For audio/protocol changes, report CPU, buffer, flash, RAM, and
-output-format impact; for protocol changes, update the Python `sdk/` and
-`docs/protocol.md` in the same change.
+**Safety rules the skill enforces.** Do not guess files, functions, Kconfig, or board targets — search the real source first. Do not infer a public interface from an internal module name. Do not modify MCUboot, the partition table, or signing keys without explicit confirmation. Do not auto-erase the whole chip or flash a production device. Do not break existing AT responses or file formats. "Build passes" is not "hardware verified" — claim only what was actually tested on a device. For audio/protocol changes, report CPU, buffer, flash, RAM, and output-format impact; for protocol changes, update the Python `sdk/` and `docs/protocol.md` in the same change.
 
 ## Related Resources
 
 - [Getting Started with the reSpeaker Clip Firmware SDK](./respeaker_clip_firmware_quick_start.md) — build-to-smoke-test path
 - [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md) — full build/flash/power/pitfalls reference
 - [`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/) — firmware AI development skill
-- Source: [clip_event.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/clip_event.c) (state machine),
-  [audio.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/audio.c) (DSP/Opus),
-  [at_commands.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_commands.c) (AT registry),
-  [at_server.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_server.c) (parse/route),
-  [transfer.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/transfer.c) (transfer engine),
-  [transport.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/transport.c) (transport abstraction),
-  [storage.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/storage.c) (sessions/SD lifecycle),
-  [main.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/main.c) (init order)
-- [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md),
-  [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md),
-  [udp_protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/udp_protocol.md)
+- Source: [clip_event.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/clip_event.c) (state machine), [audio.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/audio.c) (DSP/Opus), [at_commands.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_commands.c) (AT registry), [at_server.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/at_server.c) (parse/route), [transfer.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/transfer.c) (transfer engine), [transport.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/transport.c) (transport abstraction), [storage.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/storage.c) (sessions/SD lifecycle), [main.c](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/applications/clip/src/main.c) (init order)
+- [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md), [protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/protocol.md), [udp_protocol.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/udp_protocol.md)
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="button_tech_support_container">
+<a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+<a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+</div>
+
+<div class="button_tech_support_container">
+<a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+<a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+</div>

--- a/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_firmware_quick_start.md
+++ b/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_firmware_quick_start.md
@@ -11,8 +11,6 @@ keywords:
   - NCS
 image: https://files.seeedstudio.com/wiki/reSpeaker_Clip/clip-banner.jpg
 slug: /respeaker_clip_firmware_quick_start
-aliases:
-  - /respeaker_clip_firmware_sdk
 sku: 100020126
 last_update:
   date: 07/28/2026
@@ -24,26 +22,15 @@ url: https://wiki.seeedstudio.com/respeaker_clip_firmware_quick_start/
 
 # Getting Started with the reSpeaker Clip Firmware SDK
 
-End-to-end path from a clean machine to a reSpeaker Clip that boots, records,
-and is controllable from the host SDK — the baseline before any custom or
-AI-assisted firmware work. It also tells you whether firmware work is even the
-right path for your task.
+End-to-end path from a clean machine to a reSpeaker Clip that boots, records, and is controllable from the host SDK — the baseline before any custom or AI-assisted firmware work. It also tells you whether firmware work is even the right path for your task.
 
-> **Enclosed device.** The Clip ships in a sealed housing — the SWD/J-Link pads
-> are not reachable without opening the case. **End users upgrade over USB or
-> BLE**, never with a probe. SWD flashing below is the *development* path (bench
-> units with the case off or a debug break-out).
+> **Enclosed device.** The Clip ships in a sealed housing — the SWD/J-Link pads are not reachable without opening the case. **End users upgrade over USB or BLE**, never with a probe. SWD flashing below is the *development* path (bench units with the case off or a debug break-out).
 
 ## Introduction
 
-The **Firmware SDK** is the device-side Zephyr RTOS firmware on the Nordic
-nRF5340 (dual-core: application core + network core). It is for developers who
-need to **modify device-side behavior** — the audio pipeline, the AT command
-surface or BLE GATT service, the button / OLED / haptic interaction model, the
-power or productization strategy, or custom hardware bring-up.
+The **Firmware SDK** is the device-side Zephyr RTOS firmware on the Nordic nRF5340 (dual-core: application core + network core). It is for developers who need to **modify device-side behavior** — the audio pipeline, the AT command surface or BLE GATT service, the button / OLED / haptic interaction model, the power or productization strategy, or custom hardware bring-up.
 
-The checked-out firmware source is authoritative; docs summarize it. When they
-disagree, the source wins.
+The checked-out firmware source is authoritative; docs summarize it. When they disagree, the source wins.
 
 ## Choose the Right Development Path
 
@@ -55,16 +42,12 @@ Not every task needs firmware work. Pick the path that matches your goal:
 | Modify the audio pipeline, AT/GATT, button/OLED/haptic, power, or hardware | **Firmware SDK** (this guide + the [Firmware Development Guide](./respeaker_clip_firmware_development_guide.md)) | Yes |
 | Have an AI agent modify the repo within the firmware's real constraints | [`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/) skill | Yes |
 
-The Basic and mobile SDKs talk to the Clip over BLE and the device Wi-Fi AP and
-require no firmware source. They are the supported path for app integration.
+The Basic and mobile SDKs talk to the Clip over BLE and the device Wi-Fi AP and require no firmware source. They are the supported path for app integration.
 
 **Out of scope for the device firmware** (do not expect these capabilities):
 
-- **Cloud transcription / AI summary** — the Clip records Opus to the SD card;
-  transcription runs off-device. There is no on-device speech-to-text path.
-- **BLE real-time audio streaming** — the BLE link carries AT commands, file
-  transfer frames, and an audio *energy-level* visualization notify only. It
-  does not stream live audio.
+- **Cloud transcription / AI summary** — the Clip records Opus to the SD card; transcription runs off-device. There is no on-device speech-to-text path.
+- **BLE real-time audio streaming** — the BLE link carries AT commands, file transfer frames, and an audio *energy-level* visualization notify only. It does not stream live audio.
 
 ## Firmware Capabilities and Customization Boundaries
 
@@ -80,29 +63,17 @@ require no firmware source. They are the supported path for app integration.
 | File transfer (BLE + Wi-Fi UDP) | Yes (`AT+DOWNLOAD/CANCEL`) | Yes | Yes (`transport.c`, `transfer.c`) |
 | BLE real-time audio stream | No (energy-level notify only) | N/A | Out of scope |
 
-The full registered AT command list, protocol frames, architecture, validation
-matrix, and production/release details live in the
-[Firmware Development Guide](./respeaker_clip_firmware_development_guide.md) —
-this page only summarizes what you need to get started.
+The full registered AT command list, protocol frames, architecture, validation matrix, and production/release details live in the [Firmware Development Guide](./respeaker_clip_firmware_development_guide.md) — this page only summarizes what you need to get started.
 
 ## Recording Mode and Audio Pipeline Facts
 
-> Older docs describe `MODE_NORMAL` as **stereo**. That is wrong. Both modes
-> record **mono**.
+> Older docs describe `MODE_NORMAL` as **stereo**. That is wrong. Both modes record **mono**.
 
-- **Both modes** record **mono** via an L+R merge. `clip_event.c` always calls
-  `audio_start_recording(AUDIO_MODE_MERGE)`. `MODE_NORMAL` is **not** stereo —
-  the name is legacy.
-- **`MODE_NORMAL`** (default) = merge + a hand-rolled DSP path only
-  (delay-aligned merge, 100 Hz high-pass, integer AGC, soft limiter). **No
-  SpeexDSP.**
-- **`MODE_ENHANCED`** = merge + SpeexDSP noise suppression and dereverb, gated
-  on `mode == ENHANCED && noise_suppress > 0` (`audio.c:506`). With
-  `noise == 0`, Enhanced behaves like Normal.
-- Opus bitrate and complexity are **per-mode Kconfig constants**
-  (`CLIP_NORMAL_*`/`CLIP_ENHANCED_*`), not runtime-settable.
-- Set the mode with `AT+MODE=normal|enhanced` (persisted) or
-  `AT+START mode=enhanced` (session-only, not persisted).
+- **Both modes** record **mono** via an L+R merge. `clip_event.c` always calls `audio_start_recording(AUDIO_MODE_MERGE)`. `MODE_NORMAL` is **not** stereo — the name is legacy.
+- **`MODE_NORMAL`** (default) = merge + a hand-rolled DSP path only (delay-aligned merge, 100 Hz high-pass, integer AGC, soft limiter). **No SpeexDSP.**
+- **`MODE_ENHANCED`** = merge + SpeexDSP noise suppression and dereverb, gated on `mode == ENHANCED && noise_suppress > 0` (`audio.c:506`). With `noise == 0`, Enhanced behaves like Normal.
+- Opus bitrate and complexity are **per-mode Kconfig constants** (`CLIP_NORMAL_*`/`CLIP_ENHANCED_*`), not runtime-settable.
+- Set the mode with `AT+MODE=normal|enhanced` (persisted) or `AT+START mode=enhanced` (session-only, not persisted).
 
 ## Prerequisites
 
@@ -123,12 +94,9 @@ pip install -r applications/clip/tests/requirements.txt
 
 ## Get the Source Code
 
-The repo is a **Zephyr module** (it carries its own board, drivers, and libs via
-`zephyr/module.yml`). Clone it anywhere, then point the NCS environment at it.
+The repo is a **Zephyr module** (it carries its own board, drivers, and libs via `zephyr/module.yml`). Clone it anywhere, then point the NCS environment at it.
 
-> **Verified baseline.** This guide targets firmware tag **`v0.0.9`**,
-> NCS **v3.3.0**, board **`clip/nrf5340/cpuapp`**, on Ubuntu 24.04. Pin the same
-> tag for a reproducible build, instead of cloning the moving `main` branch:
+> **Verified baseline.** This guide targets firmware tag **`v0.0.9`**, NCS **v3.3.0**, board **`clip/nrf5340/cpuapp`**, on Ubuntu 24.04. Pin the same tag for a reproducible build, instead of cloning the moving `main` branch:
 
 ```sh
 git clone --branch v0.0.9 https://github.com/Seeed-Studio/reSpeaker_Clip.git
@@ -136,21 +104,13 @@ cd reSpeaker_Clip
 git describe --tags    # confirm: v0.0.9
 ```
 
-**Supported hardware:** reSpeaker Clip (nRF5340 + nRF7002 + NPM1300 PMIC). Other
-board revisions are not covered by this guide.
+**Supported hardware:** reSpeaker Clip (nRF5340 + nRF7002 + NPM1300 PMIC). Other board revisions are not covered by this guide.
 
 ## Set Up NCS v3.3.0
 
-NCS v3.3.0 is installed as a **west workspace** — the NCS source tree plus a
-separate **Zephyr SDK toolchain**. This is how the reference setup installs it.
+NCS v3.3.0 is installed as a **west workspace** — the NCS source tree plus a separate **Zephyr SDK toolchain**. This is how the reference setup installs it.
 
-> **Do not use `nrfutil toolchain-manager`.** The `nrfutil` v6.1.7 binary does
-> not actually have the `toolchain-manager`/`self-upgrade` commands, so the
-> firmware CI's NCS-install step is currently broken (the
-> [`firmware.yml`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/.github/workflows/firmware.yml)
-> runs are failing). Use the west steps below instead. If you already have NCS
-> v3.3.0 (e.g. installed via nRF Connect for Desktop), skip to
-> [Enter the NCS environment](#enter-the-ncs-environment--register-this-repo-as-a-module).
+> **Do not use `nrfutil toolchain-manager`.** The `nrfutil` v6.1.7 binary does not actually have the `toolchain-manager`/`self-upgrade` commands, so the firmware CI's NCS-install step is currently broken (the [`firmware.yml`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/.github/workflows/firmware.yml) runs are failing). Use the west steps below instead. If you already have NCS v3.3.0 (e.g. installed via nRF Connect for Desktop), skip to [Enter the NCS environment](#enter-the-ncs-environment--register-this-repo-as-a-module).
 
 ### 1. Install build dependencies + `west`
 
@@ -163,8 +123,7 @@ west --version          # expect west 1.x
 
 ### 2. Install the NCS v3.3.0 source (west manifest)
 
-This creates the workspace at `~/ncs/v3.3.0` and fetches the NCS modules
-(zephyr, nrf, nrfxlib, mcuboot, HALs, crypto, …) — about 2 GB from GitHub.
+This creates the workspace at `~/ncs/v3.3.0` and fetches the NCS modules (zephyr, nrf, nrfxlib, mcuboot, HALs, crypto, …) — about 2 GB from GitHub.
 
 ```sh
 west init -m https://github.com/nrfconnect/sdk-nrf --mr v3.3.0 ~/ncs/v3.3.0
@@ -174,10 +133,7 @@ west update
 
 ### 3. Install the Zephyr SDK toolchain (separate)
 
-The west workspace gives the **source**; the **compiler** comes from the
-Zephyr SDK. Download version **0.16.4** from the
-[Zephyr SDK releases](https://github.com/zephyrproject-rtos/sdk/releases)
-(the `*_linux-x86_64.tar.xz` asset), extract it, and run its setup once:
+The west workspace gives the **source**; the **compiler** comes from the Zephyr SDK. Download version **0.16.4** from the [Zephyr SDK releases](https://github.com/zephyrproject-rtos/sdk/releases) (the `*_linux-x86_64.tar.xz` asset), extract it, and run its setup once:
 
 ```sh
 cd ~
@@ -187,11 +143,7 @@ cd zephyr-sdk-0.16.4
 # → compiler at ~/zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
 ```
 
-> **Linux device access — `nrf-udev` + J-Link udev rules.** To flash or reset
-> over USB/J-Link without root, install `nrf-udev` (Nordic's `.deb`) and the
-> SEGGER udev rules — otherwise `/dev/ttyACMx` and J-Link probes are root-only.
-> See the
-> [nRF Util prerequisites](https://docs.nordicsemi.com/r/bundle/nrfutil/page/guides/installing.html/prerequisites).
+> **Linux device access — `nrf-udev` + J-Link udev rules.** To flash or reset over USB/J-Link without root, install `nrf-udev` (Nordic's `.deb`) and the SEGGER udev rules — otherwise `/dev/ttyACMx` and J-Link probes are root-only. See the [nRF Util prerequisites](https://docs.nordicsemi.com/r/bundle/nrfutil/page/guides/installing.html/prerequisites).
 
 ### Enter the NCS environment + register this repo as a module
 
@@ -200,10 +152,7 @@ source ~/ncs/v3.3.0/zephyr/zephyr-env.sh
 export ZEPHYR_EXTRA_MODULES=$PWD     # the reSpeaker_Clip checkout
 ```
 
-> **Why `ZEPHYR_EXTRA_MODULES` is an env var, not a `-D` CMake var.** Kconfig
-> module discovery runs *before* CMake configures. A `-D` would arrive too late,
-> so Kconfig would never see this repo's board (`clip`), drivers, or libraries.
-> Set it in the same shell you build from — or export it in your shell profile.
+> **Why `ZEPHYR_EXTRA_MODULES` is an env var, not a `-D` CMake var.** Kconfig module discovery runs *before* CMake configures. A `-D` would arrive too late, so Kconfig would never see this repo's board (`clip`), drivers, or libraries. Set it in the same shell you build from — or export it in your shell profile.
 
 **Checkpoint — your environment is ready when these all succeed:**
 
@@ -220,41 +169,28 @@ echo $ZEPHYR_BASE                # .../ncs/v3.3.0/zephyr
 west build --build-dir build-clip --board clip/nrf5340/cpuapp applications/clip
 ```
 
-For a fully clean rebuild (required after MCUboot patch changes or a stale
-build dir), add `--pristine`:
+For a fully clean rebuild (required after MCUboot patch changes or a stale build dir), add `--pristine`:
 
 ```sh
 west build --build-dir build-clip --pristine --board clip/nrf5340/cpuapp applications/clip
 ```
 
-This is a **sysbuild by default** — one command produces the custom signed
-MCUboot bootloader + the application core + the network-core BLE controller
-image. The board supplies all the sysbuild glue; no per-app `sysbuild.conf` is
-needed.
+This is a **sysbuild by default** — one command produces the custom signed MCUboot bootloader + the application core + the network-core BLE controller image. The board supplies all the sysbuild glue; no per-app `sysbuild.conf` is needed.
 
 > **Board identifier**: `clip/nrf5340/cpuapp` — **not** `respeaker/...`.
 
-> **Reproducibility — VM vs. device.** The install path targets Ubuntu 24.04
-> with real network access (the multi-GB NCS fetch needs reliable GitHub
-> connectivity — a QEMU/VM's user-mode networking struggles with it). A QEMU/VM
-> can exercise the *install and build steps* but is **not** a device substitute —
-> QEMU cannot emulate the nRF5340 dual-core, nRF7002, PDM mic, SD, OLED, PMIC, or
-> real USB/BLE behavior. Flash, transport, audio, and recovery must be verified
-> on a real Clip.
+> **Reproducibility — VM vs. device.** The install path targets Ubuntu 24.04 with real network access (the multi-GB NCS fetch needs reliable GitHub connectivity — a QEMU/VM's user-mode networking struggles with it). A QEMU/VM can exercise the *install and build steps* but is **not** a device substitute — QEMU cannot emulate the nRF5340 dual-core, nRF7002, PDM mic, SD, OLED, PMIC, or real USB/BLE behavior. Flash, transport, audio, and recovery must be verified on a real Clip.
 
 ## Build the Production Configuration
 
-The low-power variant: UART console and the FS/UART log backends off, idle
-≈170 µA (vs. the debug build, where the console leaks ~570 µA). Use this for
-battery/production builds where the console current matters.
+The low-power variant: UART console and the FS/UART log backends off, idle ≈170 µA (vs. the debug build, where the console leaks ~570 µA). Use this for battery/production builds where the console current matters.
 
 ```sh
 west build --build-dir build-clip-prod --board clip/nrf5340/cpuapp applications/clip \
   -- -DSNIPPET_ROOT=$(pwd)/applications/clip -DSNIPPET=production
 ```
 
-`SNIPPET_ROOT` must be an absolute path. The `production` snippet lives in
-`applications/clip/snippets/production/`.
+`SNIPPET_ROOT` must be an absolute path. The `production` snippet lives in `applications/clip/snippets/production/`.
 
 ## Flash and Reset
 
@@ -263,20 +199,14 @@ west flash --build-dir build-clip          # flash both cores
 nrfutil device reset --serial-number <JLINK-SN>
 ```
 
-> **`--serial-number` targets a specific J-Link.** Omit it only when a single
-> device is attached — with multiple probes the bare `nrfutil device reset` is
-> ambiguous. Find the SN with `nrfutil device list` or printed on the J-Link case.
+> **`--serial-number` targets a specific J-Link.** Omit it only when a single device is attached — with multiple probes the bare `nrfutil device reset` is ambiguous. Find the SN with `nrfutil device list` or printed on the J-Link case.
 
 Two caveats specific to this board:
 
-- **`west flash --reset` does NOT work** here. Always reset separately with
-  `nrfutil device reset`.
-- **`--recover` erases both cores** (it clears the net-core access-port lock).
-  Use it only when the net-core AP is `b0n`-locked (e.g. after a prior secure
-  boot) — not as a routine flag.
+- **`west flash --reset` does NOT work** here. Always reset separately with `nrfutil device reset`.
+- **`--recover` erases both cores** (it clears the net-core access-port lock). Use it only when the net-core AP is `b0n`-locked (e.g. after a prior secure boot) — not as a routine flag.
 
-End users (case on, no probe) skip this step entirely and use USB serial DFU —
-see [Recover with USB Serial DFU](#recover-with-usb-serial-dfu) below.
+End users (case on, no probe) skip this step entirely and use USB serial DFU — see [Recover with USB Serial DFU](#recover-with-usb-serial-dfu) below.
 
 ## Open the Debug Console
 
@@ -284,15 +214,11 @@ see [Recover with USB Serial DFU](#recover-with-usb-serial-dfu) below.
 minicom -D /dev/ttyACM0 -b 921600
 ```
 
-When a J-Link probe is also connected, the J-Link grabs `ttyACM0` and the Clip's
-UART0 bridge moves to `ttyACM1` — use whichever port is the "USB Single Serial"
-(non-J-Link) one.
+When a J-Link probe is also connected, the J-Link grabs `ttyACM0` and the Clip's UART0 bridge moves to `ttyACM1` — use whichever port is the "USB Single Serial" (non-J-Link) one.
 
 ## Run the Smoke Test
 
-Success criteria: the device boots, answers AT commands over BLE, records a
-valid Opus file, and pulls it back over Wi-Fi. All AT responses are JSON —
-success is `{"ok":true,"data":{...}}`, failure is `{"ok":false,"msg":"..."}`.
+Success criteria: the device boots, answers AT commands over BLE, records a valid Opus file, and pulls it back over Wi-Fi. All AT responses are JSON — success is `{"ok":true,"data":{...}}`, failure is `{"ok":false,"msg":"..."}`.
 
 ### Boot & status
 
@@ -305,8 +231,7 @@ AT+VERSION      →  {"ok":true,"data":{"version":"0.0.6",...}}
 
 ### Record → list → download (over BLE)
 
-`clip-cli.py` is the unified host CLI (BLE default, also Wi-Fi). With the device
-advertising:
+`clip-cli.py` is the unified host CLI (BLE default, also Wi-Fi). With the device advertising:
 
 ```sh
 # status over BLE
@@ -317,8 +242,7 @@ python applications/clip/tests/tools/clip-cli.py record --duration 5
 python applications/clip/tests/tools/clip-cli.py list
 ```
 
-`AT+LIST` should show the new session (sorted newest-first). Pull the Opus
-files back over BLE and decode one to WAV to confirm it is valid audio:
+`AT+LIST` should show the new session (sorted newest-first). Pull the Opus files back over BLE and decode one to WAV to confirm it is valid audio:
 
 ```sh
 python applications/clip/tests/tools/clip-cli.py sync --session <session_id>
@@ -341,14 +265,12 @@ Then from the host, join the AP and sync the session:
 python applications/clip/tests/tools/udp_sync.py --session <session_id>
 ```
 
-If all four pass — status, record, list/download with a decodable Opus file, and
-the Wi-Fi pull — the stock firmware baseline is good.
+If all four pass — status, record, list/download with a decodable Opus file, and the Wi-Fi pull — the stock firmware baseline is good.
 
 ## Export Build Artifacts
 
 There is no single-zip export yet — the tag-triggered `scripts/build_release.sh`
-+ `.github/workflows/release.yml` are not yet implemented. For now, build both
-variants and copy the four artifacts each manually:
++ `.github/workflows/release.yml` are not yet implemented. For now, build both variants and copy the four artifacts each manually:
 
 ```sh
 VERSION=$(grep APP_VERSION_STRING build-clip/clip/zephyr/include/generated/zephyr/app_version.h | cut -d'"' -f2)
@@ -366,24 +288,15 @@ cp build-clip-prod/dfu_application.zip   output/$VERSION/clip-$VERSION-productio
 cp build-clip-prod/clip/zephyr/zephyr.signed.bin output/$VERSION/clip-$VERSION-production-signed.bin
 ```
 
-Per release: `*-merged.hex` / `*-merged_CPUNET.hex` (programmer), `*-signed.bin`
-(USB serial DFU), `*-ota.zip` (BLE/USB mcumgr multi-image package).
+Per release: `*-merged.hex` / `*-merged_CPUNET.hex` (programmer), `*-signed.bin` (USB serial DFU), `*-ota.zip` (BLE/USB mcumgr multi-image package).
 
 ## Recover with USB Serial DFU
 
-If a bench build left the device in a bad state, use the **1200-baud USB
-trigger** — no probe, no opening the case. Every clip app has it built in
-(board-level, `lib/clip_usb_dfu`).
+If a bench build left the device in a bad state, use the **1200-baud USB trigger** — no probe, no opening the case. Every clip app has it built in (board-level, `lib/clip_usb_dfu`).
 
-> **Dev recovery vs. official release.** This recovers to a *self-built*
-> `*-signed.bin` you exported above. A published, downloadable release package
-> (GitHub Releases + `scripts/build_release.sh`) is **not yet available** —
-> "return to the official release" is pending that pipeline. Until then, treat
-> this as the development-recovery path; it does not prove a public release.
+> **Dev recovery vs. official release.** This recovers to a *self-built* `*-signed.bin` you exported above. A published, downloadable release package (GitHub Releases + `scripts/build_release.sh`) is **not yet available** — "return to the official release" is pending that pipeline. Until then, treat this as the development-recovery path; it does not prove a public release.
 
-1. The clip app keeps USB off by default — send `AT+USB=on` over BLE first
-   (samples and custom apps with the default CDC auto-enable USB, so skip this
-   there). Then trigger recovery by opening the CDC-ACM port at 1200 baud:
+1. The clip app keeps USB off by default — send `AT+USB=on` over BLE first (samples and custom apps with the default CDC auto-enable USB, so skip this there). Then trigger recovery by opening the CDC-ACM port at 1200 baud:
 
    ```sh
    python3 -c "import serial; s=serial.Serial('/dev/ttyACMx',1200); s.close()"
@@ -391,32 +304,34 @@ trigger** — no probe, no opening the case. Every clip app has it built in
 
    (Holding the user button while plugging USB also enters recovery.)
 
-2. A new CDC-ACM port appears — **PID `0x8069`** (the running app is `0x0069`;
-   the `0x8000` bit marks bootloader mode; both Seeed VID `0x2886`). Upload the
-   signed release app and reset:
+2. A new CDC-ACM port appears — **PID `0x8069`** (the running app is `0x0069`; the `0x8000` bit marks bootloader mode; both Seeed VID `0x2886`). Upload the signed release app and reset:
 
    ```sh
    nrfutil mcu-manager serial image-upload --firmware clip-<version>-signed.bin --serial-port /dev/ttyACMx
    nrfutil mcu-manager serial reset     --serial-port /dev/ttyACMx
    ```
 
-MCUboot verifies the RSA signature and boots the new app; the bootloader
-partition is never touched. The full guide (BLE OTA, the button path, `mcumgr`,
-nRF Connect, troubleshooting) is in [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md).
+MCUboot verifies the RSA signature and boots the new app; the bootloader partition is never touched. The full guide (BLE OTA, the button path, `mcumgr`, nRF Connect, troubleshooting) is in [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md).
 
 ## Where to Go Next
 
-- **System architecture, protocol, update/recovery, validation, production** →
-  [Firmware Development Guide](./respeaker_clip_firmware_development_guide.md)
-  (the comprehensive reference).
+- **System architecture, protocol, update/recovery, validation, production** → [Firmware Development Guide](./respeaker_clip_firmware_development_guide.md) (the comprehensive reference).
 - **Build / flash / power / pitfalls (full reference)** → [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md).
 - **Example apps to copy** → [samples/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/samples/).
-- **AI-assisted development** → [`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/) — load
-  this skill in your AI agent. Its `SKILL.md` plus nine references already
-  encode the project's real constraints, including that **runtime commands for
-  bitrate, codec complexity, AGC, noise suppression, and dereverb do not
-  exist** — audio mode is `normal` or `enhanced` only.
+- **AI-assisted development** → [`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/) — load this skill in your AI agent. Its `SKILL.md` plus nine references already encode the project's real constraints, including that **runtime commands for bitrate, codec complexity, AGC, noise suppression, and dereverb do not exist** — audio mode is `normal` or `enhanced` only.
 
-A stock build that boots, records, and is controllable from the Basic SDK
-(`clip-cli` / SenseCraft Voice app) is the prerequisite for any AI-assisted or
-custom firmware work on this repo.
+A stock build that boots, records, and is controllable from the Basic SDK (`clip-cli` / SenseCraft Voice app) is the prerequisite for any AI-assisted or custom firmware work on this repo.
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="button_tech_support_container">
+<a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+<a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+</div>
+
+<div class="button_tech_support_container">
+<a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+<a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+</div>

--- a/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_firmware_quick_start.md
+++ b/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_firmware_quick_start.md
@@ -1,0 +1,422 @@
+---
+description: "End-to-end path from a clean machine to a reSpeaker Clip that boots, records, and is controllable from the host SDK — the baseline before custom or AI-assisted firmware work, and how to decide whether firmware work is the right path."
+title: Getting Started with the reSpeaker Clip Firmware SDK
+keywords:
+  - reSpeaker clip
+  - firmware
+  - sdk
+  - getting started
+  - nRF5340
+  - Zephyr
+  - NCS
+image: https://files.seeedstudio.com/wiki/reSpeaker_Clip/clip-banner.jpg
+slug: /respeaker_clip_firmware_quick_start
+aliases:
+  - /respeaker_clip_firmware_sdk
+sku: 100020126
+last_update:
+  date: 07/28/2026
+  author: Ray
+createdAt: '2026-07-28'
+updatedAt: '2026-07-28'
+url: https://wiki.seeedstudio.com/respeaker_clip_firmware_quick_start/
+---
+
+# Getting Started with the reSpeaker Clip Firmware SDK
+
+End-to-end path from a clean machine to a reSpeaker Clip that boots, records,
+and is controllable from the host SDK — the baseline before any custom or
+AI-assisted firmware work. It also tells you whether firmware work is even the
+right path for your task.
+
+> **Enclosed device.** The Clip ships in a sealed housing — the SWD/J-Link pads
+> are not reachable without opening the case. **End users upgrade over USB or
+> BLE**, never with a probe. SWD flashing below is the *development* path (bench
+> units with the case off or a debug break-out).
+
+## Introduction
+
+The **Firmware SDK** is the device-side Zephyr RTOS firmware on the Nordic
+nRF5340 (dual-core: application core + network core). It is for developers who
+need to **modify device-side behavior** — the audio pipeline, the AT command
+surface or BLE GATT service, the button / OLED / haptic interaction model, the
+power or productization strategy, or custom hardware bring-up.
+
+The checked-out firmware source is authoritative; docs summarize it. When they
+disagree, the source wins.
+
+## Choose the Right Development Path
+
+Not every task needs firmware work. Pick the path that matches your goal:
+
+| You want to… | Use this | Touches firmware? |
+|---|---|---|
+| Control recording and download files from a host or phone | **Basic SDK** ([sdk/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/sdk/)) or **mobile SDKs** ([mobile/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/mobile/)) | No |
+| Modify the audio pipeline, AT/GATT, button/OLED/haptic, power, or hardware | **Firmware SDK** (this guide + the [Firmware Development Guide](./respeaker_clip_firmware_development_guide.md)) | Yes |
+| Have an AI agent modify the repo within the firmware's real constraints | [`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/) skill | Yes |
+
+The Basic and mobile SDKs talk to the Clip over BLE and the device Wi-Fi AP and
+require no firmware source. They are the supported path for app integration.
+
+**Out of scope for the device firmware** (do not expect these capabilities):
+
+- **Cloud transcription / AI summary** — the Clip records Opus to the SD card;
+  transcription runs off-device. There is no on-device speech-to-text path.
+- **BLE real-time audio streaming** — the BLE link carries AT commands, file
+  transfer frames, and an audio *energy-level* visualization notify only. It
+  does not stream live audio.
+
+## Firmware Capabilities and Customization Boundaries
+
+| Capability | Implemented? | Basic/mobile-SDK controllable? | Firmware-customizable? |
+|---|---|---|---|
+| Recording start/stop/pause/resume/mark | Yes (`AT+START/STOP/PAUSE/RESUME/MARK`) | Yes | Yes (`clip_event.c`, `button.c`) |
+| Normal/Enhanced mode | Yes (`AT+MODE=normal\|enhanced`, persisted) | Yes | Yes (`audio.c` + per-mode Kconfig) |
+| Opus bitrate/complexity | Yes (per-mode Kconfig) | No — build-time only | Yes (Kconfig) |
+| Noise suppression (SpeexDSP NS) | Partial — Enhanced-only, boot-time default, **no runtime AT** (legacy `AT+NOISE` removed) | No | Yes (Kconfig + `config.c`; add an AT handler to expose at runtime) |
+| Dereverberation | Partial — Enhanced-only, boot-time default, **no runtime AT** | No | Yes (Kconfig + `config.c`) |
+| AGC | Yes — hand-rolled integer, always-on | No — not configurable | No — edit `audio.c` |
+| Haptic motor | Yes (`haptic.c`), disabled by default (`CONFIG_CLIP_HAPTIC_MOTOR_ENABLED=n`, but `prj.conf` sets `=y` for this app) | No | Yes |
+| File transfer (BLE + Wi-Fi UDP) | Yes (`AT+DOWNLOAD/CANCEL`) | Yes | Yes (`transport.c`, `transfer.c`) |
+| BLE real-time audio stream | No (energy-level notify only) | N/A | Out of scope |
+
+The full registered AT command list, protocol frames, architecture, validation
+matrix, and production/release details live in the
+[Firmware Development Guide](./respeaker_clip_firmware_development_guide.md) —
+this page only summarizes what you need to get started.
+
+## Recording Mode and Audio Pipeline Facts
+
+> Older docs describe `MODE_NORMAL` as **stereo**. That is wrong. Both modes
+> record **mono**.
+
+- **Both modes** record **mono** via an L+R merge. `clip_event.c` always calls
+  `audio_start_recording(AUDIO_MODE_MERGE)`. `MODE_NORMAL` is **not** stereo —
+  the name is legacy.
+- **`MODE_NORMAL`** (default) = merge + a hand-rolled DSP path only
+  (delay-aligned merge, 100 Hz high-pass, integer AGC, soft limiter). **No
+  SpeexDSP.**
+- **`MODE_ENHANCED`** = merge + SpeexDSP noise suppression and dereverb, gated
+  on `mode == ENHANCED && noise_suppress > 0` (`audio.c:506`). With
+  `noise == 0`, Enhanced behaves like Normal.
+- Opus bitrate and complexity are **per-mode Kconfig constants**
+  (`CLIP_NORMAL_*`/`CLIP_ENHANCED_*`), not runtime-settable.
+- Set the mode with `AT+MODE=normal|enhanced` (persisted) or
+  `AT+START mode=enhanced` (session-only, not persisted).
+
+## Prerequisites
+
+| Tool | Why | Install |
+|------|-----|---------|
+| [NCS **v3.3.0**](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html) source | Zephyr + nRF + nrfxlib + mcuboot source tree. **v3.2.1 is dropped** — `main` needs v3.3.0-only Kconfig and will not build against it. | `west` (see [Set Up NCS](#set-up-ncs-v330)) |
+| Zephyr SDK **0.16.4** toolchain | `arm-zephyr-eabi-gcc` compiler/debugger for nRF5340 | separate install (see [Set Up NCS](#set-up-ncs-v330)) |
+| `west` | Zephyr's meta-tool (build/flash) | `pip install west` |
+| [`nrfutil`](https://www.nordicsemi.com/Products/Development-tools/nrf-util) (≥ 8.x, with `device` + `mcu-manager`) | Reset after flash; USB serial DFU | Nordic site |
+| Python **3.10+** | Host test/SDK tools (`clip-cli`, `udp_sync`, `decode_opus`) | python.org |
+| J-Link (optional, dev only) | SWD flashing on a bench unit | SEGGER |
+
+Install the Python tool dependencies once:
+
+```sh
+pip install -r applications/clip/tests/requirements.txt
+```
+
+## Get the Source Code
+
+The repo is a **Zephyr module** (it carries its own board, drivers, and libs via
+`zephyr/module.yml`). Clone it anywhere, then point the NCS environment at it.
+
+> **Verified baseline.** This guide targets firmware tag **`v0.0.9`**,
+> NCS **v3.3.0**, board **`clip/nrf5340/cpuapp`**, on Ubuntu 24.04. Pin the same
+> tag for a reproducible build, instead of cloning the moving `main` branch:
+
+```sh
+git clone --branch v0.0.9 https://github.com/Seeed-Studio/reSpeaker_Clip.git
+cd reSpeaker_Clip
+git describe --tags    # confirm: v0.0.9
+```
+
+**Supported hardware:** reSpeaker Clip (nRF5340 + nRF7002 + NPM1300 PMIC). Other
+board revisions are not covered by this guide.
+
+## Set Up NCS v3.3.0
+
+NCS v3.3.0 is installed as a **west workspace** — the NCS source tree plus a
+separate **Zephyr SDK toolchain**. This is how the reference setup installs it.
+
+> **Do not use `nrfutil toolchain-manager`.** The `nrfutil` v6.1.7 binary does
+> not actually have the `toolchain-manager`/`self-upgrade` commands, so the
+> firmware CI's NCS-install step is currently broken (the
+> [`firmware.yml`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/.github/workflows/firmware.yml)
+> runs are failing). Use the west steps below instead. If you already have NCS
+> v3.3.0 (e.g. installed via nRF Connect for Desktop), skip to
+> [Enter the NCS environment](#enter-the-ncs-environment--register-this-repo-as-a-module).
+
+### 1. Install build dependencies + `west`
+
+```sh
+sudo apt install -y cmake ninja-build g++ make device-tree-compiler \
+    python3 python3-pip git curl ca-certificates
+sudo pip3 install --break-system-packages west
+west --version          # expect west 1.x
+```
+
+### 2. Install the NCS v3.3.0 source (west manifest)
+
+This creates the workspace at `~/ncs/v3.3.0` and fetches the NCS modules
+(zephyr, nrf, nrfxlib, mcuboot, HALs, crypto, …) — about 2 GB from GitHub.
+
+```sh
+west init -m https://github.com/nrfconnect/sdk-nrf --mr v3.3.0 ~/ncs/v3.3.0
+cd ~/ncs/v3.3.0
+west update
+```
+
+### 3. Install the Zephyr SDK toolchain (separate)
+
+The west workspace gives the **source**; the **compiler** comes from the
+Zephyr SDK. Download version **0.16.4** from the
+[Zephyr SDK releases](https://github.com/zephyrproject-rtos/sdk/releases)
+(the `*_linux-x86_64.tar.xz` asset), extract it, and run its setup once:
+
+```sh
+cd ~
+tar xf zephyr-sdk-0.16.4_linux-x86_64.tar.xz     # you downloaded this
+cd zephyr-sdk-0.16.4
+./setup.sh                                        # registers toolchains + udev rules
+# → compiler at ~/zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
+```
+
+> **Linux device access — `nrf-udev` + J-Link udev rules.** To flash or reset
+> over USB/J-Link without root, install `nrf-udev` (Nordic's `.deb`) and the
+> SEGGER udev rules — otherwise `/dev/ttyACMx` and J-Link probes are root-only.
+> See the
+> [nRF Util prerequisites](https://docs.nordicsemi.com/r/bundle/nrfutil/page/guides/installing.html/prerequisites).
+
+### Enter the NCS environment + register this repo as a module
+
+```sh
+source ~/ncs/v3.3.0/zephyr/zephyr-env.sh
+export ZEPHYR_EXTRA_MODULES=$PWD     # the reSpeaker_Clip checkout
+```
+
+> **Why `ZEPHYR_EXTRA_MODULES` is an env var, not a `-D` CMake var.** Kconfig
+> module discovery runs *before* CMake configures. A `-D` would arrive too late,
+> so Kconfig would never see this repo's board (`clip`), drivers, or libraries.
+> Set it in the same shell you build from — or export it in your shell profile.
+
+**Checkpoint — your environment is ready when these all succeed:**
+
+```sh
+west --version                   # west 1.x
+arm-zephyr-eabi-gcc --version    # (Zephyr SDK 0.16.4) gcc 12.x
+python3 --version                # Python 3.10+
+echo $ZEPHYR_BASE                # .../ncs/v3.3.0/zephyr
+```
+
+## Build the Stock Firmware
+
+```sh
+west build --build-dir build-clip --board clip/nrf5340/cpuapp applications/clip
+```
+
+For a fully clean rebuild (required after MCUboot patch changes or a stale
+build dir), add `--pristine`:
+
+```sh
+west build --build-dir build-clip --pristine --board clip/nrf5340/cpuapp applications/clip
+```
+
+This is a **sysbuild by default** — one command produces the custom signed
+MCUboot bootloader + the application core + the network-core BLE controller
+image. The board supplies all the sysbuild glue; no per-app `sysbuild.conf` is
+needed.
+
+> **Board identifier**: `clip/nrf5340/cpuapp` — **not** `respeaker/...`.
+
+> **Reproducibility — VM vs. device.** The install path targets Ubuntu 24.04
+> with real network access (the multi-GB NCS fetch needs reliable GitHub
+> connectivity — a QEMU/VM's user-mode networking struggles with it). A QEMU/VM
+> can exercise the *install and build steps* but is **not** a device substitute —
+> QEMU cannot emulate the nRF5340 dual-core, nRF7002, PDM mic, SD, OLED, PMIC, or
+> real USB/BLE behavior. Flash, transport, audio, and recovery must be verified
+> on a real Clip.
+
+## Build the Production Configuration
+
+The low-power variant: UART console and the FS/UART log backends off, idle
+≈170 µA (vs. the debug build, where the console leaks ~570 µA). Use this for
+battery/production builds where the console current matters.
+
+```sh
+west build --build-dir build-clip-prod --board clip/nrf5340/cpuapp applications/clip \
+  -- -DSNIPPET_ROOT=$(pwd)/applications/clip -DSNIPPET=production
+```
+
+`SNIPPET_ROOT` must be an absolute path. The `production` snippet lives in
+`applications/clip/snippets/production/`.
+
+## Flash and Reset
+
+```sh
+west flash --build-dir build-clip          # flash both cores
+nrfutil device reset --serial-number <JLINK-SN>
+```
+
+> **`--serial-number` targets a specific J-Link.** Omit it only when a single
+> device is attached — with multiple probes the bare `nrfutil device reset` is
+> ambiguous. Find the SN with `nrfutil device list` or printed on the J-Link case.
+
+Two caveats specific to this board:
+
+- **`west flash --reset` does NOT work** here. Always reset separately with
+  `nrfutil device reset`.
+- **`--recover` erases both cores** (it clears the net-core access-port lock).
+  Use it only when the net-core AP is `b0n`-locked (e.g. after a prior secure
+  boot) — not as a routine flag.
+
+End users (case on, no probe) skip this step entirely and use USB serial DFU —
+see [Recover with USB Serial DFU](#recover-with-usb-serial-dfu) below.
+
+## Open the Debug Console
+
+```sh
+minicom -D /dev/ttyACM0 -b 921600
+```
+
+When a J-Link probe is also connected, the J-Link grabs `ttyACM0` and the Clip's
+UART0 bridge moves to `ttyACM1` — use whichever port is the "USB Single Serial"
+(non-J-Link) one.
+
+## Run the Smoke Test
+
+Success criteria: the device boots, answers AT commands over BLE, records a
+valid Opus file, and pulls it back over Wi-Fi. All AT responses are JSON —
+success is `{"ok":true,"data":{...}}`, failure is `{"ok":false,"msg":"..."}`.
+
+### Boot & status
+
+The OLED lights up and the device reaches IDLE. Confirm over any AT channel:
+
+```
+AT+GSTAT        →  {"ok":true,"data":{"state":"IDLE","battery":..,"mode":..,...}}
+AT+VERSION      →  {"ok":true,"data":{"version":"0.0.6",...}}
+```
+
+### Record → list → download (over BLE)
+
+`clip-cli.py` is the unified host CLI (BLE default, also Wi-Fi). With the device
+advertising:
+
+```sh
+# status over BLE
+python applications/clip/tests/tools/clip-cli.py status
+
+# record ~5s, stop, list sessions
+python applications/clip/tests/tools/clip-cli.py record --duration 5
+python applications/clip/tests/tools/clip-cli.py list
+```
+
+`AT+LIST` should show the new session (sorted newest-first). Pull the Opus
+files back over BLE and decode one to WAV to confirm it is valid audio:
+
+```sh
+python applications/clip/tests/tools/clip-cli.py sync --session <session_id>
+python applications/clip/tests/tools/decode_opus.py recordings/<session_id>/0001.opus out.wav   # plays
+```
+
+### Wi-Fi pull (UDP sync, CRC32-verified)
+
+The device exposes a Wi-Fi AP once enabled. Over BLE first:
+
+```
+AT+WIFI=on     →  {"ok":true,"data":{"ssid":"ClipAP_XXXX",...}}
+```
+
+Then from the host, join the AP and sync the session:
+
+```sh
+# SSID ClipAP_XXXX (last 4 hex of chip ID) · password 12345678 (default;
+# becomes random after the first BLE pairing) · IP 192.168.4.1 · UDP 8089
+python applications/clip/tests/tools/udp_sync.py --session <session_id>
+```
+
+If all four pass — status, record, list/download with a decodable Opus file, and
+the Wi-Fi pull — the stock firmware baseline is good.
+
+## Export Build Artifacts
+
+There is no single-zip export yet — the tag-triggered `scripts/build_release.sh`
++ `.github/workflows/release.yml` are not yet implemented. For now, build both
+variants and copy the four artifacts each manually:
+
+```sh
+VERSION=$(grep APP_VERSION_STRING build-clip/clip/zephyr/include/generated/zephyr/app_version.h | cut -d'"' -f2)
+mkdir -p output/$VERSION
+
+# Debug
+cp build-clip/merged.hex            output/$VERSION/clip-$VERSION-debug-merged.hex
+cp build-clip/merged_CPUNET.hex     output/$VERSION/clip-$VERSION-debug-merged_CPUNET.hex
+cp build-clip/dfu_application.zip   output/$VERSION/clip-$VERSION-debug-ota.zip
+cp build-clip/clip/zephyr/zephyr.signed.bin output/$VERSION/clip-$VERSION-debug-signed.bin
+# Production
+cp build-clip-prod/merged.hex            output/$VERSION/clip-$VERSION-production-merged.hex
+cp build-clip-prod/merged_CPUNET.hex     output/$VERSION/clip-$VERSION-production-merged_CPUNET.hex
+cp build-clip-prod/dfu_application.zip   output/$VERSION/clip-$VERSION-production-ota.zip
+cp build-clip-prod/clip/zephyr/zephyr.signed.bin output/$VERSION/clip-$VERSION-production-signed.bin
+```
+
+Per release: `*-merged.hex` / `*-merged_CPUNET.hex` (programmer), `*-signed.bin`
+(USB serial DFU), `*-ota.zip` (BLE/USB mcumgr multi-image package).
+
+## Recover with USB Serial DFU
+
+If a bench build left the device in a bad state, use the **1200-baud USB
+trigger** — no probe, no opening the case. Every clip app has it built in
+(board-level, `lib/clip_usb_dfu`).
+
+> **Dev recovery vs. official release.** This recovers to a *self-built*
+> `*-signed.bin` you exported above. A published, downloadable release package
+> (GitHub Releases + `scripts/build_release.sh`) is **not yet available** —
+> "return to the official release" is pending that pipeline. Until then, treat
+> this as the development-recovery path; it does not prove a public release.
+
+1. The clip app keeps USB off by default — send `AT+USB=on` over BLE first
+   (samples and custom apps with the default CDC auto-enable USB, so skip this
+   there). Then trigger recovery by opening the CDC-ACM port at 1200 baud:
+
+   ```sh
+   python3 -c "import serial; s=serial.Serial('/dev/ttyACMx',1200); s.close()"
+   ```
+
+   (Holding the user button while plugging USB also enters recovery.)
+
+2. A new CDC-ACM port appears — **PID `0x8069`** (the running app is `0x0069`;
+   the `0x8000` bit marks bootloader mode; both Seeed VID `0x2886`). Upload the
+   signed release app and reset:
+
+   ```sh
+   nrfutil mcu-manager serial image-upload --firmware clip-<version>-signed.bin --serial-port /dev/ttyACMx
+   nrfutil mcu-manager serial reset     --serial-port /dev/ttyACMx
+   ```
+
+MCUboot verifies the RSA signature and boots the new app; the bootloader
+partition is never touched. The full guide (BLE OTA, the button path, `mcumgr`,
+nRF Connect, troubleshooting) is in [usb_dfu.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/docs/usb_dfu.md).
+
+## Where to Go Next
+
+- **System architecture, protocol, update/recovery, validation, production** →
+  [Firmware Development Guide](./respeaker_clip_firmware_development_guide.md)
+  (the comprehensive reference).
+- **Build / flash / power / pitfalls (full reference)** → [CLAUDE.md](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/CLAUDE.md).
+- **Example apps to copy** → [samples/](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/samples/).
+- **AI-assisted development** → [`skills/clip-dev/`](https://github.com/Seeed-Studio/reSpeaker_Clip/blob/main/skills/clip-dev/) — load
+  this skill in your AI agent. Its `SKILL.md` plus nine references already
+  encode the project's real constraints, including that **runtime commands for
+  bitrate, codec complexity, AGC, noise suppression, and dereverb do not
+  exist** — audio mode is `normal` or `enhanced` only.
+
+A stock build that boots, records, and is controllable from the Basic SDK
+(`clip-cli` / SenseCraft Voice app) is the prerequisite for any AI-assisted or
+custom firmware work on this repo.

--- a/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_getting_started.md
+++ b/sites/en/docs/Sensor/reSpeaker_clip/respeaker_clip_getting_started.md
@@ -458,7 +458,11 @@ From a development perspective, the firmware is mainly divided into the followin
 
 A typical development workflow is: set up the Zephyr / nRF Connect SDK environment, obtain the reSpeaker Clip firmware project, confirm the board target and configuration files, build and flash the firmware, check serial logs, and finally verify recording, file sync, and firmware update through the SenseCraft Voice App or BLE / Wi-Fi protocols.
 
-For more firmware architecture, environment setup, build, flashing, and secondary development details, refer to the reSpeaker Clip Firmware Development Guide (coming soon).
+Go to the Firmware SDK documentation for the next steps:
+
+- [Getting Started with the reSpeaker Clip Firmware SDK](/respeaker_clip_firmware_quick_start/) covers environment setup, build, flash, and smoke testing.
+- [reSpeaker Clip Firmware Development Guide](/respeaker_clip_firmware_development_guide/) explains the firmware architecture, communication protocol, update and recovery paths, validation, and production release.
+- [Customization: Add a Custom AT Command](/respeaker_clip_customization_at_command/) shows how to add and validate a new AT command, including an AI prompt that uses the repository firmware Skill.
 
 ### Application SDK
 
@@ -559,7 +563,8 @@ If OTA or firmware update fails, try the following:
 | Product Page | [reSpeaker Clip Wearable AI Recorder](https://www.seeedstudio.com/respeaker-clip-wearable-ai-recorder.html) |
 | SenseCraft Voice App Download | [Download Page](https://sensecraft-voice-download.seeed.cc/) |
 | Firmware Download | Coming soon |
-| SDK Repository | Coming soon |
+| Firmware SDK Documentation | [Getting Started with the Firmware SDK](./respeaker_clip_firmware_quick_start.md) |
+| SDK Repository | [reSpeaker Clip GitHub](https://github.com/Seeed-Studio/reSpeaker_Clip) |
 | User Manual | <a href="https://files.seeedstudio.com/wiki/reSpeaker_Clip/respeaker_clip_user_manual.pdf" target="_blank" rel="noopener noreferrer">reSpeaker Clip User Manual</a> |
 | Datasheet | Coming soon |
 | Mechanical Drawing | Coming soon |

--- a/sites/en/sidebars.js
+++ b/sites/en/sidebars.js
@@ -2171,6 +2171,29 @@ const sidebars = {
           items: [
             'Sensor/reSpeaker_clip/respeaker_clip_getting_started',
             'Sensor/reSpeaker_clip/respeaker_clip_basic_sdk_guide',
+            {
+              type: 'category',
+              label: 'Firmware SDK',
+              collapsed: true,
+              collapsible: true,
+              items: [
+                {
+                  type: 'doc',
+                  id: 'Sensor/reSpeaker_clip/respeaker_clip_firmware_quick_start',
+                  label: 'Getting Started',
+                },
+                {
+                  type: 'doc',
+                  id: 'Sensor/reSpeaker_clip/respeaker_clip_firmware_development_guide',
+                  label: 'Development Guide',
+                },
+                {
+                  type: 'doc',
+                  id: 'Sensor/reSpeaker_clip/respeaker_clip_customization_at_command',
+                  label: 'Custom AT Command',
+                },
+              ],
+            },
           ],
         },
         {


### PR DESCRIPTION
  ## Summary

  - Add reSpeaker Clip firmware SDK quick-start, development, and custom AT command guides.
  - Update the basic SDK and getting-started documentation.
  - Add the new firmware SDK pages to the English documentation sidebar.

  ## Validation

  - `git diff --cached --check`