### PR TITLE
Update ePaper Displays documentation for reTerminal E Series

### DIFF
--- a/sites/en/docs/Sensor/ePaper_Displays/Application/work_with_esphome.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/Application/work_with_esphome.md
@@ -22,12 +22,12 @@ updatedAt: '2026-06-16'
 
 # Work with ESPHome
 
-:::tip Try demos without setting up a development environment
-If you want to quickly preview project results or try the basic demo firmware before setting up a development environment, open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)**. You can choose a supported reTerminal E Series device and flash demo firmware directly from a browser.
+:::tip Generate ESPHome YAML or flash demos in the browser
+The fastest way to start is the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)**. Choose the **ESPHome** card, pick your device, check the onboard features you want (display, buttons, battery, sensors, RTC, SD card, microphone, touch, deep sleep, and more), then copy or download the generated YAML into your ESPHome dashboard. The same Hub can also flash demo firmware from the browser (desktop Chrome or Edge).
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
     <a class="get_one_now_item" href="https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/" target="_blank">
-            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Flasher 🖱️</font></span></strong>
+            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Hub 🖱️</font></span></strong>
     </a>
 </div><br />
 :::
@@ -57,7 +57,7 @@ Every Seeed ePaper product on the [main hub page](/seeed_epaper_displays) that h
       <td>XIAO ESP32-S3</td>
       <td>
         <a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome/">Display basics, HA integration & drawing</a><br/>
-        <a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced/">Buttons, buzzer, LED, battery, SHT4x & deep sleep</a><br/>
+        <a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced/">Buttons, buzzer, LED, battery, touch (E1003), SHT4x & deep sleep</a><br/>
         <a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_rtc_sd_microphone/">RTC, SD card & microphone</a>
       </td>
     </tr>
@@ -263,7 +263,7 @@ You can now drag the entities into a Lovelace dashboard, or — much more intere
 This page intentionally stops at the boilerplate. The product-specific YAML, peripheral examples, and end-to-end recipes live in each product's cookbook:
 
 - **[reTerminal E Series — ESPHome Display](/reterminal_e10xx_with_esphome)** — first dashboard, Wi-Fi setup, and ePaper drawing examples for E1001/E1002/E1003/E1004.
-- **[reTerminal E Series — ESPHome I/O, Battery & Power](/reterminal_e10xx_with_esphome_advanced)** — buttons, buzzer, onboard LED, battery monitoring, SHT4x sensor, deep sleep, and multi-page dashboards.
+- **[reTerminal E Series — ESPHome I/O, Battery, Touch & Power](/reterminal_e10xx_with_esphome_advanced)** — buttons, buzzer, onboard LED, battery monitoring, SHT4x sensor, capacitive touch (E1003), deep sleep, and multi-page dashboards.
 - **[reTerminal E1001 / E1002 — ESPHome RTC, SD & Microphone](/reterminal_e10xx_with_esphome_rtc_sd_microphone)** — PCF8563 RTC time sync, microSD card power/detect pins, and onboard PDM microphone setup.
 - **[EE04 driver board — ESPHome](/EE04_with_esphome_advanced)** — full Home Assistant integration on the XIAO ESP32-S3 + EE04 + your choice of ePaper screen.
 - **[XIAO 7.5" ePaper Panel — ESPHome](/xiao_075inch_epaper_panel_esphome)** — minimal ESP32-C3 dashboard.

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome.md
@@ -9,10 +9,10 @@ sku: 100017057,100073581
 sidebar_position: 3
 sidebar_label: ESPHome - Display
 last_update:
-  date: 04/28/2026
+  date: 08/05/2026
   author: Citric
 createdAt: '2025-07-25'
-updatedAt: '2026-06-16'
+updatedAt: '2026-08-05'
 url: https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome/
 ---
 
@@ -22,15 +22,17 @@ import TabItem from '@theme/TabItem';
 # ESPHome Cookbook - Display Basics: reTerminal E Series
 
 :::tip Read the main ESPHome guide first
-This page is the **reTerminal E Series-specific ESPHome display cookbook**. The shared boilerplate — picking a flashing path, the generic YAML skeleton, connecting to Home Assistant — lives in **[Work with ESPHome](/epaper_work_with_esphome)**. Skim that first if you're new to ESPHome on Seeed ePaper. For buttons, buzzer, LED, battery, SHT4x, and deep sleep, see the [I/O, battery, and low-power cookbook](/reterminal_e10xx_with_esphome_advanced). For RTC, microSD card detect, and microphone setup, see the [RTC, SD card, and microphone cookbook](/reterminal_e10xx_with_esphome_rtc_sd_microphone).
+This page is the **reTerminal E Series-specific ESPHome display cookbook**. The shared boilerplate — picking a flashing path, the generic YAML skeleton, connecting to Home Assistant — lives in **[Work with ESPHome](/epaper_work_with_esphome)**. Skim that first if you're new to ESPHome on Seeed ePaper. For buttons, buzzer, LED, battery, SHT4x, and deep sleep, see the [I/O, battery, touch, and low-power cookbook](/reterminal_e10xx_with_esphome_advanced). For RTC, microSD card detect, and microphone setup, see the [RTC, SD card, and microphone cookbook](/reterminal_e10xx_with_esphome_rtc_sd_microphone).
 :::
 
-:::tip Try demos without setting up a development environment
-If you want to quickly preview project results or try the basic demo firmware before setting up a development environment, open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)**. You can choose a supported reTerminal E Series device and flash demo firmware directly from a browser.
+:::tip Generate ESPHome YAML or flash demos in the browser
+Want a ready-made ESPHome configuration without assembling every pin by hand? Open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)**, choose the **ESPHome** card, pick your device (E1001 / E1002 / E1003 / E1004), then check the onboard features you need — display, buttons, battery, sensors, RTC, SD card, microphone, touch, deep sleep, and more. The Hub generates matching ESPHome YAML you can copy or download into your ESPHome dashboard.
+
+The same Hub can also flash demo firmware directly from the browser (desktop Chrome or Edge). For the shared ESPHome workflow, see **[Work with ESPHome](/epaper_work_with_esphome)**.
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
     <a class="get_one_now_item" href="https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/" target="_blank">
-            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Flasher 🖱️</font></span></strong>
+            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Hub 🖱️</font></span></strong>
     </a>
 </div><br />
 :::
@@ -89,17 +91,19 @@ Before the tutorial content of this article begins, you may need to have the fol
 
 ### Materials Required
 
+:::tip Supported models
+This cookbook covers **reTerminal E1001, E1002, E1003, and E1004**. Choose the matching tab in each example for your device. E1003 and E1004 require **ESPHome 2026.7.0 or later**.
+:::
+
 <div class="table-center">
   <table align="center">
     <tr>
       <th>reTerminal E1001</th>
       <th>reTerminal E1002</th>
-      <th>Home Assistant Green</th>
     </tr>
     <tr>
       <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/145.jpg" style={{width:250, height:'auto'}}/></div></td>
       <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/146.jpg" style={{width:250, height:'auto'}}/></div></td>
-      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/visionai-v2-ha/ha.png" style={{width:210, height:'auto'}}/></div></td>
     </tr>
     <tr>
       <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
@@ -112,6 +116,44 @@ Before the tutorial content of this article begins, you may need to have the fol
         <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
         </a>
       </div></td>
+    </tr>
+  </table>
+</div>
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <th>reTerminal E1003</th>
+      <th>reTerminal E1004</th>
+    </tr>
+    <tr>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/e1003/2-reTerminal-E1003-Epaper-Display.jpg" style={{width:250, height:'auto'}}/></div></td>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/e1004/2-reterminal-e1004-epaper-display.jpg" style={{width:250, height:'auto'}}/></div></td>
+    </tr>
+    <tr>
+      <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+        <a class="get_one_now_item" href="https://www.seeedstudio.com/reTerminal-E1003-p-6731.html" target="_blank" rel="noopener noreferrer">
+        <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+        </a>
+      </div></td>
+      <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+        <a class="get_one_now_item" href="https://www.seeedstudio.com/reTerminal-E1004-p-6692.html" target="_blank" rel="noopener noreferrer">
+        <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+        </a>
+      </div></td>
+    </tr>
+  </table>
+</div>
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <th>Home Assistant Green</th>
+    </tr>
+    <tr>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/visionai-v2-ha/ha.png" style={{width:210, height:'auto'}}/></div></td>
+    </tr>
+    <tr>
       <td><div class="get_one_now_container" style={{textAlign: 'center'}}>
         <a class="get_one_now_item" href="https://www.seeedstudio.com/Home-Assistant-Green-p-5792.html" target="_blank">
         <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
@@ -124,6 +166,30 @@ Before the tutorial content of this article begins, you may need to have the fol
 Home Assistant Green is the easiest and most privacy-focused way to automate your home. It offers an effortless setup and allows you to control all the smart devices with just one system, where all the data is stored locally by default. This board benefits from the thriving Home Assistant ecosystem and it will be improved every month by open source.
 
 We recommend using Home Assistant Green as the Home Assistant host for this tutorial, or you can use any Home Assistant host with a Supervisor.
+
+### Generate your first ESPHome YAML (recommended)
+
+Before you copy the cookbook snippets below, you can build a complete, device-matched configuration in one place:
+
+**Step 1.** Open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)** in desktop Chrome or Edge.
+
+**Step 2.** Select the **ESPHome** platform card, then pick your reTerminal model (E1001 / E1002 / E1003 / E1004).
+
+**Step 3.** In the setup step, check the features available on your device — for example display, buttons, buzzer, LED, battery, SHT4x, RTC, microSD, microphone, touch (E1003), or deep sleep.
+
+**Step 4.** Generate the YAML, then use **Copy to clipboard** or **Download file** and import it into your ESPHome dashboard.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/257.png" style={{width:1000, height:'auto'}}/></div>
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/" target="_blank">
+            <strong><span><font color={'FFFFFF'} size={"4"}> Open Firmware Hub 🖱️</font></span></strong>
+    </a>
+</div><br />
+
+:::tip
+The Firmware Hub fills in board, bus, and peripheral pins for you. Use this cookbook when you want to learn each drawing or display example step by step, or when you customize the generated YAML. The full shared workflow is documented in **[Work with ESPHome](/epaper_work_with_esphome)**.
+:::
 
 :::tip install Home Assistant
 We have also written how to install Home Assistant for some of Seeed Studio products, please refer to them.
