### PR TITLE
docs: redesign SenseCraft product and user guide

### DIFF
--- a/sites/en/docs/Cloud.md
+++ b/sites/en/docs/Cloud.md
@@ -1,144 +1,339 @@
 ---
-description: Discover Seeed’s SenseCraft Cloud services — a powerful, industrial-grade platform designed for efficient data management, real-time operations, and scalable IoT applications. Learn more about how SenseCraft supports your industrial IoT cloud deployment.
-title: Cloud
+description: Choose the right SenseCraft product for edge AI, hardware coding, robotics, IoT data, HMI dashboards, device operations, and SenseCAP MX or Hotspot workflows.
+title: SenseCraft Products and User Guides
+hide_title: true
 keywords:
-  - SenseCraft Matrix
   - SenseCraft
   - SenseCraft AI
-  - SenseCraft Cloud
-  - Industrial IoT Cloud
-  - Data Management
-  - Device management
-  - Real-Time Operations
-image: https://files.seeedstudio.com/wiki/wiki-platform/S-tempor.png
+  - CodeCraft
+  - reComputer AI Lab
+  - SenseCraft Robotics
+  - SenseCraft Data Platform
+  - SenseCraft App
+  - SenseCraft HMI
+  - Device Management Platform
+  - SenseCAP MX
+  - SenseCAP Hotspot
+image: https://sensecraft-statics.seeed.cc/sensecraft-ai/Banner1.650c5596.png
 slug: /Cloud
 last_update:
-  date: 06/06/2025
+  date: 08/06/2026
   author: Jancee
 createdAt: '2023-01-05'
-updatedAt: '2026-08-04'
+updatedAt: '2026-08-06'
 url: https://wiki.seeedstudio.com/Cloud/
 ---
 
-
-Cloud services are a vital component that enable processed data management from computing boards and provide users with real-time operations. This page introduces Seeed’s industrial-grade SenseCraft cloud services, along with other cloud service applications tailored for diverse industrial IoT needs. Through a robust cloud infrastructure, Seeed empowers users to securely store, analyze, and leverage processed data, facilitating data-driven decision-making and enhancing operational efficiency across various domains.
-
-## SenseCraft Cloud Service
-
-<strong><font color={'8DC215'} size={"4"}>This section highlights different cloud services offered by Seeed Studio, tailored for various industrial IoT applications. You can explore more in the following areas:</font></strong>
-
-- Catalogue of SenseCraft ecosystem and cloud services.
-- Instructions for data and device management for each cloud product
-- APIs for various connection purposes
-- Introduction to cloud services
-
-### SenseCraft Data Platform / Blockchain Dashboard
-
-<div class="title_container">
-    <div class="title_item" style={{textAlign: 'center'}}>
-            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>SenseCraft Data Platform</font></div>
-            <p class="start_card_title" style={{textAlign: 'center'}}><font color={'FFFFFF'} size={"3"}>The SenseCraft Data Platform provides data monitoring for SenseCAP sensor nodes and gateways.</font></p>
+<div className="hero hero--primary margin-bottom--xl">
+  <div className="container">
+    <h1 className="hero__title">Find the right SenseCraft product</h1>
+    <div className="hero__subtitle">
+      Start with what you want to create, connect, visualize, or operate. This guide maps each goal to the right SenseCraft product, platform, download, and user guide.
     </div>
+    <div className="margin-top--md">
+      <a className="button button--secondary button--lg margin-right--sm margin-bottom--sm" href="#choose-by-goal">
+        Choose by goal
+      </a>
+      <a className="button button--outline button--secondary button--lg margin-bottom--sm" href="https://sensecraft.seeed.cc/en/products" target="_blank" rel="noopener noreferrer">
+        Open the product catalog
+      </a>
+    </div>
+  </div>
 </div>
 
