### PR TITLE
Fix: XIAO_ESP32S3_Sense_tf_and_filesystem.md - correct microSD CS GPIO

### DIFF
--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3_Sense/XIAO_ESP32S3_Sense_tf_and_filesystem.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_ESP32S3_Sense/XIAO_ESP32S3_Sense_tf_and_filesystem.md
@@ -10,7 +10,7 @@ keywords:
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /xiao_esp32s3_sense_filesystem
 last_update:
-  date: 09/15/2024
+  date: 08/06/2026
   author: Priyanshu Roy
 createdAt: '2022-11-15'
 updatedAt: '2025-09-11'
@@ -109,7 +109,7 @@ The XIAO ESP32S3 Sense card slot occupies 4 GPIOs of the ESP32-S3, and the pin d
             <th align="center">microSD Card Slot</th>
         </tr>
         <tr>
-            <td align="center">GPIO21</td>
+            <td align="center">GPIO3</td>
             <td align="center">CS</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Summary\n- Correct the XIAO ESP32S3 Sense microSD card slot CS GPIO from GPIO21 to GPIO3.\n- Update last_update.date to 08/06/2026.\n\n## Validation\n- DOCUSAURUS_IGNORE_SSG_WARNINGS=true yarn build\n\nNote: A plain yarn build currently fails on pre-existing repository-wide Docusaurus SSG warnings in localized pages; rerun with DOCUSAURUS_IGNORE_SSG_WARNINGS=true exits successfully.