### PR TITLE
Fix: Grove Starter Kit for Pi Pico - correct DHT20 port and filename

### DIFF
--- a/sites/en/docs/Sensor/Pi_Pico/Grove-Starter-Kit-for-Raspberry-Pi-Pico.md
+++ b/sites/en/docs/Sensor/Pi_Pico/Grove-Starter-Kit-for-Raspberry-Pi-Pico.md
@@ -447,10 +447,10 @@ while True:
 ```
 
 2. Download the following required Python files to your local machine:
-   - [dht20.py](https://files.seeedstudio.com/wiki/Grove-Temperature-Humidity-Sensor/dht/DHT20.py)
+   - [DHT20.py](https://files.seeedstudio.com/wiki/Grove-Temperature-Humidity-Sensor/dht/DHT20.py)
    - [lcd1602.py](https://files.seeedstudio.com/wiki/Grove-16x2_LCD--White_on_Blue/lcd1602.py)
 
-3. Open **dht20.py** in Thonny IDE, click `File -> Save As -> MicroPython device`, and save the file with the name **dht20.py** on your device.
+3. Open **DHT20.py** in Thonny IDE, click `File -> Save As -> MicroPython device`, and save the file with the name **dht20.py** on your device.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Grove-Temperature-Humidity-Sensor/saveas.png" style={{width:750, height:'auto'}}/></div>
 

--- a/sites/en/docs/Sensor/Pi_Pico/Grove-Starter-Kit-for-Raspberry-Pi-Pico.md
+++ b/sites/en/docs/Sensor/Pi_Pico/Grove-Starter-Kit-for-Raspberry-Pi-Pico.md
@@ -405,7 +405,7 @@ You should now see the temperature and humidity displayed on the OLED screen, si
 
 **Step 2.** Connect the Grove 16x2 LCD (White on Blue) to port I2C1 of the Grove Shield.
 
-**Step 3.** Connect the Grove Temperature & Humidity Sensor V2.0 (DHT20) to port D18 of the Grove Shield.
+**Step 3.** Connect the Grove Temperature & Humidity Sensor V2.0 (DHT20) to port I2C0 of the Grove Shield.
 
 **Step 4.** Plug the Grove Shield into the Pi Pico.
 
@@ -447,10 +447,10 @@ while True:
 ```
 
 2. Download the following required Python files to your local machine:
-   - [DHT20.py](https://files.seeedstudio.com/wiki/Grove-Temperature-Humidity-Sensor/dht/DHT20.py)
+   - [dht20.py](https://files.seeedstudio.com/wiki/Grove-Temperature-Humidity-Sensor/dht/DHT20.py)
    - [lcd1602.py](https://files.seeedstudio.com/wiki/Grove-16x2_LCD--White_on_Blue/lcd1602.py)
 
-3. Open **DHT20.py** in Thonny IDE, click `File -> Save As -> MicroPython device`, and save the file with the name **DHT20.py** on your device.
+3. Open **dht20.py** in Thonny IDE, click `File -> Save As -> MicroPython device`, and save the file with the name **dht20.py** on your device.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Grove-Temperature-Humidity-Sensor/saveas.png" style={{width:750, height:'auto'}}/></div>
 


### PR DESCRIPTION
## Summary

This PR fixes two errors in Project 2 (Option 2: DHT20 and LCD1602) of the Grove Starter Kit for Raspberry Pi Pico wiki:

### Fix 1: DHT20 wiring port — D18 → I2C0

The wiring instruction said to connect DHT20 to port **D18**, but the code initializes the sensor on **I2C0** (`I2C(0, scl=Pin(9), sda=Pin(8))`). The DHT20 is an I2C sensor and must be connected to an I2C port — D18 is a digital GPIO pin and will not work.

### Fix 2: Library filename — DHT20.py → dht20.py

The save instruction told users to name the file **DHT20.py**, but the code imports it as `from dht20 import DHT20` (lowercase). MicroPython's filesystem on the Pico is case-sensitive, so the import fails if the file is saved with uppercase letters.

### Changes made

| Location | Before | After |
|---|---|---|
| Line 408 (wiring step) | port **D18** | port **I2C0** |
| Line 450 (download link text) | [**DHT20.py**] | [**dht20.py**] |
| Line 453 (save instruction) | save as **DHT20.py** | save as **dht20.py** |

These issues were reported by a customer who spent considerable time troubleshooting them.