@@ -250,6 +316,88 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later for the `it8951` display platform.
+:::
+
+```yaml
+# define font to display words
+font:
+  - file: "gfonts://Inter@700"
+    id: myFont
+    size: 24
+
+# OPI PSRAM is required for the E1003 framebuffer
+psram:
+  mode: octal
+
+# define SPI interface
+spi:
+  id: epaper_spi_bus
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 300s
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      it.print(0, 0, id(myFont), Color::BLACK, "Hello World!");
+```
+
+</TabItem>
+
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later for the `seeed-reterminal-e1004` model.
+:::
+
+```yaml
+# define font to display words
+font:
+  - file: "gfonts://Inter@700"
+    id: myFont
+    size: 24
+
+# OPI PSRAM is required for the E1004 framebuffer
+psram:
+  mode: octal
+
+# define SPI interface
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+display:
+  - platform: epaper_spi
+    model: seeed-reterminal-e1004
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK   = Color(0,   0,   0,   0);
+      # const auto RED     = Color(255, 0,   0,   0);
+      # const auto GREEN   = Color(0,   255, 0,   0);
+      # const auto BLUE    = Color(0,   0,   255, 0);
+      # const auto YELLOW  = Color(255, 255, 0,   0);
+      it.print(0, 0, id(myFont), BLACK, "Hello World!");
+```
+
+</TabItem>
+
 </Tabs>
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/36.png" style={{width:1000, height:'auto'}}/></div>
@@ -425,6 +573,94 @@ When you see the feedback like the following image, it means the code is running
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/144.jpg" style={{width:600, height:'auto'}}/></div>
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+font:
+  - file: "gfonts://Inter@700"
+    id: myFont
+    size: 24
+
+psram:
+  mode: octal
+
+spi:
+  id: epaper_spi_bus
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 300s
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      it.rectangle(10, 10, 100, 50, Color::BLACK);
+      it.rectangle(150, 10, 50, 50, Color::BLACK);
+      it.circle(250, 35, 25, Color::BLACK);
+      it.filled_rectangle(10, 80, 100, 50, Color::BLACK);
+      it.filled_rectangle(150, 80, 50, 50, Color::BLACK);
+      it.filled_circle(250, 105, 25, Color::BLACK);
+```
+
+</TabItem>
+
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+font:
+  - file: "gfonts://Inter@700"
+    id: myFont
+    size: 24
+
+psram:
+  mode: octal
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+display:
+  - platform: epaper_spi
+    model: seeed-reterminal-e1004
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK   = Color(0,   0,   0,   0);
+      const auto RED     = Color(255, 0,   0,   0);
+      const auto GREEN   = Color(0,   255, 0,   0);
+      const auto BLUE    = Color(0,   0,   255, 0);
+      const auto YELLOW  = Color(255, 255, 0,   0);
+      const auto WHITE   = Color(255, 255, 255, 0);
+
+      it.rectangle(10, 10, 100, 50, BLACK);
+      it.rectangle(150, 10, 50, 50, RED);
+      it.circle(250, 35, 25, GREEN);
+      it.filled_rectangle(10, 80, 100, 50, BLUE);
+      it.filled_rectangle(150, 80, 50, 50, YELLOW);
+      it.filled_circle(250, 105, 25, WHITE);
+```
+
+</TabItem>
+
 </Tabs>
 
 Due to space constraints, we will not elaborate too much on the drawing methods and principles of other patterns, if necessary, the reader is recommended to read [ESPHome in this part of the detailed examples](https://esphome.io/components/display/).
@@ -615,6 +851,131 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+# Example ESPHome configuration to retrieve weather data
+# Get info from HA, as string format
+text_sensor:
+  - platform: homeassistant
+    entity_id: weather.home
+    id: myWeather
+    internal: true
+  - platform: homeassistant
+    entity_id: weather.home
+    id: myTemperature
+    attribute: "temperature"
+    internal: true
+
+# Get info from HA, as float format
+sensor:
+  - platform: homeassistant
+    entity_id: weather.home
+    id: myWindBearing
+    attribute: "wind_bearing"
+    internal: true
+
+font:
+  - file: "gfonts://Inter@700"
+    id: myFont
+    size: 24
+
+psram:
+  mode: octal
+
+spi:
+  id: epaper_spi_bus
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 300s
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      ESP_LOGD("epaper", "weather: %s", id(myWeather).state.c_str());
+      ESP_LOGD("epaper", "temperature: %s", id(myTemperature).state.c_str());
+      ESP_LOGD("epaper", "pressure: %.1f", id(myWindBearing).state);
+      it.printf(100, 100, id(myFont), Color::BLACK, "%s", id(myWeather).state.c_str());
+      it.printf(100, 150, id(myFont), Color::BLACK, "%s", id(myTemperature).state.c_str());
+      it.printf(100, 200, id(myFont), Color::BLACK, "%.1f", id(myWindBearing).state);
+```
+
+</TabItem>
+
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+# Example ESPHome configuration to retrieve weather data
+# Get info from HA, as string format
+text_sensor:
+  - platform: homeassistant
+    entity_id: weather.home
+    id: myWeather
+    internal: true
+  - platform: homeassistant
+    entity_id: weather.home
+    id: myTemperature
+    attribute: "temperature"
+    internal: true
+
+# Get info from HA, as float format
+sensor:
+  - platform: homeassistant
+    entity_id: weather.home
+    id: myWindBearing
+    attribute: "wind_bearing"
+    internal: true
+
+font:
+  - file: "gfonts://Inter@700"
+    id: myFont
+    size: 24
+
+psram:
+  mode: octal
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+display:
+  - platform: epaper_spi
+    model: seeed-reterminal-e1004
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK   = Color(0,   0,   0,   0);
+
+      ESP_LOGD("epaper", "weather: %s", id(myWeather).state.c_str());
+      ESP_LOGD("epaper", "temperature: %s", id(myTemperature).state.c_str());
+      ESP_LOGD("epaper", "pressure: %.1f", id(myWindBearing).state);
+      it.printf(100, 100, id(myFont), BLACK, "%s", id(myWeather).state.c_str());
+      it.printf(100, 150, id(myFont), BLACK, "%s", id(myTemperature).state.c_str());
+      it.printf(100, 200, id(myFont), BLACK, "%.1f", id(myWindBearing).state);
+```
+
+</TabItem>
+
 </Tabs>
 
 After compiling the above code and uploading it to your device, you may first see **NaN** displayed on the screen, please don't worry, this is normal. This is due to the fact that the device has not yet been added to the Home Assistant environment, so reTerminal has not yet been able to acquire Home Assistant data. We just need to follow the steps below to add the device.
@@ -754,6 +1115,101 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+# define font to display words
+font:
+  - file: 'fonts/materialdesignicons-webfont.ttf'  # Path to the font file
+    id: font_mdi_large
+    size: 200        # Large icon size
+    glyphs: &mdi-weather-glyphs
+      - "\U000F0595" # weather-cloudy icon
+      - "\U000F0592" # weather-hail icon
+  - file: 'fonts/materialdesignicons-webfont.ttf'
+    id: font_mdi_medium   # Medium icon size
+    size: 40
+    glyphs: *mdi-weather-glyphs
+
+psram:
+  mode: octal
+
+spi:
+  id: epaper_spi_bus
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 300s
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      it.printf(100, 200, id(font_mdi_medium), Color::BLACK, TextAlign::CENTER, "\U000F0595");
+      it.printf(400, 200, id(font_mdi_large), Color::BLACK, TextAlign::CENTER, "\U000F0592");
+```
+
+</TabItem>
+
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+# define font to display words
+font:
+  - file: 'fonts/materialdesignicons-webfont.ttf'  # Path to the font file
+    id: font_mdi_large
+    size: 200        # Large icon size
+    glyphs: &mdi-weather-glyphs
+      - "\U000F0595" # weather-cloudy icon
+      - "\U000F0592" # weather-hail icon
+  - file: 'fonts/materialdesignicons-webfont.ttf'
+    id: font_mdi_medium   # Medium icon size
+    size: 40
+    glyphs: *mdi-weather-glyphs
+
+psram:
+  mode: octal
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+display:
+  - platform: epaper_spi
+    model: seeed-reterminal-e1004
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK   = Color(0,   0,   0,   0);
+      const auto RED     = Color(255, 0,   0,   0);
+      const auto GREEN   = Color(0,   255, 0,   0);
+      const auto BLUE    = Color(0,   0,   255, 0);
+      const auto YELLOW  = Color(255, 255, 0,   0);
+
+      it.printf(100, 200, id(font_mdi_medium), RED, TextAlign::CENTER, "\U000F0595");
+      it.printf(400, 200, id(font_mdi_large), GREEN, TextAlign::CENTER, "\U000F0592");
+```
+
+</TabItem>
+
 </Tabs>
 
 :::note
@@ -916,6 +1372,79 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later. E1003 uses a 16-level grayscale panel — prefer `GRAYSCALE` image type and a larger resize for the 1872×1404 panel when needed.
+:::
+
+```yaml
+image:
+  - file: /config/esphome/image/wifi.jpg    # Path to your image file (JPG or PNG)
+    id: myImage
+    type: GRAYSCALE                         # Grayscale for the E1003 16-level panel
+    resize: 800x480                         # Start with a smaller size for a quick test
+
+psram:
+  mode: octal
+
+spi:
+  id: epaper_spi_bus
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 300s
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      it.image(0, 0, id(myImage));          # Display image at position (0,0)
+```
+
+</TabItem>
+
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+image:
+  - file: /config/esphome/image/wifi.jpg    # Path to your image file (JPG or PNG)
+    id: myImage
+    type: RGB565                            # RGB565 works for colorful e-ink
+    resize: 800x480                         # Start with a smaller size for a quick test
+
+psram:
+  mode: octal
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+display:
+  - platform: epaper_spi
+    model: seeed-reterminal-e1004
+    update_interval: 300s
+    lambda: |-
+      it.image(0, 0, id(myImage));          # Display image at position (0,0)
+```
+
+</TabItem>
+
 </Tabs>
 
 Step 6. Save your configuration and upload it to your reTerminal E Series. When the update completes, your e-paper display will show the image.
@@ -981,7 +1510,8 @@ By combining images with text and other display elements covered in previous exa
 
 This article focuses on connecting the display and drawing content on the ePaper screen. Continue with these ESPHome cookbooks when you want to use the rest of the onboard hardware:
 
-- **[ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power](/reterminal_e10xx_with_esphome_advanced)** - user buttons, buzzer feedback, onboard LED, battery monitoring, SHT4x sensor, deep sleep, and multi-page dashboards.
+- **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)** - generate a full ESPHome YAML by selecting your device and checking onboard features, or flash demo firmware from the browser.
+- **[ESPHome Cookbook: Buttons, Buzzer, LED, Battery, Touch & Low Power](/reterminal_e10xx_with_esphome_advanced)** - user buttons, buzzer feedback, onboard LED, battery monitoring, SHT4x sensor, capacitive touch (E1003), deep sleep, and multi-page dashboards.
 - **[ESPHome Cookbook: RTC, SD Card & Microphone](/reterminal_e10xx_with_esphome_rtc_sd_microphone)** - PCF8563 RTC time sync, microSD card power/detect pins, and onboard PDM microphone initialization.
 
 ## FAQ

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome.md
@@ -308,10 +308,6 @@ display:
     update_interval: 300s
     lambda: |-
       const auto BLACK   = Color(0,   0,   0,   0);
-      # const auto RED     = Color(255, 0,   0,   0);
-      # const auto GREEN   = Color(0,   255, 0,   0);
-      # const auto BLUE    = Color(0,   0,   255, 0);
-      # const auto YELLOW  = Color(255, 255, 0,   0);
       it.print(0, 0, id(myFont), BLACK, "Hello World!");
 ```
 
@@ -389,10 +385,6 @@ display:
     update_interval: 300s
     lambda: |-
       const auto BLACK   = Color(0,   0,   0,   0);
-      # const auto RED     = Color(255, 0,   0,   0);
-      # const auto GREEN   = Color(0,   255, 0,   0);
-      # const auto BLUE    = Color(0,   0,   255, 0);
-      # const auto YELLOW  = Color(255, 255, 0,   0);
       it.print(0, 0, id(myFont), BLACK, "Hello World!");
 ```
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_advanced.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_advanced.md
@@ -1,33 +1,35 @@
 ---
-description: ESPHome cookbook for reTerminal E1001 / E1002 / E1003 / E1004 - buttons, buzzer, onboard LED, battery monitoring, SHT4x sensor, deep sleep, and multi-page dashboards.
-title: 'ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power (reTerminal E Series)'
+description: ESPHome cookbook for reTerminal E1001 / E1002 / E1003 / E1004 - buttons, buzzer, onboard LED, battery monitoring, SHT4x sensor, capacitive touch (E1003), deep sleep, and multi-page dashboards.
+title: 'ESPHome Cookbook: Buttons, Buzzer, LED, Battery, Touch & Low Power (reTerminal E Series)'
 image: https://files.seeedstudio.com/wiki/reterminal_e10xx/img/27.webp
 slug: /reterminal_e10xx_with_esphome_advanced
 sidebar_position: 4
-sidebar_label: ESPHome - I/O, Battery & Power
+sidebar_label: ESPHome - I/O, Battery, Touch & Power
 last_update:
-  date: 04/28/2026
+  date: 08/05/2026
   author: Citric
 createdAt: '2025-07-25'
-updatedAt: '2026-06-16'
+updatedAt: '2026-08-05'
 url: https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced/
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power (reTerminal E Series)
+# ESPHome Cookbook: Buttons, Buzzer, LED, Battery, Touch & Low Power (reTerminal E Series)
 
 :::tip Prerequisites
-This page assumes you've already worked through the [ESPHome display cookbook for reTerminal E Series](/reterminal_e10xx_with_esphome) (device on Wi-Fi, Home Assistant integration online, first dashboard rendered). For the platform-level YAML skeleton and Home Assistant integration steps, see [Work with ESPHome](/epaper_work_with_esphome). For RTC, microSD card detect, and microphone setup, see [ESPHome Cookbook: RTC, SD Card & Microphone](/reterminal_e10xx_with_esphome_rtc_sd_microphone).
+This page assumes you've already worked through the [ESPHome display cookbook for reTerminal E Series](/reterminal_e10xx_with_esphome) (device on Wi-Fi, Home Assistant integration online, first dashboard rendered). For the platform-level YAML skeleton and Home Assistant integration steps, see [Work with ESPHome](/epaper_work_with_esphome). For RTC, microSD card detect, and microphone setup, see [ESPHome Cookbook: RTC, SD Card & Microphone](/reterminal_e10xx_with_esphome_rtc_sd_microphone). Capacitive touch (GT911) is covered later on this page and applies to **reTerminal E1003** only.
 :::
 
-:::tip Try demos without setting up a development environment
-If you want to quickly preview project results or try the basic demo firmware before setting up a development environment, open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)**. You can choose a supported reTerminal E Series device and flash demo firmware directly from a browser.
+:::tip Generate ESPHome YAML or flash demos in the browser
+Want a ready-made ESPHome configuration without assembling every pin by hand? Open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)**, choose the **ESPHome** card, pick your device (E1001 / E1002 / E1003 / E1004), then check the onboard features you need — display, buttons, battery, sensors, RTC, SD card, microphone, touch, deep sleep, and more. The Hub generates matching ESPHome YAML you can copy or download into your ESPHome dashboard.
+
+The same Hub can also flash demo firmware directly from the browser (desktop Chrome or Edge). For the shared ESPHome workflow, see **[Work with ESPHome](/epaper_work_with_esphome)**.
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
     <a class="get_one_now_item" href="https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/" target="_blank">
-            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Flasher 🖱️</font></span></strong>
+            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Hub 🖱️</font></span></strong>
     </a>
 </div><br />
 :::
@@ -44,13 +46,19 @@ The reTerminal E Series ePaper Display includes several hardware components that
 
 - Buzzer (GPIO45)
 
-- Battery level monitoring (GPIO1 for voltage)
+- Battery level monitoring (GPIO1 for voltage; enable pin differs by model)
 
-- On-board LED (GPIO6)
+- On-board LED (GPIO6 on E1001/E1002, GPIO16 on E1003, GPIO48 on E1004)
 
 - Temperature and humidity sensor (I²C interface)
 
+- Capacitive touchscreen (GT911 on **reTerminal E1003** only)
+
 Let's explore how to use each of these components in practical applications.
+
+:::tip Supported models & ESPHome version
+Examples on this page cover **E1001 / E1002 / E1003 / E1004**. For E1003 and E1004 display drivers, use **ESPHome 2026.7.0 or later**.
+:::
 
 ## reTerminal E Series ePaper Display Hardware Component Control
 
@@ -61,6 +69,15 @@ Let's explore how to use each of the hardware components on the reTerminal E Ser
 This example demonstrates how to use the three buttons on your reTerminal E Series ePaper Display to control functions and provide visual feedback with the on-board LED.
 
 You can use this example by copying the code below and pasting it after the `captive_portal` code line in your Yaml file.
+
+:::note Onboard LED pin by model
+- **E1001 / E1002**: `GPIO6`
+- **E1003**: `GPIO16`
+- **E1004**: `GPIO48`
+
+Update the `output` pin in the snippet above to match your device.
+:::
+
 
 ```yaml
 # Button configuration
@@ -197,6 +214,13 @@ You can adjust the `frequency` parameter to change the tone of the buzzer. Highe
 
 The reTerminal E Series ePaper Display can monitor its battery level through the analog input on GPIO1. Here's how to set it up:
 
+:::caution Battery measurement enable pin by model
+To measure the battery level, you must turn on the battery enable output before reading GPIO1. Use the pin that matches your device:
+
+- **E1001 / E1002 / E1004**: `GPIO21`
+- **E1003**: `GPIO40`
+:::
+
 ```yaml
 esphome:
   name: reterminal-e10xx
@@ -283,9 +307,6 @@ This configuration:
 - Converts the voltage to a battery percentage using a calibration curve
 - Makes both the raw voltage and the percentage available in Home Assistant
 
-:::caution
-To measure the battery level, you need to enable the **GPIO21** pin. Otherwise it is not possible to read the battery voltage value from GPIO1.
-:::
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/46.png" style={{width:1000, height:'auto'}}/></div>
 
@@ -468,6 +489,112 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later. Adjust the `viewport` size if you want a capture closer to the native 1872×1404 panel.
+:::
+
+```yaml
+
+……
+psram:
+  mode: octal
+  speed: 80MHz
+
+……
+
+captive_portal:
+
+spi:
+  id: epaper_spi_bus
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+http_request:
+  verify_ssl: false
+  timeout: 20s
+  watchdog_timeout: 25s
+
+online_image:
+  - id: dashboard_image
+    format: PNG
+    type: GRAYSCALE
+    buffer_size: 65536
+    url: http://homeassistant.local:10000/lovelace/0?viewport=800x480&eink=2&invert
+    update_interval: 1min
+    on_download_finished:
+      - component.update: epaper_display
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: never
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      it.image(0, 0, id(dashboard_image));
+```
+
+</TabItem>
+
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later. Adjust the `viewport` size if you want a capture closer to the native 1200×1600 panel.
+:::
+
+```yaml
+
+……
+psram:
+  mode: octal
+  speed: 80MHz
+
+……
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+http_request:
+  verify_ssl: false
+  timeout: 20s
+  watchdog_timeout: 25s
+
+online_image:
+  - id: dashboard_image
+    format: PNG
+    type: RGB565
+    buffer_size: 65536
+    url: http://homeassistant.local:10000/lovelace/0?viewport=800x480
+    update_interval: 1min
+    on_download_finished:
+      - component.update: epaper_display
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: seeed-reterminal-e1004
+    update_interval: never
+    lambda: |-
+      it.image(0, 0, id(dashboard_image));
+```
+
+</TabItem>
+
 </Tabs>
 
 :::caution
@@ -597,6 +724,129 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later. This example wakes from the right green button on **GPIO3**.
+:::
+
+```yaml
+globals:
+  - id: sleep_counter
+    type: int
+    restore_value: yes  # Use RTC storage to maintain counter during sleep
+    initial_value: '0'
+
+# Deep sleep configuration
+deep_sleep:
+  id: deep_sleep_1
+  run_duration: 30s  # Device remains awake for 30 seconds
+  sleep_duration: 5min  # Then sleeps for 5 minutes
+  esp32_ext1_wakeup:
+    pins:
+      - number: GPIO3
+        allow_other_uses: true
+        mode: INPUT_PULLUP
+    mode: ANY_LOW
+
+interval:
+  - interval: 29s  # Schedule sleep just before run_duration ends
+    then:
+      - logger.log: "Entering deep sleep now..."
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font1
+    size: 24
+
+psram:
+  mode: octal
+
+spi:
+  id: epaper_spi_bus
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 5min
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      id(sleep_counter) += 1;
+      ESP_LOGD("main", "Wakeup count: %d", id(sleep_counter));
+      it.printf(100, 100, id(font1), Color::BLACK, "Wakeup count: %d", id(sleep_counter));
+```
+
+</TabItem>
+
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later. This example wakes from the front direction button on **GPIO4**.
+:::
+
+```yaml
+globals:
+  - id: sleep_counter
+    type: int
+    restore_value: yes  # Use RTC storage to maintain counter during sleep
+    initial_value: '0'
+
+# Deep sleep configuration
+deep_sleep:
+  id: deep_sleep_1
+  run_duration: 30s  # Device remains awake for 30 seconds
+  sleep_duration: 5min  # Then sleeps for 5 minutes
+  esp32_ext1_wakeup:
+    pins:
+      - number: GPIO4
+        allow_other_uses: true
+        mode: INPUT_PULLUP
+    mode: ANY_LOW
+
+interval:
+  - interval: 29s  # Schedule sleep just before run_duration ends
+    then:
+      - logger.log: "Entering deep sleep now..."
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font1
+    size: 24
+
+psram:
+  mode: octal
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: seeed-reterminal-e1004
+    update_interval: 5min
+    lambda: |-
+      const auto BLACK   = Color(0,   0,   0,   0);
+      id(sleep_counter) += 1;
+      ESP_LOGD("main", "Wakeup count: %d", id(sleep_counter));
+      it.printf(100, 100, id(font1), BLACK, "Wakeup count: %d", id(sleep_counter));
+```
+
+</TabItem>
+
 </Tabs>
 
 This configuration:
@@ -1270,6 +1520,674 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later. This comprehensive example uses the E1003 pin map (LED `GPIO16`, SD enable `GPIO39`, battery enable `GPIO40`, wake `GPIO3`).
+:::
+
+```yaml
+esphome:
+  name: reterminal_e1003
+  friendly_name: reTerminal_E1003
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - output.turn_on: bsp_battery_enable
+      - delay: 200ms
+      - component.update: battery_voltage
+      - component.update: battery_level
+
+
+esp32:
+  board: seeed_xiao_esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+# Enable logging
+logger:
+  hardware_uart: UART0
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "reTerminal-E1003"
+    password: "ChangeMe123"
+
+captive_portal:
+
+# Deep-sleep, wake by GPIO4
+deep_sleep:
+  id: deep_sleep_1
+  run_duration: 1min
+  sleep_duration: 60min
+  wakeup_pin: GPIO3          # Right green button
+  wakeup_pin_mode: INVERT_WAKEUP
+
+# I²C
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+# Fonts
+font:
+  - file: "gfonts://Inter@700"
+    id: small_font
+    size: 24
+  - file: "gfonts://Inter@700"
+    id: mid_font
+    size: 36
+  - file: "gfonts://Inter@700"
+    id: big_font
+    size: 180
+  - file: "gfonts://Inter@700"
+    id: time_font
+    size: 96      # for the big time display
+  - file: 'fonts/materialdesignicons-webfont.ttf'
+    id: font_mdi_large
+    size: 70
+    glyphs:
+      - "\U000F050F"  # thermometer
+      - "\U000F058E"  # humidity
+  - file: 'fonts/materialdesignicons-webfont.ttf'
+    id: font_bat_icon
+    size: 24
+    glyphs:
+      - "\U000F007A"  # mdi-battery-10
+      - "\U000F007B"  # mdi-battery-20
+      - "\U000F007C"  # mdi-battery-30
+      - "\U000F007D"  # mdi-battery-40
+      - "\U000F007E"  # mdi-battery-50
+      - "\U000F007F"  # mdi-battery-60
+      - "\U000F0080"  # mdi-battery-70
+      - "\U000F0081"  # mdi-battery-80
+      - "\U000F0082"  # mdi-battery-90
+      - "\U000F0079"  # mdi-battery
+
+globals:
+  - id: page_index
+    type: int
+    restore_value: true
+    initial_value: '0'
+  - id: battery_glyph
+    type: std::string
+    restore_value: no
+    initial_value: "\"\\U000F0079\""   # default full battery
+
+sensor:
+  - platform: sht4x
+    temperature:
+      name: "Temperature"
+      id: temp_sensor
+    humidity:
+      name: "Relative Humidity"
+      id: hum_sensor
+  - platform: adc
+    pin: GPIO1
+    name: "Battery Voltage"
+    id: battery_voltage
+    update_interval: 60s
+    attenuation: 12db
+    filters:
+      - multiply: 2.0
+  - platform: template
+    name: "Battery Level"
+    id: battery_level
+    unit_of_measurement: "%"
+    icon: "mdi:battery"
+    device_class: battery
+    state_class: measurement
+    lambda: 'return id(battery_voltage).state;'
+    update_interval: 60s
+    on_value:
+      then:
+        - lambda: |-
+            int pct = int(x);
+            if (pct <= 10)      id(battery_glyph) = "\U000F007A";
+            else if (pct <= 20) id(battery_glyph) = "\U000F007B";
+            else if (pct <= 30) id(battery_glyph) = "\U000F007C";
+            else if (pct <= 40) id(battery_glyph) = "\U000F007D";
+            else if (pct <= 50) id(battery_glyph) = "\U000F007E";
+            else if (pct <= 60) id(battery_glyph) = "\U000F007F";
+            else if (pct <= 70) id(battery_glyph) = "\U000F0080";
+            else if (pct <= 80) id(battery_glyph) = "\U000F0081";
+            else if (pct <= 90) id(battery_glyph) = "\U000F0082";
+            else                id(battery_glyph) = "\U000F0079";
+    filters:
+      - calibrate_linear:
+          - 4.15 -> 100.0
+          - 3.96 -> 90.0
+          - 3.91 -> 80.0
+          - 3.85 -> 70.0
+          - 3.80 -> 60.0
+          - 3.75 -> 50.0
+          - 3.68 -> 40.0
+          - 3.58 -> 30.0
+          - 3.49 -> 20.0
+          - 3.41 -> 10.0
+          - 3.30 -> 5.0
+          - 3.27 -> 0.0
+      - clamp:
+          min_value: 0
+          max_value: 100
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    id: bsp_led
+    inverted: true
+  - platform: gpio
+    pin: GPIO39
+    id: bsp_sd_enable
+  - platform: gpio
+    pin: GPIO40
+    id: bsp_battery_enable
+
+# Onboard LED
+light:
+  - platform: binary
+    name: "Onboard LED"
+    output: bsp_led
+    id: onboard_led
+    
+binary_sensor:
+  - platform: gpio    # Next page
+    pin:
+      number: GPIO3
+      mode: INPUT_PULLUP
+      inverted: true
+    id: key1
+    name: "Key1"
+    on_press:
+      then:
+        - lambda: |-
+            id(page_index) = (id(page_index) + 1) % 2;
+            id(epaper_display).update();
+
+  - platform: gpio     # Prev page
+    pin:
+      number: GPIO5
+      mode: INPUT_PULLUP
+      inverted: true
+    id: key2
+    name: "Key2"
+    on_press:
+      then:
+        - lambda: |-
+            id(page_index) = (id(page_index) - 1 + 2) % 2;
+            id(epaper_display).update();
+
+  # - platform: gpio
+  #   pin:
+  #     number: GPIO4
+  #     mode: INPUT_PULLUP
+  #     inverted: true
+  #   id: key2
+  #   name: "Key2"
+  #   on_press:
+  #     then:
+  #       - lambda: |-
+  #           id(page_index) = (id(page_index) - 1 + 3) % 3;
+  #           id(epaper_display).update();
+
+# Home Assistant time
+time:
+  - platform: homeassistant
+    id: ha_time
+
+# SPI bus for IT8951 (replaces the simple SPI block above)
+spi:
+  id: epaper_spi_bus
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+# e-paper (10.3" 16-level grayscale, IT8951)
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: never
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      // ----------  PAGE 0  ----------
+      if (id(page_index) == 0) {
+        const int scr_w = 800;
+        const int scr_h = 480;
+
+        // Battery in upper-right corner
+        it.printf(670, 13, id(font_bat_icon), Color::BLACK, "%s", id(battery_glyph).c_str());
+        it.printf(700, 10, id(small_font), Color::BLACK, "%.0f%%", id(battery_level).state);
+
+        //line
+        it.filled_rectangle(400, 100, 2, 280, Color::BLACK);
+
+        // Convert °C to °F
+        float temp_f = id(temp_sensor).state * 9.0 / 5.0 + 32.0;
+
+        // ---------------------------------------------------------
+        // Horizontal split: two 400 px columns
+        const int col_w = scr_w / 2;
+
+        const int icon_y   = 100;   // Icon baseline
+        const int value_y  = 220;   // Number baseline
+        const int unit_y   = 300;   // Unit baseline
+        const int label_y  = 380;   // Text label baseline
+
+        const int icon_size = 70;   // icon font size
+        const int val_size  = 120;  // number font size
+        const int unit_size = 44;   // unit font size
+        const int label_size= 36;   // label font size
+
+        // --- Left column : Temperature -----------------------------
+        const int left_mid = col_w / 2 - 30;   // 200 px
+
+        // Icon
+        it.printf(left_mid, icon_y, id(font_mdi_large), Color::BLACK, TextAlign::CENTER, "\U000F050F");
+        // Value
+        it.printf(left_mid, value_y, id(big_font), Color::BLACK, TextAlign::CENTER, "%.0f", temp_f);
+        // Unit
+        it.printf(left_mid + 150, unit_y, id(mid_font), Color::BLACK, TextAlign::CENTER, "°F");
+        // Label
+        it.printf(left_mid, label_y, id(mid_font), Color::BLACK, TextAlign::CENTER, "Temperature");
+
+        // --- Right column : Humidity -------------------------------
+        const int right_mid = col_w + col_w / 2;   // 600 px
+
+        // Icon
+        it.printf(right_mid, icon_y, id(font_mdi_large), Color::BLACK, TextAlign::CENTER, "\U000F058E");
+        // Value
+        it.printf(right_mid, value_y, id(big_font), Color::BLACK, TextAlign::CENTER, "%.0f", id(hum_sensor).state);
+        // Unit
+        it.printf(right_mid + 150, unit_y, id(mid_font), Color::BLACK, TextAlign::CENTER, "%%");
+        // Label
+        it.printf(right_mid, label_y, id(mid_font), Color::BLACK, TextAlign::CENTER, "Humidity");
+      }
+      // ----------  PAGE 1  ----------
+      else{
+        // Battery top-right
+        it.printf(670, 13, id(font_bat_icon), Color::BLACK, "%s", id(battery_glyph).c_str());
+        it.printf(700, 10, id(small_font), Color::BLACK, "%.0f%%", id(battery_level).state);
+
+        auto now = id(ha_time).now();
+        struct tm timeinfo = now.to_c_tm();
+
+        // centering time HH:MM
+        char timeStr[6];
+        strftime(timeStr, sizeof(timeStr), "%H:%M", &timeinfo);
+        it.printf(400, 180, id(time_font), Color::BLACK, TextAlign::CENTER, timeStr);
+
+        // Date: Day of week
+        const char *weekday[] = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat"};
+        const char *wday = weekday[timeinfo.tm_wday];
+
+        // Date: month - day
+        char dateStr[12];
+        strftime(dateStr, sizeof(dateStr), "%b %d", &timeinfo);  // e.g. Jun 15
+
+        // Day of the week + date below the time
+        it.printf(400, 280, id(mid_font), Color::BLACK, TextAlign::CENTER, "%s, %s", wday, dateStr);
+      }
+
+```
+
+</TabItem>
+
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later. This comprehensive example uses the E1004 pin map (LED `GPIO48`, SD enable `GPIO16`, battery enable `GPIO21`, wake `GPIO4`).
+:::
+
+```yaml
+esphome:
+  name: reterminal_e1004
+  friendly_name: reTerminal_E1004
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - output.turn_on: bsp_battery_enable
+      - delay: 200ms
+      - component.update: battery_voltage
+      - component.update: battery_level
+
+
+esp32:
+  board: seeed_xiao_esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+# Enable logging
+logger:
+  hardware_uart: UART0
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "reTerminal-E1004"
+    password: "ChangeMe123"
+
+captive_portal:
+
+# Deep-sleep, wake by GPIO4
+deep_sleep:
+  id: deep_sleep_1
+  run_duration: 1min
+  sleep_duration: 60min
+  wakeup_pin: GPIO4          # Right white button
+  wakeup_pin_mode: INVERT_WAKEUP
+
+# SPI / I²C
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+# Fonts
+font:
+  - file: "gfonts://Inter@700"
+    id: small_font
+    size: 24
+  - file: "gfonts://Inter@700"
+    id: mid_font
+    size: 36
+  - file: "gfonts://Inter@700"
+    id: big_font
+    size: 180
+  - file: "gfonts://Inter@700"
+    id: time_font
+    size: 96      # for the big time display
+  - file: 'fonts/materialdesignicons-webfont.ttf'
+    id: font_mdi_large
+    size: 70
+    glyphs:
+      - "\U000F050F"  # thermometer
+      - "\U000F058E"  # humidity
+  - file: 'fonts/materialdesignicons-webfont.ttf'
+    id: font_bat_icon
+    size: 24
+    glyphs:
+      - "\U000F007A"  # mdi-battery-10
+      - "\U000F007B"  # mdi-battery-20
+      - "\U000F007C"  # mdi-battery-30
+      - "\U000F007D"  # mdi-battery-40
+      - "\U000F007E"  # mdi-battery-50
+      - "\U000F007F"  # mdi-battery-60
+      - "\U000F0080"  # mdi-battery-70
+      - "\U000F0081"  # mdi-battery-80
+      - "\U000F0082"  # mdi-battery-90
+      - "\U000F0079"  # mdi-battery
+
+globals:
+  - id: page_index
+    type: int
+    restore_value: true
+    initial_value: '0'
+  - id: battery_glyph
+    type: std::string
+    restore_value: no
+    initial_value: "\"\\U000F0079\""   # default full battery
+
+sensor:
+  - platform: sht4x
+    temperature:
+      name: "Temperature"
+      id: temp_sensor
+    humidity:
+      name: "Relative Humidity"
+      id: hum_sensor
+  - platform: adc
+    pin: GPIO1
+    name: "Battery Voltage"
+    id: battery_voltage
+    update_interval: 60s
+    attenuation: 12db
+    filters:
+      - multiply: 2.0
+  - platform: template
+    name: "Battery Level"
+    id: battery_level
+    unit_of_measurement: "%"
+    icon: "mdi:battery"
+    device_class: battery
+    state_class: measurement
+    lambda: 'return id(battery_voltage).state;'
+    update_interval: 60s
+    on_value:
+      then:
+        - lambda: |-
+            int pct = int(x);
+            if (pct <= 10)      id(battery_glyph) = "\U000F007A";
+            else if (pct <= 20) id(battery_glyph) = "\U000F007B";
+            else if (pct <= 30) id(battery_glyph) = "\U000F007C";
+            else if (pct <= 40) id(battery_glyph) = "\U000F007D";
+            else if (pct <= 50) id(battery_glyph) = "\U000F007E";
+            else if (pct <= 60) id(battery_glyph) = "\U000F007F";
+            else if (pct <= 70) id(battery_glyph) = "\U000F0080";
+            else if (pct <= 80) id(battery_glyph) = "\U000F0081";
+            else if (pct <= 90) id(battery_glyph) = "\U000F0082";
+            else                id(battery_glyph) = "\U000F0079";
+    filters:
+      - calibrate_linear:
+          - 4.15 -> 100.0
+          - 3.96 -> 90.0
+          - 3.91 -> 80.0
+          - 3.85 -> 70.0
+          - 3.80 -> 60.0
+          - 3.75 -> 50.0
+          - 3.68 -> 40.0
+          - 3.58 -> 30.0
+          - 3.49 -> 20.0
+          - 3.41 -> 10.0
+          - 3.30 -> 5.0
+          - 3.27 -> 0.0
+      - clamp:
+          min_value: 0
+          max_value: 100
+
+output:
+  - platform: gpio
+    pin: GPIO48
+    id: bsp_led
+    inverted: true
+  - platform: gpio
+    pin: GPIO16
+    id: bsp_sd_enable
+  - platform: gpio
+    pin: GPIO21
+    id: bsp_battery_enable
+
+# Onboard LED
+light:
+  - platform: binary
+    name: "Onboard LED"
+    output: bsp_led
+    id: onboard_led
+    
+binary_sensor:
+  - platform: gpio    # Next page
+    pin:
+      number: GPIO3
+      mode: INPUT_PULLUP
+      inverted: true
+    id: key1
+    name: "Key1"
+    on_press:
+      then:
+        - lambda: |-
+            id(page_index) = (id(page_index) + 1) % 2;
+            id(epaper_display).update();
+
+  - platform: gpio     # Prev page
+    pin:
+      number: GPIO5
+      mode: INPUT_PULLUP
+      inverted: true
+    id: key2
+    name: "Key2"
+    on_press:
+      then:
+        - lambda: |-
+            id(page_index) = (id(page_index) - 1 + 2) % 2;
+            id(epaper_display).update();
+
+  # - platform: gpio
+  #   pin:
+  #     number: GPIO4
+  #     mode: INPUT_PULLUP
+  #     inverted: true
+  #   id: key2
+  #   name: "Key2"
+  #   on_press:
+  #     then:
+  #       - lambda: |-
+  #           id(page_index) = (id(page_index) - 1 + 3) % 3;
+  #           id(epaper_display).update();
+
+# Home Assistant time
+time:
+  - platform: homeassistant
+    id: ha_time
+
+# e-paper
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: seeed-reterminal-e1004
+    update_interval: never
+    lambda: |-
+      const auto BLACK   = Color(0,   0,   0,   0);
+      const auto RED     = Color(255, 0,   0,   0);
+      const auto GREEN   = Color(0,   255, 0,   0);
+      const auto BLUE    = Color(0,   0,   255, 0);
+      const auto YELLOW  = Color(255, 255, 0,   0);
+
+      // ----------  PAGE 0  ----------
+      if (id(page_index) == 0) {
+        const int scr_w = 800;
+        const int scr_h = 480;
+
+        // Battery in upper-right corner
+        it.printf(670, 13, id(font_bat_icon), GREEN, "%s", id(battery_glyph).c_str());
+        it.printf(700, 10, id(small_font), GREEN, "%.0f%%", id(battery_level).state);
+
+        //line
+        it.filled_rectangle(400, 100, 2, 280, BLACK);
+
+        // Convert °C to °F
+        float temp_f = id(temp_sensor).state * 9.0 / 5.0 + 32.0;
+
+        // ---------------------------------------------------------
+        // Horizontal split: two 400 px columns
+        const int col_w = scr_w / 2;
+
+        const int icon_y   = 100;   // Icon baseline
+        const int value_y  = 220;   // Number baseline
+        const int unit_y   = 300;   // Unit baseline
+        const int label_y  = 380;   // Text label baseline
+
+        const int icon_size = 70;   // icon font size
+        const int val_size  = 120;  // number font size
+        const int unit_size = 44;   // unit font size
+        const int label_size= 36;   // label font size
+
+        // --- Left column : Temperature -----------------------------
+        const int left_mid = col_w / 2 - 30;   // 200 px
+
+        // Icon
+        it.printf(left_mid, icon_y, id(font_mdi_large), BLUE, TextAlign::CENTER, "\U000F050F");
+        // Value
+        it.printf(left_mid, value_y, id(big_font), BLUE, TextAlign::CENTER, "%.0f", temp_f);
+        // Unit
+        it.printf(left_mid + 150, unit_y, id(mid_font), RED, TextAlign::CENTER, "°F");
+        // Label
+        it.printf(left_mid, label_y, id(mid_font), RED, TextAlign::CENTER, "Temperature");
+
+        // --- Right column : Humidity -------------------------------
+        const int right_mid = col_w + col_w / 2;   // 600 px
+
+        // Icon
+        it.printf(right_mid, icon_y, id(font_mdi_large), YELLOW, TextAlign::CENTER, "\U000F058E");
+        // Value
+        it.printf(right_mid, value_y, id(big_font), YELLOW, TextAlign::CENTER, "%.0f", id(hum_sensor).state);
+        // Unit
+        it.printf(right_mid + 150, unit_y, id(mid_font), GREEN, TextAlign::CENTER, "%%");
+        // Label
+        it.printf(right_mid, label_y, id(mid_font), GREEN, TextAlign::CENTER, "Humidity");
+      }
+      // ----------  PAGE 1  ----------
+      else{
+        // Battery top-right
+        it.printf(670, 13, id(font_bat_icon), BLUE, "%s", id(battery_glyph).c_str());
+        it.printf(700, 10, id(small_font), BLUE, "%.0f%%", id(battery_level).state);
+
+        auto now = id(ha_time).now();
+        struct tm timeinfo = now.to_c_tm();
+
+        // centering time HH:MM
+        char timeStr[6];
+        strftime(timeStr, sizeof(timeStr), "%H:%M", &timeinfo);
+        it.printf(400, 180, id(time_font), BLUE, TextAlign::CENTER, timeStr);
+
+        // Date: Day of week
+        const char *weekday[] = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat"};
+        const char *wday = weekday[timeinfo.tm_wday];
+
+        // Date: month - day
+        char dateStr[12];
+        strftime(dateStr, sizeof(dateStr), "%b %d", &timeinfo);  // e.g. Jun 15
+
+        // Day of the week + date below the time
+        it.printf(400, 280, id(mid_font), YELLOW, TextAlign::CENTER, "%s, %s", wday, dateStr);
+      }
+
+```
+
+</TabItem>
+
 </Tabs>
 
 </details>
@@ -1288,6 +2206,69 @@ This example implements:
 4. **Hardware Initialization**: SD card and battery monitoring circuits are enabled on boot
 5. **Temperature and Humidity Display**: Using the onboard SHT4x sensor via I²C
 6. **Dynamic Icons**: Material Design Icons change based on sensor values
+
+
+## Capacitive Touch (reTerminal E1003 only)
+
+:::note E1003 only
+The GT911 capacitive touchscreen is available on **reTerminal E1003**. reTerminal E1001, E1002, and E1004 do not include this touch controller, so skip this section on those models.
+:::
+
+reTerminal E1003 uses a **GT911** touch controller on the shared I2C bus. In ESPHome you attach it to the `it8951` display with the `touchscreen` component, then log or act on touch events.
+
+### Wiring summary
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <th>Function</th>
+      <th>Pin / Bus</th>
+    </tr>
+    <tr>
+      <td>Touch interrupt</td>
+      <td><code>GPIO2</code></td>
+    </tr>
+    <tr>
+      <td>Touch reset</td>
+      <td><code>GPIO48</code></td>
+    </tr>
+    <tr>
+      <td>I2C</td>
+      <td>SDA <code>GPIO19</code>, SCL <code>GPIO20</code> (shared with SHT4x / PCF8563)</td>
+    </tr>
+  </table>
+</div>
+
+### Minimal touch example
+
+Add the following after your E1003 display configuration (the `display` block must use `id: epaper_display`). Requires **ESPHome 2026.7.0** or later.
+
+```yaml
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+touchscreen:
+  - platform: gt911
+    id: e1003_touch
+    display: epaper_display
+    interrupt_pin: GPIO2
+    reset_pin: GPIO48
+    transform:
+      mirror_x: true
+    on_touch:
+      - logger.log:
+          format: "Touch: x=%d, y=%d"
+          args: ["touch.x", "touch.y"]
+```
+
+### What you should see
+
+1. Flash an E1003 configuration that includes both the `it8951` display and the `gt911` touchscreen blocks.
+2. Open the ESPHome logs over USB (`logger` with `hardware_uart: UART0`).
+3. Tap the panel — you should see `Touch: x=..., y=...` lines in the log.
+
+You can extend `on_touch` with automations such as page changes, button-like hotspots, or Home Assistant events. Keep `transform.mirror_x: true` aligned with the E1003 display transform so touch coordinates match what you draw on screen.
 
 ## FAQ
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
@@ -1805,8 +1805,6 @@ display:
       it.printf(30, 295, id(font_small), BLACK, "SD: DET GPIO15 / EN GPIO16");
 ```
 
-```
-
 </TabItem>
 </Tabs>
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
@@ -551,6 +551,7 @@ wifi:
 captive_portal:
 
 spi:
+  id: epaper_spi_bus
   clk_pin: GPIO7
   mosi_pin: GPIO9
   miso_pin: GPIO8
@@ -648,6 +649,7 @@ wifi:
 captive_portal:
 
 spi:
+  id: epaper_spi_bus
   clk_pin: GPIO7
   mosi_pin: GPIO9
   miso_pin: GPIO8
@@ -749,6 +751,7 @@ wifi:
 captive_portal:
 
 spi:
+  id: epaper_spi_bus
   clk_pin: GPIO7
   mosi_pin: GPIO9
   miso_pin: GPIO8
@@ -854,6 +857,7 @@ wifi:
 captive_portal:
 
 spi:
+  id: epaper_spi_bus
   clk_pin: GPIO7
   mosi_pin: GPIO9
   miso_pin: GPIO8
@@ -912,7 +916,7 @@ display:
 
 This configuration:
 
-- Enables SD card power through `GPIO16`.
+- Enables SD card power through `GPIO16` (E1001 / E1002 / E1004) or `GPIO39` (E1003).
 - Reads the card-detect signal from `GPIO15`.
 - Shows the card state on the ePaper screen.
 - Exposes `SD Card Detected` to Home Assistant as a binary sensor.
@@ -1274,6 +1278,7 @@ wifi:
 captive_portal:
 
 spi:
+  id: epaper_spi_bus
   clk_pin: GPIO7
   mosi_pin: GPIO9
   miso_pin: GPIO8
@@ -1417,6 +1422,7 @@ wifi:
 captive_portal:
 
 spi:
+  id: epaper_spi_bus
   clk_pin: GPIO7
   mosi_pin: GPIO9
   miso_pin: GPIO8
@@ -1565,6 +1571,7 @@ wifi:
 captive_portal:
 
 spi:
+  id: epaper_spi_bus
   clk_pin: GPIO7
   mosi_pin: GPIO9
   miso_pin: GPIO8
@@ -1642,8 +1649,8 @@ display:
       mirror_y: false
     lambda: |-
       it.printf(400, 20, id(font_medium), Color::BLACK, TextAlign::TOP_CENTER,
-                "reTerminal E1002 Hardware Status");
-      it.line(20, 60, 780, 60, BLACK);
+                "reTerminal E1003 Hardware Status");
+      it.line(20, 60, 780, 60, Color::BLACK);
 
       auto now = id(rtc_time).now();
       if (now.is_valid()) {
@@ -1662,7 +1669,7 @@ display:
 
       it.printf(30, 215, id(font_medium), Color::BLACK, "PDM Mic: initialized");
       it.printf(30, 265, id(font_small), Color::BLACK, "RTC: I2C address 0x51");
-      it.printf(30, 295, id(font_small), Color::BLACK, "SD: DET GPIO15 / EN GPIO16");
+      it.printf(30, 295, id(font_small), Color::BLACK, "SD: DET GPIO15 / EN GPIO39");
       it.printf(30, 325, id(font_small), Color::BLACK, "Mic: CLK GPIO42 / DATA GPIO41 / EN GPIO38");
 ```
 
@@ -1671,7 +1678,7 @@ display:
 <TabItem value="For E1004" label="For E1004">
 
 :::tip
-Please update your ESPHome version to **2026.7.0** or later.
+Please update your ESPHome version to **2026.7.0** or later. reTerminal E1004 does not include an onboard PDM microphone, so this status demo covers RTC and microSD only.
 :::
 
 ```yaml
@@ -1682,7 +1689,6 @@ esphome:
     priority: 600
     then:
       - output.turn_on: bsp_sd_enable
-      - output.turn_on: mic_power_enable
       - delay: 200ms
       - pcf8563.read_time:
       - component.update: epaper_display
@@ -1724,17 +1730,10 @@ i2c:
   scl: GPIO20
   sda: GPIO19
 
-i2s_audio:
-  i2s_lrclk_pin: GPIO42
-
 output:
   - platform: gpio
     pin: GPIO16
     id: bsp_sd_enable
-
-  - platform: gpio
-    pin: GPIO38
-    id: mic_power_enable
 
 time:
   - platform: pcf8563
@@ -1747,13 +1746,6 @@ time:
       then:
         - pcf8563.write_time:
         - component.update: epaper_display
-
-microphone:
-  - platform: i2s_audio
-    id: onboard_mic
-    adc_type: external
-    pdm: true
-    i2s_din_pin: GPIO41
 
 binary_sensor:
   - platform: gpio
@@ -1790,7 +1782,7 @@ display:
       const auto RED = Color(255, 0, 0, 0);
 
       it.printf(400, 20, id(font_medium), BLACK, TextAlign::TOP_CENTER,
-                "reTerminal E1002 Hardware Status");
+                "reTerminal E1004 Hardware Status");
       it.line(20, 60, 780, 60, BLACK);
 
       auto now = id(rtc_time).now();
@@ -1808,10 +1800,11 @@ display:
         it.printf(30, 155, id(font_medium), RED, "SD Card: not detected");
       }
 
-      it.printf(30, 215, id(font_medium), BLUE, "PDM Mic: initialized");
+      it.printf(30, 215, id(font_medium), BLUE, "PDM Mic: not available on E1004");
       it.printf(30, 265, id(font_small), BLACK, "RTC: I2C address 0x51");
       it.printf(30, 295, id(font_small), BLACK, "SD: DET GPIO15 / EN GPIO16");
-      it.printf(30, 325, id(font_small), BLACK, "Mic: CLK GPIO42 / DATA GPIO41 / EN GPIO38");
+```
+
 ```
 
 </TabItem>
@@ -1819,7 +1812,7 @@ display:
 
 </details>
 
-When the firmware is running, the screen shows the RTC time, SD card state, and microphone initialization status on one page.
+When the firmware is running, the screen shows the RTC time and SD card state on one page. Models with an onboard PDM microphone (E1001 / E1002 / E1003) also show microphone initialization status; E1004 shows that the microphone is not available.
 
 The following image shows the expected result on reTerminal E1002. The same demo pattern works across the reTerminal E Series. Choose the matching device tab above. Monochrome / grayscale panels (E1001, E1003) and color panels (E1002, E1004) differ mainly in the display platform and color drawing API.
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/cookbooks/esphome_rtc_sd_microphone.md
@@ -1,15 +1,15 @@
 ---
-description: ESPHome cookbook for reTerminal E1001 / E1002 - standalone demos for PCF8563 RTC time sync, microSD card detection, onboard PDM microphone initialization, and a combined hardware status dashboard.
+description: ESPHome cookbook for reTerminal E1001 / E1002 / E1003 / E1004 - standalone demos for PCF8563 RTC time sync, microSD card detection, onboard PDM microphone initialization, and a combined hardware status dashboard.
 title: 'ESPHome Cookbook: RTC, SD Card & Microphone (reTerminal E Series)'
 image: https://files.seeedstudio.com/wiki/reterminal_e10xx/img/27.webp
 slug: /reterminal_e10xx_with_esphome_rtc_sd_microphone
 sidebar_position: 5
 sidebar_label: ESPHome - RTC, SD & Microphone
 last_update:
-  date: 06/12/2026
+  date: 08/05/2026
   author: Citric
 createdAt: '2026-06-12'
-updatedAt: '2026-06-16'
+updatedAt: '2026-08-05'
 url: https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_rtc_sd_microphone/
 ---
 
@@ -21,15 +21,17 @@ import TabItem from '@theme/TabItem';
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/251.jpeg" style={{width:1000, height:'auto'}}/></div><br />
 
 :::tip Prerequisites
-This page assumes you have already completed the [ESPHome display cookbook for reTerminal E Series](/reterminal_e10xx_with_esphome) and your device is online in Home Assistant. For buttons, buzzer, LED, battery monitoring, SHT4x, and deep sleep, see [ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power](/reterminal_e10xx_with_esphome_advanced).
+This page assumes you have already completed the [ESPHome display cookbook for reTerminal E Series](/reterminal_e10xx_with_esphome) and your device is online in Home Assistant. For buttons, buzzer, LED, battery monitoring, SHT4x, capacitive touch (E1003), and deep sleep, see [ESPHome Cookbook: Buttons, Buzzer, LED, Battery, Touch & Low Power](/reterminal_e10xx_with_esphome_advanced).
 :::
 
-:::tip Try demos without setting up a development environment
-If you want to quickly preview project results or try the basic demo firmware before setting up a development environment, open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)**. You can choose a supported reTerminal E Series device and flash demo firmware directly from a browser.
+:::tip Generate ESPHome YAML or flash demos in the browser
+Want a ready-made ESPHome configuration without assembling every pin by hand? Open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)**, choose the **ESPHome** card, pick your device (E1001 / E1002 / E1003 / E1004), then check the onboard features you need — display, buttons, battery, sensors, RTC, SD card, microphone, touch, deep sleep, and more. The Hub generates matching ESPHome YAML you can copy or download into your ESPHome dashboard.
+
+The same Hub can also flash demo firmware directly from the browser (desktop Chrome or Edge). For the shared ESPHome workflow, see **[Work with ESPHome](/epaper_work_with_esphome)**.
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
     <a class="get_one_now_item" href="https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/" target="_blank">
-            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Flasher 🖱️</font></span></strong>
+            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Hub 🖱️</font></span></strong>
     </a>
 </div><br />
 :::
@@ -43,7 +45,7 @@ This cookbook continues the reTerminal E Series ESPHome examples with three onbo
 Each section below is organized as a small standalone ESPHome demo. You can copy one complete YAML example, replace the API and OTA placeholders, and upload it directly from ESPHome.
 
 :::note Model coverage
-The ready-to-copy examples in this page are written for **reTerminal E1001** and **reTerminal E1002**, matching the tested ESPHome hardware examples. The onboard microphone examples apply to models that include the PDM microphone hardware; reTerminal E1004 does not include the microphone.
+The ready-to-copy examples in this page cover **reTerminal E1001 / E1002 / E1003 / E1004**. E1003 and E1004 require **ESPHome 2026.7.0 or later**. The onboard microphone examples apply to models that include the PDM microphone hardware (**E1001 / E1002 / E1003**); **reTerminal E1004 does not include the microphone**.
 :::
 
 ## Hardware Capabilities
@@ -70,7 +72,7 @@ The following pins are used by the demos in this cookbook.
     <tr>
       <td>microSD power enable</td>
       <td><code>output.gpio</code></td>
-      <td><code>GPIO16</code></td>
+      <td><code>GPIO16</code> (E1001 / E1002 / E1004), <code>GPIO39</code> (E1003)</td>
     </tr>
     <tr>
       <td>PDM microphone power enable</td>
@@ -290,6 +292,200 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+esphome:
+  name: reterminal-e1003-rtc-demo
+  friendly_name: reTerminal_E1003_RTC_Demo
+  on_boot:
+    priority: 600
+    then:
+      - pcf8563.read_time:
+
+esp32:
+  board: seeed_xiao_esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1003-RTC-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+time:
+  - platform: pcf8563
+    id: rtc_time
+    address: 0x51
+    update_interval: never
+
+  - platform: homeassistant
+    on_time_sync:
+      then:
+        - pcf8563.write_time:
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 26
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 300s
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      it.printf(400, 40, id(font_title), Color::BLACK, TextAlign::TOP_CENTER, "RTC Time Sync Demo");
+      auto now = id(rtc_time).now();
+      if (now.is_valid()) {
+        it.strftime(400, 135, id(font_title), Color::BLACK, TextAlign::TOP_CENTER, "%Y-%m-%d", now);
+        it.strftime(400, 190, id(font_title), Color::BLACK, TextAlign::TOP_CENTER, "%H:%M:%S", now);
+        ESP_LOGD("rtc_demo", "RTC time is valid");
+      } else {
+        it.printf(400, 150, id(font_body), Color::BLACK, TextAlign::TOP_CENTER, "RTC: waiting for sync");
+        ESP_LOGW("rtc_demo", "RTC time is not valid yet");
+      }
+```
+
+</TabItem>
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+esphome:
+  name: reterminal-e1004-rtc-demo
+  friendly_name: reTerminal_E1004_RTC_Demo
+  on_boot:
+    priority: 600
+    then:
+      - pcf8563.read_time:
+
+esp32:
+  board: seeed_xiao_esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1004-RTC-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+time:
+  - platform: pcf8563
+    id: rtc_time
+    address: 0x51
+    update_interval: never
+
+  - platform: homeassistant
+    on_time_sync:
+      then:
+        - pcf8563.write_time:
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 26
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: seeed-reterminal-e1004
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK = Color(0, 0, 0, 0);
+      const auto RED = Color(255, 0, 0, 0);
+      const auto BLUE = Color(0, 0, 255, 0);
+
+      it.printf(400, 40, id(font_title), BLACK, TextAlign::TOP_CENTER, "RTC Time Sync Demo");
+      auto now = id(rtc_time).now();
+      if (now.is_valid()) {
+        it.strftime(400, 135, id(font_title), BLUE, TextAlign::TOP_CENTER, "%Y-%m-%d", now);
+        it.strftime(400, 190, id(font_title), BLUE, TextAlign::TOP_CENTER, "%H:%M:%S", now);
+        ESP_LOGD("rtc_demo", "RTC time is valid");
+      } else {
+        it.printf(400, 150, id(font_body), RED, TextAlign::TOP_CENTER, "RTC: waiting for sync");
+        ESP_LOGW("rtc_demo", "RTC time is not valid yet");
+      }
+```
+
+</TabItem>
 </Tabs>
 
 This configuration:
@@ -299,7 +495,7 @@ This configuration:
 - Writes the Home Assistant time back to the hardware RTC.
 - Displays the current date and time on the ePaper screen.
 
-The following image shows the expected result on reTerminal E1002. The same demo works on both reTerminal E1001 and E1002. The main difference is the display output: E1001 shows a monochrome result, while E1002 can show a color result.
+The following image shows the expected result on reTerminal E1002. The same demo pattern works across the reTerminal E Series. Choose the matching device tab above. Monochrome / grayscale panels (E1001, E1003) and color panels (E1002, E1004) differ mainly in the display platform and color drawing API.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/252.jpeg" style={{width:700, height:'auto'}}/></div>
 
@@ -309,7 +505,7 @@ If the RTC time does not stay correct after a full power cycle, install or repla
 
 ## MicroSD Card Detection
 
-This demo reports whether a microSD card is inserted. It also turns on the SD card power rail through `GPIO16`.
+This demo reports whether a microSD card is inserted. It also turns on the SD card power rail through `GPIO16` (E1001 / E1002 / E1004) or `GPIO39` (E1003).
 
 The card detect pin is active LOW, so the binary sensor uses `inverted: true`.
 
@@ -506,6 +702,212 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later. E1003 uses SD power enable on `GPIO39`.
+:::
+
+```yaml
+esphome:
+  name: reterminal-e1003-sd-demo
+  friendly_name: reTerminal_E1003_SD_Demo
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - delay: 200ms
+      - component.update: epaper_display
+
+esp32:
+  board: seeed_xiao_esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1003-SD-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+output:
+  - platform: gpio
+    pin: GPIO39
+    id: bsp_sd_enable
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO15
+      mode: INPUT_PULLUP
+      inverted: true
+    id: sd_card_detect
+    name: "SD Card Detected"
+    on_press:
+      then:
+        - logger.log: "SD card inserted"
+        - component.update: epaper_display
+    on_release:
+      then:
+        - logger.log: "SD card removed"
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 28
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 300s
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      it.printf(400, 40, id(font_title), Color::BLACK, TextAlign::TOP_CENTER, "microSD Card Detection");
+      if (id(sd_card_detect).state) {
+        it.printf(400, 160, id(font_body), Color::BLACK, TextAlign::TOP_CENTER, "SD Card: inserted");
+      } else {
+        it.printf(400, 160, id(font_body), Color::BLACK, TextAlign::TOP_CENTER, "SD Card: not detected");
+      }
+      it.printf(400, 230, id(font_body), Color::BLACK, TextAlign::TOP_CENTER, "Detect pin: GPIO15");
+```
+
+</TabItem>
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+esphome:
+  name: reterminal-e1004-sd-demo
+  friendly_name: reTerminal_E1004_SD_Demo
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - delay: 200ms
+      - component.update: epaper_display
+
+esp32:
+  board: seeed_xiao_esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1004-SD-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    id: bsp_sd_enable
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO15
+      mode: INPUT_PULLUP
+      inverted: true
+    id: sd_card_detect
+    name: "SD Card Detected"
+    on_press:
+      then:
+        - logger.log: "SD card inserted"
+        - component.update: epaper_display
+    on_release:
+      then:
+        - logger.log: "SD card removed"
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 28
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: seeed-reterminal-e1004
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK = Color(0, 0, 0, 0);
+      const auto RED = Color(255, 0, 0, 0);
+      const auto GREEN = Color(0, 255, 0, 0);
+
+      it.printf(400, 40, id(font_title), BLACK, TextAlign::TOP_CENTER, "microSD Card Detection");
+      if (id(sd_card_detect).state) {
+        it.printf(400, 160, id(font_body), GREEN, TextAlign::TOP_CENTER, "SD Card: inserted");
+      } else {
+        it.printf(400, 160, id(font_body), RED, TextAlign::TOP_CENTER, "SD Card: not detected");
+      }
+      it.printf(400, 230, id(font_body), BLACK, TextAlign::TOP_CENTER, "Detect pin: GPIO15");
+```
+
+</TabItem>
 </Tabs>
 
 This configuration:
@@ -515,7 +917,7 @@ This configuration:
 - Shows the card state on the ePaper screen.
 - Exposes `SD Card Detected` to Home Assistant as a binary sensor.
 
-The following image shows the expected result on reTerminal E1002. The same demo works on both reTerminal E1001 and E1002. The main difference is the display output: E1001 shows a monochrome result, while E1002 can show a color result.
+The following image shows the expected result on reTerminal E1002. The same demo pattern works across the reTerminal E Series. Choose the matching device tab above. Monochrome / grayscale panels (E1001, E1003) and color panels (E1002, E1004) differ mainly in the display platform and color drawing API.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/253.jpeg" style={{width:700, height:'auto'}}/></div>
 
@@ -694,6 +1096,99 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later. reTerminal E1003 includes the onboard PDM microphone.
+:::
+
+```yaml
+esphome:
+  name: reterminal-e1003-mic-demo
+  friendly_name: reTerminal_E1003_Mic_Demo
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - logger.log: "PDM microphone power enabled"
+      - component.update: epaper_display
+
+esp32:
+  board: seeed_xiao_esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1003-Mic-Demo"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+
+output:
+  - platform: gpio
+    pin: GPIO38
+    id: mic_power_enable
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_title
+    size: 32
+  - file: "gfonts://Inter@700"
+    id: font_body
+    size: 26
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 300s
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      it.printf(400, 40, id(font_title), Color::BLACK, TextAlign::TOP_CENTER, "PDM Microphone Power");
+      it.printf(400, 135, id(font_body), Color::BLACK, TextAlign::TOP_CENTER, "Mic Power: ON");
+      it.printf(400, 190, id(font_body), Color::BLACK, TextAlign::TOP_CENTER, "CLK GPIO42 / DATA GPIO41");
+      it.printf(400, 245, id(font_body), Color::BLACK, TextAlign::TOP_CENTER, "I2S microphone: optional");
+```
+
+</TabItem>
+
+<TabItem value="For E1004" label="For E1004">
+
+:::note
+**reTerminal E1004 does not include an onboard PDM microphone.** Use the RTC and microSD demos on this page for E1004, or skip this section.
+:::
+
+</TabItem>
 </Tabs>
 
 This configuration:
@@ -716,7 +1211,7 @@ microphone:
     i2s_din_pin: GPIO41
 ```
 
-The following image shows the expected result on reTerminal E1002. The same demo works on both reTerminal E1001 and E1002. The main difference is the display output: E1001 shows a monochrome result, while E1002 can show a color result.
+The following image shows the expected result on reTerminal E1002. The same demo pattern works across the reTerminal E Series. Choose the matching device tab above. Monochrome / grayscale panels (E1001, E1003) and color panels (E1002, E1004) differ mainly in the display platform and color drawing API.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/254.jpeg" style={{width:700, height:'auto'}}/></div>
 
@@ -1021,13 +1516,312 @@ display:
 ```
 
 </TabItem>
+
+<TabItem value="For E1003" label="For E1003">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+esphome:
+  name: reterminal-e1003-hardware-status
+  friendly_name: reTerminal_E1003_Hardware_Status
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - pcf8563.read_time:
+      - component.update: epaper_display
+
+esp32:
+  board: seeed_xiao_esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1003-HW-Status"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+i2s_audio:
+  i2s_lrclk_pin: GPIO42
+
+output:
+  - platform: gpio
+    pin: GPIO39
+    id: bsp_sd_enable
+
+  - platform: gpio
+    pin: GPIO38
+    id: mic_power_enable
+
+time:
+  - platform: pcf8563
+    id: rtc_time
+    address: 0x51
+    update_interval: never
+
+  - platform: homeassistant
+    on_time_sync:
+      then:
+        - pcf8563.write_time:
+        - component.update: epaper_display
+
+microphone:
+  - platform: i2s_audio
+    id: onboard_mic
+    adc_type: external
+    pdm: true
+    i2s_din_pin: GPIO41
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO15
+      mode: INPUT_PULLUP
+      inverted: true
+    id: sd_card_detect
+    name: "SD Card Detected"
+    on_press:
+      then:
+        - component.update: epaper_display
+    on_release:
+      then:
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_small
+    size: 20
+  - file: "gfonts://Inter@700"
+    id: font_medium
+    size: 32
+
+display:
+  - platform: it8951
+    id: epaper_display
+    spi_id: epaper_spi_bus
+    model: seeed-reterminal-e1003
+    update_interval: 300s
+    full_update_every: 30
+    grayscale: true
+    dithering: true
+    update_mode: GC16
+    transform:
+      mirror_x: true
+      mirror_y: false
+    lambda: |-
+      it.printf(400, 20, id(font_medium), Color::BLACK, TextAlign::TOP_CENTER,
+                "reTerminal E1002 Hardware Status");
+      it.line(20, 60, 780, 60, BLACK);
+
+      auto now = id(rtc_time).now();
+      if (now.is_valid()) {
+        it.strftime(30, 95, id(font_medium), Color::BLACK, "%Y-%m-%d %H:%M", now);
+        ESP_LOGD("status", "RTC time is valid");
+      } else {
+        it.printf(30, 95, id(font_medium), Color::BLACK, "RTC: waiting for sync");
+        ESP_LOGW("status", "RTC time is not valid yet");
+      }
+
+      if (id(sd_card_detect).state) {
+        it.printf(30, 155, id(font_medium), Color::BLACK, "SD Card: inserted");
+      } else {
+        it.printf(30, 155, id(font_medium), Color::BLACK, "SD Card: not detected");
+      }
+
+      it.printf(30, 215, id(font_medium), Color::BLACK, "PDM Mic: initialized");
+      it.printf(30, 265, id(font_small), Color::BLACK, "RTC: I2C address 0x51");
+      it.printf(30, 295, id(font_small), Color::BLACK, "SD: DET GPIO15 / EN GPIO16");
+      it.printf(30, 325, id(font_small), Color::BLACK, "Mic: CLK GPIO42 / DATA GPIO41 / EN GPIO38");
+```
+
+</TabItem>
+
+<TabItem value="For E1004" label="For E1004">
+
+:::tip
+Please update your ESPHome version to **2026.7.0** or later.
+:::
+
+```yaml
+esphome:
+  name: reterminal-e1004-hardware-status
+  friendly_name: reTerminal_E1004_Hardware_Status
+  on_boot:
+    priority: 600
+    then:
+      - output.turn_on: bsp_sd_enable
+      - output.turn_on: mic_power_enable
+      - delay: 200ms
+      - pcf8563.read_time:
+      - component.update: epaper_display
+
+esp32:
+  board: seeed_xiao_esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+
+logger:
+  hardware_uart: UART0
+
+api:
+  encryption:
+    key: "REPLACE_WITH_YOUR_API_KEY"
+
+ota:
+  - platform: esphome
+    password: "REPLACE_WITH_YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "E1004-HW-Status"
+    password: "ChangeMe123"
+
+captive_portal:
+
+spi:
+  clk_pin: GPIO7
+  mosi_pin: GPIO9
+  miso_pin: GPIO8
+
+i2c:
+  scl: GPIO20
+  sda: GPIO19
+
+i2s_audio:
+  i2s_lrclk_pin: GPIO42
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    id: bsp_sd_enable
+
+  - platform: gpio
+    pin: GPIO38
+    id: mic_power_enable
+
+time:
+  - platform: pcf8563
+    id: rtc_time
+    address: 0x51
+    update_interval: never
+
+  - platform: homeassistant
+    on_time_sync:
+      then:
+        - pcf8563.write_time:
+        - component.update: epaper_display
+
+microphone:
+  - platform: i2s_audio
+    id: onboard_mic
+    adc_type: external
+    pdm: true
+    i2s_din_pin: GPIO41
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO15
+      mode: INPUT_PULLUP
+      inverted: true
+    id: sd_card_detect
+    name: "SD Card Detected"
+    on_press:
+      then:
+        - component.update: epaper_display
+    on_release:
+      then:
+        - component.update: epaper_display
+
+font:
+  - file: "gfonts://Inter@700"
+    id: font_small
+    size: 20
+  - file: "gfonts://Inter@700"
+    id: font_medium
+    size: 32
+
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: seeed-reterminal-e1004
+    update_interval: 300s
+    lambda: |-
+      const auto BLACK = Color(0, 0, 0, 0);
+      const auto BLUE = Color(0, 0, 255, 0);
+      const auto GREEN = Color(0, 255, 0, 0);
+      const auto RED = Color(255, 0, 0, 0);
+
+      it.printf(400, 20, id(font_medium), BLACK, TextAlign::TOP_CENTER,
+                "reTerminal E1002 Hardware Status");
+      it.line(20, 60, 780, 60, BLACK);
+
+      auto now = id(rtc_time).now();
+      if (now.is_valid()) {
+        it.strftime(30, 95, id(font_medium), BLUE, "%Y-%m-%d %H:%M", now);
+        ESP_LOGD("status", "RTC time is valid");
+      } else {
+        it.printf(30, 95, id(font_medium), RED, "RTC: waiting for sync");
+        ESP_LOGW("status", "RTC time is not valid yet");
+      }
+
+      if (id(sd_card_detect).state) {
+        it.printf(30, 155, id(font_medium), GREEN, "SD Card: inserted");
+      } else {
+        it.printf(30, 155, id(font_medium), RED, "SD Card: not detected");
+      }
+
+      it.printf(30, 215, id(font_medium), BLUE, "PDM Mic: initialized");
+      it.printf(30, 265, id(font_small), BLACK, "RTC: I2C address 0x51");
+      it.printf(30, 295, id(font_small), BLACK, "SD: DET GPIO15 / EN GPIO16");
+      it.printf(30, 325, id(font_small), BLACK, "Mic: CLK GPIO42 / DATA GPIO41 / EN GPIO38");
+```
+
+</TabItem>
 </Tabs>
 
 </details>
 
 When the firmware is running, the screen shows the RTC time, SD card state, and microphone initialization status on one page.
 
-The following image shows the expected result on reTerminal E1002. The same demo works on both reTerminal E1001 and E1002. The main difference is the display output: E1001 shows a monochrome result, while E1002 can show a color result.
+The following image shows the expected result on reTerminal E1002. The same demo pattern works across the reTerminal E Series. Choose the matching device tab above. Monochrome / grayscale panels (E1001, E1003) and color panels (E1002, E1004) differ mainly in the display platform and color drawing API.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/250.jpeg" style={{width:700, height:'auto'}}/></div>
 
@@ -1054,8 +1848,9 @@ After removing the card, upload or restart the RTC or microphone demo again. The
 
 ## Resources
 
+- **[Tool]** [reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/) — generate ESPHome YAML by selecting device features, or flash demos from the browser
 - **[Wiki]** [ESPHome Cookbook: Display Basics](/reterminal_e10xx_with_esphome)
-- **[Wiki]** [ESPHome Cookbook: Buttons, Buzzer, LED, Battery & Low Power](/reterminal_e10xx_with_esphome_advanced)
+- **[Wiki]** [ESPHome Cookbook: Buttons, Buzzer, LED, Battery, Touch & Low Power](/reterminal_e10xx_with_esphome_advanced)
 - **[Wiki]** [Work with ESPHome](/epaper_work_with_esphome)
 - **[Wiki]** [Arduino Cookbook: Onboard Peripherals](/reterminal_e10xx_with_arduino_peripherals)
 - **[Wiki]** [Arduino Cookbook: RTC, Low Power, Audio & Touch](/reterminal_e10xx_with_arduino_peripherals_2)

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/getting_started_with_reterminal_e1003.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/getting_started_with_reterminal_e1003.md
@@ -43,7 +43,7 @@ reTerminal E1003 is a 10.3 inch touch-supported, open-source monochrome ePaper d
 Touch interaction for reTerminal E1003 is supported starting from [SenseCraft HMI](https://sensecraft.seeed.cc/hmi) firmware v1.1.2. The current latest version is v1.1.4.3 — we recommend updating to it for the best experience.
 Touch-related library support is planned for future open-source release, providing greater flexibility to customize panels. More updates will be shared soon.
 
-ESPHome support for reTerminal E1003 is under development and will be available in a future release.
+reTerminal E1003 supports [ESPHome](/reterminal_e10xx_with_esphome) with Home Assistant. Start with the [display cookbook](/reterminal_e10xx_with_esphome), then continue to [I/O, battery, touch, and low power](/reterminal_e10xx_with_esphome_advanced) and [RTC, SD card, and microphone](/reterminal_e10xx_with_esphome_rtc_sd_microphone). ESPHome **2026.7.0 or later** is required for the E1003 display driver.
 :::
 
 ### Features

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/getting_started_with_reterminal_e1004.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/getting_started_with_reterminal_e1004.md
@@ -44,7 +44,7 @@ If you want to quickly preview project results or try the basic demo firmware be
 
 ## Introduction
 
-reTerminal E1004 is a 13.3 inch open-source full color ePaper display with up to 6-month battery life. Powered by ESP32-S3, it natively supports our SenseCraft HMI no-code UI platform for effortless dashboard creation, while supporting Home Assistant, Arduino and ESP-IDF for further development. With the E Ink® Spectra™ 6 full-color ePaper Display, it's perfect for digital frame, colorful dashboard visualization.
+reTerminal E1004 is a 13.3 inch open-source full color ePaper display with up to 6-month battery life. Powered by ESP32-S3, it natively supports our SenseCraft HMI no-code UI platform for effortless dashboard creation, while supporting Home Assistant via [ESPHome](/reterminal_e10xx_with_esphome), Arduino and ESP-IDF for further development. With the E Ink® Spectra™ 6 full-color ePaper Display, it's perfect for digital frame, colorful dashboard visualization. ESPHome **2026.7.0 or later** is required for the E1004 display driver.
 
 ### Features
 

--- a/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/reterminal_e10xx_main_page.md
+++ b/sites/en/docs/Sensor/ePaper_Displays/reTerminal_E10xx/reterminal_e10xx_main_page.md
@@ -6,27 +6,27 @@ slug: /reterminal_e10xx_main_page
 sku: 100017057,100073581
 sidebar_position: 1
 last_update:
-  date: 04/28/2026
+  date: 08/05/2026
   author: Citric
 createdAt: '2025-07-25'
-updatedAt: '2026-06-16'
+updatedAt: '2026-08-05'
 url: https://wiki.seeedstudio.com/reterminal_e10xx_main_page/
 ---
 # reTerminal E Series ePaper Display Overview
 
-:::tip Try demos without setting up a development environment
-If you want to quickly preview project results or try the basic demo firmware before setting up a development environment, open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)**. You can choose a supported reTerminal E Series device and flash demo firmware directly from a browser.
+:::tip Generate ESPHome YAML or flash demos in the browser
+Open the **[reTerminal E-Series Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/)** to get started fast. Choose the **ESPHome** card, pick your device (E1001 / E1002 / E1003 / E1004), check the onboard features you need, and generate matching ESPHome YAML — or flash demo firmware directly from the browser (desktop Chrome or Edge).
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
     <a class="get_one_now_item" href="https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/" target="_blank">
-            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Flasher 🖱️</font></span></strong>
+            <strong><span><font color={'FFFFFF'} size={"4"}> Firmware Hub 🖱️</font></span></strong>
     </a>
 </div><br />
 :::
 
 ## Introduction
 
-The reTerminal E Series is Seeed Studio's family of ESP32-S3-powered ePaper display terminals, purpose-built for **always-on, low-power information display**. The lineup spans four models — **E1001, E1002, E1003, E1004** — covering monochrome and full-color panels from 7.3" to 13.3", with options for touch interaction and multi-month battery life. They all share the same software stack (SenseCraft HMI, Home Assistant, Arduino, and more), so you only have to learn it once and then pick the form-factor that fits your scenario.
+The reTerminal E Series is Seeed Studio's family of ESP32-S3-powered ePaper display terminals, purpose-built for **always-on, low-power information display**. The lineup spans four models — **E1001, E1002, E1003, E1004** — covering monochrome and full-color panels from 7.3" to 13.3", with options for touch interaction and multi-month battery life. They all share the same software stack (SenseCraft HMI, Home Assistant / ESPHome, Arduino, and more), so you only have to learn it once and then pick the form-factor that fits your scenario.
 
 Unlike traditional displays that consume power continuously, the reTerminal E Series only draws current when redrawing content, making it ideal for digital photo frames, smart-home dashboards, retail signage, meeting-room boards, classroom displays, and other always-on use cases.
 
@@ -230,8 +230,8 @@ Use the quick guide below to narrow down to one model. If multiple rows apply, t
 		</tr>
 		<tr>
 			<td>Need Home Assistant / ESPHome integration today</td>
-			<td align="center"><strong>E1001 / E1002 / E1004</strong></td>
-			<td>Direct Home Assistant support is available on E1001, E1002 and E1004. ESPHome on E1003 is planned.</td>
+			<td align="center"><strong>E1001 / E1002 / E1003 / E1004</strong></td>
+			<td>All four models support Home Assistant through ESPHome. E1003 and E1004 require ESPHome 2026.7.0 or later.</td>
 		</tr>
 		<tr>
 			<td>Want a TRMNL E-Ink dashboard</td>
@@ -303,16 +303,16 @@ The reTerminal E1002 features a vibrant 7.3-inch full-color ePaper display with 
   </a>
 </div><br />
 
-reTerminal E1003 is a 10.3-inch open-source monochrome ePaper display featuring 16 levels of grayscale and a high resolution of 1404×1872 pixels, with up to 6-month battery life. Touch interaction is currently supported on SenseCraft HMI firmware v1.1.2. Powered by ESP32-S3, it natively supports SenseCraft HMI no-code UI design, while Arduino and PlatformIO are available for further development.
+reTerminal E1003 is a 10.3-inch open-source monochrome ePaper display featuring 16 levels of grayscale and a high resolution of 1404×1872 pixels, with up to 6-month battery life. Touch interaction is currently supported on SenseCraft HMI firmware v1.1.2. Powered by ESP32-S3, it natively supports SenseCraft HMI no-code UI design, while Arduino, PlatformIO, and ESPHome (Home Assistant) are available for further development.
 
-The touch-related library is planned for future open-source release, providing greater flexibility to customize panels. More updates will be shared soon. ESPHome driver support for E1003 is also planned for a future release.
+The touch-related Arduino library is planned for future open-source release, providing greater flexibility to customize panels. More updates will be shared soon. ESPHome already supports the E1003 display driver and GT911 capacitive touch — see the [ESPHome cookbooks](/reterminal_e10xx_with_esphome).
 
 ### Key Features
 
 - 10.3-inch monochrome ePaper display with touch interaction support on HMI firmware v1.1.2
 - 16-level grayscale with 1404×1872 high resolution
 - Up to 6-month battery life with ultra-low power operation
-- Native SenseCraft HMI support plus Arduino and PlatformIO compatibility, with ESPHome driver support planned
+- Native SenseCraft HMI support plus Arduino, PlatformIO, and ESPHome (Home Assistant) compatibility
 
 ## reTerminal E1004
 
@@ -327,14 +327,14 @@ The touch-related library is planned for future open-source release, providing g
   </a>
 </div><br />
 
-The reTerminal E1004 features a 13.3-inch full-color ePaper display and up to 6-month battery life. Powered by ESP32-S3, it supports SenseCraft HMI for no-code dashboard creation and image uploading, while also supporting Home Assistant, Arduino, and ESP-IDF for advanced development workflows.
+The reTerminal E1004 features a 13.3-inch full-color ePaper display and up to 6-month battery life. Powered by ESP32-S3, it supports SenseCraft HMI for no-code dashboard creation and image uploading, while also supporting Home Assistant via ESPHome, Arduino, and ESP-IDF for advanced development workflows. ESPHome **2026.7.0 or later** is required for the E1004 display driver — see the [ESPHome cookbooks](/reterminal_e10xx_with_esphome).
 
 ### Key Features
 
 - 13.3-inch full-color ePaper display
 - Up to 6-month battery life for always-on scenarios
 - ESP32-S3 platform with SenseCraft HMI no-code support
-- Compatible with Home Assistant, Arduino, and ESP-IDF
+- Compatible with Home Assistant / ESPHome, Arduino, and ESP-IDF
 
 ## SenseCraft HMI — The Default No-Code Platform
 
@@ -355,7 +355,7 @@ Every reTerminal E Series device ships with **SenseCraft HMI** firmware out of t
 - **RSS / Web Content** — pull live news, weather, calendar, or any web feed onto the screen.
 - **Touch interaction** — fully supported on E1003 starting from HMI firmware v1.1.2.
 
-If you need more control than the no-code workflow gives you, every device also exposes the underlying ESP32-S3, so you can drop down to the application tutorials below at any time.
+If you need more control than the no-code workflow gives you, every device also exposes the underlying ESP32-S3, so you can drop down to ESPHome / Home Assistant, Arduino, and the application tutorials below at any time. For a ready-made ESPHome YAML, use the [Firmware Hub](https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/) ESPHome card and check the features you need.
 
 ## Applications & Tutorials
 
@@ -375,27 +375,27 @@ Beyond SenseCraft HMI, the reTerminal E Series integrates with several industry-
 		</tr>
 		<tr>
 			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome">ESPHome — Display</a></td>
-			<td>Plug the device into Home Assistant and draw simple ePaper graphics with YAML.</td>
+			<td>Plug the device into Home Assistant and draw simple ePaper graphics with YAML. Generate a starter YAML from the <a href="https://seeed-projects.github.io/OSHW-reTerminal-Series-E-D/">Firmware Hub</a> by selecting your device and features.</td>
 			<td align="center">✅</td>
 			<td align="center">✅</td>
-			<td align="center">Planned</td>
-			<td align="center">via Home Assistant</td>
+			<td align="center">✅</td>
+			<td align="center">✅</td>
 		</tr>
 		<tr>
-			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced">ESPHome — I/O, Battery &amp; Power</a></td>
-			<td>Buttons, buzzer, onboard LED, battery monitoring, deep sleep, multi-page dashboards.</td>
+			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced">ESPHome — I/O, Battery, Touch &amp; Power</a></td>
+			<td>Buttons, buzzer, onboard LED, battery monitoring, deep sleep, multi-page dashboards, and capacitive touch (E1003).</td>
 			<td align="center">✅</td>
 			<td align="center">✅</td>
-			<td align="center">Planned</td>
-			<td align="center">via Home Assistant</td>
+			<td align="center">✅</td>
+			<td align="center">✅</td>
 		</tr>
 		<tr>
 			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_rtc_sd_microphone">ESPHome — RTC, SD &amp; Microphone</a></td>
 			<td>PCF8563 RTC time sync, microSD card detect, and onboard PDM microphone setup.</td>
 			<td align="center">✅</td>
 			<td align="center">✅</td>
-			<td align="center">Planned</td>
-			<td align="center">No mic</td>
+			<td align="center">✅</td>
+			<td align="center">✅ <em>(no mic)</em></td>
 		</tr>
 		<tr>
 			<td><a href="https://wiki.seeedstudio.com/reterminal_e10xx_trmnl">Works with TRMNL</a></td>


### PR DESCRIPTION
- Enhanced the ESPHome integration section, clarifying support for E1003 and E1004 with required ESPHome version 2026.7.0 or later.
- Revised tips for generating ESPHome YAML and flashing demos directly from the browser.
- Updated descriptions and titles in the ESPHome cookbooks to include capacitive touch support for E1003.
- Corrected and standardized references to the Firmware Hub across multiple documents.
- Adjusted last update dates to reflect recent changes.