-<div class="intro_container">
-    <div class="intro_item" style={{textAlign: 'center'}}>
-            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"5"}>SenseCAP MX Dashboard</font></div>
-            <a href="/sensecraft-blockchain/blockchain-dashboard/dashboard-basics" target="_blank"><span><font color={'FFFFFF'} size={"2"}>Dashboard Basics</font></span></a>
-            <br/>
-            <a href="/sensecraft-blockchain/blockchain-dashboard/dashboard-registration" target="_blank"><span><font color={'FFFFFF'} size={"2"}>Dashboard Registration</font></span></a>
-            <br/>
-            <a href="/sensecraft-blockchain/blockchain-dashboard/hotspot-registration" target="_blank"><span><font color={'FFFFFF'} size={"2"}>Hotspot Registration</font></span></a>
-            <br/>
+SenseCraft brings together software for building AI and hardware applications, training robots, connecting IoT devices, creating human-machine interfaces, and operating deployed edge systems. The products are related, but each serves a different stage of the workflow.
+
+## Choose by goal
+
+
+| Your goal | Start with |
+| --- | --- |
+| Create, train, or deploy an edge-AI application | [SenseCraft AI](#sensecraft-ai) |
+| Turn an idea into runnable hardware code | [CodeCraft](#codecraft) |
+| Run optimized AI models and tools on reComputer hardware | [reComputer AI Lab](#recomputer-ai-lab) |
+| Collect demonstrations, train, and validate a robotic-arm behavior | [SenseCraft Robotics](#sensecraft-robotics) |
+| Connect IoT devices and collect or view sensor data | [SenseCraft Data Platform](#sensecraft-data-platform) |
+| Configure supported devices and monitor them from a phone | [SenseCraft App](#sensecraft-app) |
+| Create dashboards and display experiences for reTerminal | [SenseCraft HMI](#sensecraft-hmi) |
+| Operate distributed edge devices and roll out applications | [SenseCraft Device Management Platform](#sensecraft-device-management-platform) |
+| Deploy or manage SenseCAP gateways for decentralized networks | [SenseCAP MX / Hotspot](#sensecap-mx-hotspot) |
+
+## Create AI and hardware applications
+
+<div className="row">
+  <div className="col col--6 margin-bottom--lg">
+    <div className="card card--full-height">
+      <div className="card__image">
+        <img
+          src="https://sensecraft.seeed.cc/assets/new_home/illustrations/sensecraft-ai-preview.png"
+          alt="SenseCraft AI vision application preview"
+          loading="lazy"
+          style={{ width: '100%', height: '220px', objectFit: 'cover', display: 'block' }}
+        />
+      </div>
+      <div className="card__body">
+        <div className="badge badge--success margin-bottom--sm">Create</div>
+        <h3 id="sensecraft-ai">SenseCraft AI</h3>
+        <div className="margin-bottom--sm"><strong>Create, share, explore, and deploy AI applications.</strong></div>
+        <div className="margin-bottom--sm">
+          Use the model library, no-code training, and application community to move from an AI idea to inference on supported edge devices. SenseCraft AI includes more than 400 models for SBC devices and supports one-click deployment from community applications.
+        </div>
+        <div className="margin-bottom--sm">
+          <a href="https://sensecraft.seeed.cc/ai/model?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_model_library" target="_blank" rel="noopener noreferrer">Model library</a>
+          {' · '}
+          <a href="https://sensecraft.seeed.cc/ai/training?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_training" target="_blank" rel="noopener noreferrer">Train a model</a>
+          {' · '}
+          <a href="https://sensecraft.seeed.cc/ai/application?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_app_square" target="_blank" rel="noopener noreferrer">Explore applications</a>
+        </div>
+      </div>
+      <div className="card__footer">
+        <a className="button button--primary margin-right--sm margin-bottom--sm" href="https://sensecraft.seeed.cc/ai/home?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_home" target="_blank" rel="noopener noreferrer">Open SenseCraft AI</a>
+        <a className="button button--outline button--secondary margin-bottom--sm" href="/sensecraft-ai/sensecraft-ai-main/">Read the Wiki center</a>
+      </div>
     </div>
-    <div class="intro_item" style={{textAlign: 'center'}}>
-            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"5"}>SenseCraft Data Management</font></div>
-            <a href="/sensecraft-data-platform/tutorials/data-management#table" target="_blank"><span><font color={'FFFFFF'} size={"2"}>Detailed Data in Table View</font></span></a>
-            <br/>
-            <a href="/sensecraft-data-platform/tutorials/data-management#graph" target="_blank"><span><font color={'FFFFFF'} size={"2"}>Graphical Data in Graph View</font></span></a>
-            <br/>
-            <a href="/sensecraft-data-platform/tutorials/data-management#check-account-info" target="_blank"><span><font color={'FFFFFF'} size={"2"}>Account Information</font></span></a>
-            <br/>
+  </div>
+
+  <div className="col col--6 margin-bottom--lg">
+    <div className="card card--full-height">
+      <div className="card__image" style={{ background: 'var(--ifm-color-emphasis-100)' }}>
+        <img
+          src="https://sensecraft.seeed.cc/assets/codecraft.png"
+          alt="CodeCraft hardware projects built with Wio Terminal, XIAO, and Grove"
+          loading="lazy"
+          style={{ width: '100%', height: '220px', objectFit: 'contain', display: 'block', padding: '1rem' }}
+        />
+      </div>
+      <div className="card__body">
+        <div className="badge badge--success margin-bottom--sm">Create</div>
+        <h3 id="codecraft">CodeCraft</h3>
+        <div className="margin-bottom--sm"><strong>A hardware-focused AI coding assistant that brings an idea to life in minutes.</strong></div>
+        <div className="margin-bottom--sm">
+          Describe the hardware project you want to build, generate its code, compile it in the cloud, and flash it from the browser. CodeCraft supports practical prototyping and learning workflows with Wio Terminal, XIAO, Grove, Arduino projects, and browser-based WebSerial.
+        </div>
+        <div className="margin-bottom--sm">
+          <a href="https://codecraft.seeed.cc/workspace?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_workspace" target="_blank" rel="noopener noreferrer">Open the workspace</a>
+          {' · '}
+          <a href="https://codecraft.seeed.cc/pricing?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_pricing" target="_blank" rel="noopener noreferrer">View pricing</a>
+        </div>
+      </div>
+      <div className="card__footer">
+        <a className="button button--primary margin-right--sm margin-bottom--sm" href="https://codecraft.seeed.cc/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=codecraft_home" target="_blank" rel="noopener noreferrer">Open CodeCraft</a>
+        <a className="button button--outline button--secondary margin-bottom--sm" href="/codecraft/codecraft-overview/">Read the user guide</a>
+      </div>
     </div>
+  </div>
+
+  <div className="col col--6 margin-bottom--lg">
+    <div className="card card--full-height">
+      <div className="card__image" style={{ background: 'var(--ifm-color-emphasis-100)' }}>
+        <img
+          src="https://files.seeedstudio.com/Edge_box/reComputer_Lab.webp"
+          alt="reComputer AI Lab edge AI model and developer resource graphic"
+          loading="lazy"
+          style={{ width: '100%', height: '220px', objectFit: 'contain', display: 'block', padding: '1rem' }}
+        />
+      </div>
+      <div className="card__body">
+        <div className="badge badge--info margin-bottom--sm">Develop</div>
+        <h3 id="recomputer-ai-lab">reComputer AI Lab</h3>
+        <div className="margin-bottom--sm"><strong>Edge AI models, tools, and tutorials optimized for reComputer hardware.</strong></div>
+        <div className="margin-bottom--sm">
+          Browse more than 100 optimized computer-vision, LLM, and VLM models, then run them on NVIDIA Jetson, Rockchip, or Raspberry Pi based reComputer devices. Models include benchmarks and ready-to-run deployment commands, with conversion tools, tutorials, and community projects in the same developer resource center.
+        </div>
+        <div className="margin-bottom--sm">
+          <a href="https://sensecraft.seeed.cc/ai-lab/models?lang=en&utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=ai_lab_models" target="_blank" rel="noopener noreferrer">Browse models</a>
+          {' · '}
+          <a href="https://sensecraft.seeed.cc/ai-lab/tools?lang=en&utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=ai_lab_tools" target="_blank" rel="noopener noreferrer">Open tools</a>
+        </div>
+      </div>
+      <div className="card__footer">
+        <a className="button button--primary margin-right--sm margin-bottom--sm" href="https://sensecraft.seeed.cc/ai-lab/?lang=en&utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=ai_lab_home" target="_blank" rel="noopener noreferrer">Explore AI Lab</a>
+        <a className="button button--outline button--secondary margin-bottom--sm" href="https://sensecraft.seeed.cc/ai-lab/tutorials?lang=en&utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=ai_lab_docs" target="_blank" rel="noopener noreferrer">Browse tutorials</a>
+      </div>
+    </div>
+  </div>
+
+  <div className="col col--6 margin-bottom--lg">
+    <div className="card card--full-height">
+      <div className="card__image" style={{ background: 'var(--ifm-color-emphasis-100)' }}>
+        <img
+          src="https://sensecraft.seeed.cc/assets/rearm-landing/media/adv-overview.svg"
+          alt="SenseCraft Robotics illustration of a robotic arm, conveyor, and operator"
+          loading="lazy"
+          style={{ width: '100%', height: '220px', objectFit: 'contain', display: 'block', padding: '0.75rem' }}
+        />
+      </div>
+      <div className="card__body">
+        <div className="badge badge--info margin-bottom--sm">Develop</div>
+        <h3 id="sensecraft-robotics">SenseCraft Robotics</h3>
+        <div className="margin-bottom--sm"><strong>A ready-to-use robotic-arm training platform.</strong></div>
+        <div className="margin-bottom--sm">
+          Follow one connected workflow for calibration, demonstration data collection, cloud training, and validation. It is designed for education and labs, robotics R&amp;D proofs of concept, and early integration validation without requiring a high-end local training machine.
+        </div>
+      </div>
+      <div className="card__footer">
+        <a className="button button--primary margin-right--sm margin-bottom--sm" href="https://sensecraft.seeed.cc/en/robotics?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_robotics_home" target="_blank" rel="noopener noreferrer">Explore Robotics</a>
+        <a className="button button--outline button--secondary margin-bottom--sm" href="https://sensecraft.seeed.cc/en/download?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_robotics_download" target="_blank" rel="noopener noreferrer">Download the app</a>
+      </div>
+    </div>
+  </div>
 </div>
 
-<div class="independent_container">
-    <div class="independent_item" style={{textAlign: 'left'}}>
-            <div class="independent_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"5"}>SenseCraft Device Management</font></div>
-            <a href="/sensecraft-data-platform/tutorials/device-management#gateway" target="_blank"><span><font color={'FFFFFF'} size={"2"}><strong>SenseCAP Gateways</strong> - View EUI, Name, Status, and more.</font></span></a>
-            <br/>
-            <a href="/sensecraft-data-platform/tutorials/device-management#node-group-management" target="_blank"><span><font color={'FFFFFF'} size={"2"}><strong>SenseCAP Node Groups</strong> - Manage devices conveniently by groups.</font></span></a>
-            <br/>
-            <a href="/sensecraft-data-platform/tutorials/device-management#sensor-node-management" target="_blank"><span><font color={'FFFFFF'} size={"2"}><strong>SenseCAP Sensor Nodes</strong> - View EUI, Name, Status, Data Type, and more.</font></span></a>
-            <br/>
-            <a href="/sensecraft-data-platform/tutorials/device-management#general-information" target="_blank"><span><font color={'FFFFFF'} size={"2"}><strong>General Device Information</strong> - Battery status, recent online records, and more.</font></span></a>
-            <br/>
-            <a href="/sensecraft-data-platform/tutorials/device-management#settings" target="_blank"><span><font color={'FFFFFF'} size={"2"}><strong>Settings</strong> - Adjust data collection frequency and other settings.</font></span></a>
-            <br/>
-            <a href="/sensecraft-data-platform/tutorials/device-management#location" target="_blank"><span><font color={'FFFFFF'} size={"2"}><strong>Device Location</strong></font></span></a>
-            /
-            <a href="/sensecraft-data-platform/tutorials/device-management#bind-device" target="_blank"><span><font color={'FFFFFF'} size={"2"}><strong>Device Binding</strong></font></span></a>
-            /
-            <a href="/sensecraft-data-platform/tutorials/device-management#channel" target="_blank"><span><font color={'FFFFFF'} size={"2"}><strong>Device Channels</strong></font></span></a>
-            /
-            <a href="/sensecraft-data-platform/tutorials/device-management#data" target="_blank"><span><font color={'FFFFFF'} size={"2"}><strong>Device Data</strong></font></span></a>
+## Connect, visualize, and operate
+
+<div className="row">
+  <div className="col col--6 margin-bottom--lg">
+    <div className="card card--full-height">
+      <div className="card__image" style={{ height: '220px', display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: '0.5rem', alignItems: 'center', padding: '1rem', background: 'var(--ifm-color-emphasis-100)' }}>
+        <img src="https://sensecraft.seeed.cc/assets/new_home/illustrations/iot-2.svg" alt="SenseCAP gateway and antenna" loading="lazy" style={{ width: '100%', maxHeight: '150px', objectFit: 'contain' }} />
+        <img src="https://sensecraft.seeed.cc/assets/new_home/illustrations/iot-3.svg" alt="SenseCAP wireless field sensor" loading="lazy" style={{ width: '100%', maxHeight: '150px', objectFit: 'contain' }} />
+        <img src="https://sensecraft.seeed.cc/assets/new_home/illustrations/iot-6.svg" alt="SenseCAP weather station" loading="lazy" style={{ width: '100%', maxHeight: '150px', objectFit: 'contain' }} />
+        <img src="https://sensecraft.seeed.cc/assets/new_home/illustrations/iot-group.svg" alt="SenseCAP all-in-one environmental sensor" loading="lazy" style={{ width: '100%', maxHeight: '150px', objectFit: 'contain' }} />
+      </div>
+      <div className="card__body">
+        <div className="badge badge--primary margin-bottom--sm">Connect</div>
+        <h3 id="sensecraft-data-platform">SenseCraft Data Platform</h3>
+        <div className="margin-bottom--sm"><strong>An IoT device and data management platform.</strong></div>
+        <div className="margin-bottom--sm">
+          Pair supported gateways and sensors, collect data, and inspect device status and telemetry from one cloud platform. It serves as the data hub for SenseCAP devices and common IoT workflows using LoRaWAN, MQTT, Wi-Fi, weather, and environmental sensing.
+        </div>
+      </div>
+      <div className="card__footer">
+        <a className="button button--primary margin-right--sm margin-bottom--sm" href="https://sensecap.seeed.cc/portal/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_data_portal" target="_blank" rel="noopener noreferrer">Open Data Platform</a>
+        <a className="button button--outline button--secondary margin-bottom--sm" href="/cloud/sensecraft-data/sensecraft-data-platform/overview/">Read the quick start</a>
+      </div>
     </div>
+  </div>
+
+  <div className="col col--6 margin-bottom--lg">
+    <div className="card card--full-height">
+      <div className="card__image" style={{ height: '220px', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--ifm-color-emphasis-100)' }}>
+        <img
+          src="https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e5/56/bb/e556bba0-f994-8931-b3ce-f00ed16d2cad/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
+          alt="SenseCraft mobile app icon"
+          loading="lazy"
+          style={{ width: '132px', height: '132px', borderRadius: '28px', boxShadow: 'var(--ifm-global-shadow-md)' }}
+        />
+      </div>
+      <div className="card__body">
+        <div className="badge badge--primary margin-bottom--sm">Connect</div>
+        <h3 id="sensecraft-app">SenseCraft App</h3>
+        <div className="margin-bottom--sm"><strong>A mobile hub for IoT device management and AI configuration on iOS and Android.</strong></div>
+        <div className="margin-bottom--sm">
+          Use the app to add supported devices, monitor their data and status, change available settings, review events, and perform supported Bluetooth configuration or upgrades. Use this app for general SenseCAP device and data workflows; it is separate from the SenseCAP Hotspot App.
+        </div>
+      </div>
+      <div className="card__footer">
+        <a className="button button--primary margin-right--sm margin-bottom--sm" href="https://sensecraft.seeed.cc/en/download" target="_blank" rel="noopener noreferrer">Open Download Center</a>
+        <a className="button button--outline button--secondary margin-bottom--sm" href="/sensecraft-app/overview/">Read the App guide</a>
+      </div>
+    </div>
+  </div>
+
+  <div className="col col--6 margin-bottom--lg">
+    <div className="card card--full-height">
+      <div className="card__image">
+        <img
+          src="https://files.seeedstudio.com/wiki/reterminal_e10xx/img/23.png"
+          alt="SenseCraft HMI website showing dashboard and display scenarios"
+          loading="lazy"
+          style={{ width: '100%', height: '220px', objectFit: 'cover', objectPosition: 'top center', display: 'block' }}
+        />
+      </div>
+      <div className="card__body">
+        <div className="badge badge--primary margin-bottom--sm">Visualize</div>
+        <h3 id="sensecraft-hmi">SenseCraft HMI</h3>
+        <div className="margin-bottom--sm"><strong>Create or explore dashboard designs for reTerminal.</strong></div>
+        <div className="margin-bottom--sm">
+          Start from a dashboard template or design your own display on the canvas, then manage and push the result to supported reTerminal devices. SenseCraft HMI is intended for information displays, control interfaces, and data-rich device experiences.
+        </div>
+        <div className="margin-bottom--sm">
+          <a href="https://sensecraft.seeed.cc/hmi/workspace/page?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_hmi_canvas" target="_blank" rel="noopener noreferrer">Design on canvas</a>
+        </div>
+      </div>
+      <div className="card__footer">
+        <a className="button button--primary margin-right--sm margin-bottom--sm" href="https://sensecraft.seeed.cc/hmi/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_hmi_home" target="_blank" rel="noopener noreferrer">Open SenseCraft HMI</a>
+        <a className="button button--outline button--secondary margin-bottom--sm" href="/sensecraft_hmi_overview/">Read the HMI overview</a>
+      </div>
+    </div>
+  </div>
+
+  <div className="col col--6 margin-bottom--lg">
+    <div className="card card--full-height">
+      <div className="card__image" style={{ background: 'var(--ifm-color-emphasis-100)' }}>
+        <img
+          src="https://sensecraft.seeed.cc/assets/new_home/illustrations/fleet-scene.svg"
+          alt="A managed group of edge devices representing SenseCraft device operations"
+          loading="lazy"
+          style={{ width: '100%', height: '220px', objectFit: 'cover', objectPosition: 'center', display: 'block' }}
+        />
+      </div>
+      <div className="card__body">
+        <div className="badge badge--warning margin-bottom--sm">Operate</div>
+        <h3 id="sensecraft-device-management-platform">SenseCraft Device Management Platform</h3>
+        <div className="margin-bottom--sm"><strong>Manage distributed edge devices and roll out applications, models, and updates from one control plane.</strong></div>
+        <div className="margin-bottom--sm">
+          Use the platform after deployment to monitor supported edge nodes, apply consistent runtime policies, and manage application lifecycles across multiple devices. It supports mainstream edge hardware including NVIDIA Jetson, Rockchip, Raspberry Pi, and x86 edge PCs.
+        </div>
+        <div className="margin-bottom--sm">
+          <a href="https://seeed-fleet.com/apps?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_fleet_apps" target="_blank" rel="noopener noreferrer">Browse available apps</a>
+        </div>
+      </div>
+      <div className="card__footer">
+        <a className="button button--primary margin-right--sm margin-bottom--sm" href="https://seeed-fleet.com?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_fleet_home" target="_blank" rel="noopener noreferrer">Open Device Management</a>
+        <a className="button button--outline button--secondary margin-bottom--sm" href="https://seeed-fleet.com/docs?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_fleet_quick_start" target="_blank" rel="noopener noreferrer">Read the quick start</a>
+      </div>
+    </div>
+  </div>
 </div>
 
-### SenseCAP HotSpot APP
+## SenseCAP MX and Hotspot products
 
-<div class="title_container">
-    <div class="title_item" style={{textAlign: 'center'}}>
-            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>SenseCAP MX Blockchain App</font></div>
-            <p>The SenseCAP HotSpot App is used on mobile phones to manage LoRaWAN hotspots.</p>
-            <br/>
-            > <a href="/sensecraft-blockchain/sensecraft-hotspot-app/download-app" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Download</font></span></a> / <a href="/sensecraft-blockchain/sensecraft-hotspot-app/hotspot-management" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Hotspot Management</font></span></a> / <a href="/sensecraft-blockchain/sensecraft-hotspot-app/remote-reboot" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Remote Reboot</font></span></a> / <a href="/sensecraft-blockchain/sensecraft-hotspot-app/hotspot-onboarding" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Hotspot Onboarding</font></span></a>
+<div className="row">
+  <div className="col col--12 margin-bottom--lg">
+    <div className="card card--full-height">
+      <div className="row row--no-gutters">
+        <div className="col col--4">
+          <div className="card__image" style={{ minHeight: '260px', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--ifm-color-emphasis-100)' }}>
+            <img
+              src="https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7b/08/e7/7b08e7ab-70d4-186f-61b6-294c7ba96ae0/SenseCAP-AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
+              alt="SenseCAP Hotspot mobile app icon"
+              loading="lazy"
+              style={{ width: '144px', height: '144px', borderRadius: '30px', boxShadow: 'var(--ifm-global-shadow-md)' }}
+            />
+          </div>
+        </div>
+        <div className="col col--8">
+          <div className="card__body">
+            <div className="badge badge--secondary margin-bottom--sm">DePIN</div>
+            <h3 id="sensecap-mx-hotspot">SenseCAP MX / Hotspot</h3>
+            <div className="margin-bottom--sm"><strong>Gateways and management tools for Helium, Flux, Mysterium, and Weather XM networks.</strong></div>
+            <div className="margin-bottom--sm">
+              Explore SenseCAP MX gateway products, documentation, and service status for supported decentralized network workflows. Use the separate SenseCAP Hotspot App to deploy and manage supported SenseCAP gateways and hotspot devices; do not confuse it with the general SenseCraft App.
+            </div>
+          </div>
+          <div className="card__footer">
+            <a className="button button--primary margin-right--sm margin-bottom--sm" href="https://www.sensecapmx.com/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecap_mx_home" target="_blank" rel="noopener noreferrer">Explore SenseCAP MX</a>
+            <a className="button button--outline button--secondary margin-right--sm margin-bottom--sm" href="https://www.sensecapmx.com/docs/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecap_mx_docs" target="_blank" rel="noopener noreferrer">Read MX documentation</a>
+            <a className="button button--outline button--secondary margin-bottom--sm" href="/sensecraft-blockchain/sensecraft-hotspot-app/sensecap_hotspot_app/">Read Hotspot guides</a>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
 </div>
 
-<br />
-<br />
+:::info Product boundaries
 
-### SenseCraft App
+- **reComputer AI Lab** is the current official name of the reComputer-focused models, tools, tutorials, and project resource center.
+- **SenseCraft Device Management Platform** is the operations layer for managing deployed edge devices and applications; start with a concrete application or solution, then use device management to operate it at scale.
+- **SenseCraft App** and **SenseCAP Hotspot App** are different mobile products. Use SenseCraft App for supported IoT devices and data workflows, and SenseCAP Hotspot App for supported gateway and hotspot workflows.
 
-<div class="title_container">
-    <div class="title_item" style={{textAlign: 'center'}}>
-            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>SenseCraft App</font></div>
-            <p>SenseCraft App is used on mobile phones to configure and manage sensors and display data from SenseCraft Data Platform.</p>
-            <br/>
-            > <a href="/sensecraft-app/overview#download" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Download</font></span></a> / <a href="/sensecraft-app/overview#device" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Bind Devices</font></span></a> / <a href="/sensecraft-app/overview#account" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Account</font></span></a> / <a href="/sensecraft-app/overview#user" target="_blank"><span><font color={'FFFFFF'} size={"3"}>User</font></span></a>
-    </div>
-</div>
+:::
 
-<br />
-<br />
+## Downloads, documentation, and support
 
-<a id="sensecraft-ai"></a>
-
-### AI Advisor
-
-<div class="title_container">
-    <div class="title_item" style={{textAlign: 'center'}}>
-            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>AI Advisor</font></div>
-            <p>AI Advisor uses sensor data from SenseCraft Data Platform to provide recommendations for supported scenarios.</p>
-            <br/>
-            > <a href="/sensecraft-data-platform/applications/ai-advisor" target="_blank"><span><font color={'FFFFFF'} size={"3"}>AI Advisor</font></span></a>
-            > <a href="/sensecraft-data-platform/applications/planting-advice" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Planting Advice Example</font></span></a>
-    </div>
-</div>
-
-<br />
-<br />
-
-### SenseCAP Data Platform - API
-
-<div class="title_container">
-    <div class="title_item" style={{textAlign: 'center'}}>
-            <div class="start_card_title" style={{textAlign: 'center'}}><font color={'8DC215'} size={"6"}>SenseCraft Data Platform - API</font></div>
-            <p>The SenseCraft Data Platform API supports device and data management.</p>
-            <br/>
-            > <a href="https://sensecap-docs.seeed.cc/pdf/sensecap_opanapi_document_en.pdf" target="_blank"><span><font color={'FFFFFF'} size={"3"}>Download PDF</font></span></a> / <a href="/sensecraft-data-platform/sensecraft-data-platform-api/sensecraft-data-platform-api" target="_blank"><span><font color={'FFFFFF'} size={"3"}>API Introduction</font></span></a> / <a href="/sensecraft-fee/sensecraft-data-platform-api-pricing" target="_blank"><span><font color={'FFFFFF'} size={"3"}>API Pricing</font></span></a>
-    </div>
-</div>
-
-<br />
+- [Open the SenseCraft product catalog](https://sensecraft.seeed.cc/en/products)
+- [Open the SenseCraft Download Center](https://sensecraft.seeed.cc/en/download)
+- [Browse the SenseCraft community forum](https://forum.seeedstudio.com/c/sensecraft)
+- [Contact the SenseCraft team](https://sensecraft.seeed.cc/en/products#contact)


### PR DESCRIPTION
Fixes #5311

## Summary

Redesign the English `/Cloud/` route as the SenseCraft product and user-guide map used by the official SenseCraft site.

This replaces the legacy cloud-service directory and fixed black/white cards with a current, task-oriented product guide built from the Wiki's native Infima/Docusaurus components.

## Product paths covered

- SenseCraft AI
- CodeCraft
- reComputer AI Lab
- SenseCraft Robotics
- SenseCraft Data Platform
- SenseCraft App
- SenseCraft HMI
- SenseCraft Device Management Platform
- SenseCAP MX / Hotspot

## Content changes

- Adds a goal-first decision table so visitors can select the right product before reading details.
- Adds a concise one-line value proposition and a source-backed product introduction for every product path.
- Uses the official SenseCraft product catalog and each corresponding product destination as the primary content sources.
- Gives each product a specific platform, download, documentation, or quick-start CTA.
- Keeps SenseCraft App and SenseCAP Hotspot App clearly separated.
- Uses `reComputer AI Lab`, the current official product name.
- Presents the distributed edge-device operations product as `SenseCraft Device Management Platform` rather than the previous `SenseCraft Fleet` user-facing label.

## UI changes

- Uses the Wiki's native `hero`, `card`, `row`, responsive column, badge, and button classes.
- Inherits the current Wiki primary color and light/dark theme variables rather than hard-coding a separate page theme.
- Adds consistent media areas with current official product images or illustrations.
- Uses meaningful alt text and keeps all product information and CTAs available as HTML text.
- Uses two-column cards on desktop and the native responsive column behavior on narrow screens.
- Preserves the route and historical metadata while setting `updatedAt` to `2026-08-06`.

## Scope

Only this English source changes:

- `sites/en/docs/Cloud.md`

No sidebar, localized source, CSS, component, or downstream product page is changed.

## Primary product sources

- https://sensecraft.seeed.cc/en/products
- https://sensecraft.seeed.cc/ai/home
- https://codecraft.seeed.cc/
- https://sensecraft.seeed.cc/ai-lab/?lang=en
- https://sensecraft.seeed.cc/en/robotics
- https://sensecap.seeed.cc/portal/
- https://sensecraft.seeed.cc/en/download
- https://sensecraft.seeed.cc/hmi/
- https://seeed-fleet.com
- https://www.sensecapmx.com/

## Validation

- `git diff --check`
- `npx --yes @lint-md/cli sites/en/docs/Cloud.md`
- `yarn --cwd sites/en build -- --out-dir /private/tmp/wiki-cloud-redesign-build-latest`
  - completed successfully against the latest `origin/docusaurus-version`
  - no HTML minifier diagnostics for `/Cloud/`
- Built `/Cloud/` DOM:
  - one Hero
  - nine product cards
  - all images have non-empty alt text
  - 21 approved UTM links
  - no duplicate IDs
- External CTA and image target checks
- Approved UTM mapping check
