### PR TITLE
Add: SenseCAP Solar Node instruction image

### DIFF
--- a/sites/en/docs/Network/Meshtastic_Network/Solar_Node/solar_node.md
+++ b/sites/en/docs/Network/Meshtastic_Network/Solar_Node/solar_node.md
@@ -8,8 +8,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/solar-node.webp
 slug: /meshtastic_solar_node
 sidebar_position: 1
 last_update:
-  date: 3/10/2026
-  author: Michelle Huang
+  date: 08/06/2026
+  author: zxw
 createdAt: '2025-04-08'
 updatedAt: '2026-07-31'
 url: https://wiki.seeedstudio.com/meshtastic_solar_node/
@@ -168,6 +168,7 @@ The Solar Node is available in two variants: [SenseCAP Solar Node P1](https://ww
 **Accessories**
 
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/accessory.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/Instruction-solar-node.png" alt="pir" width={800} height="auto" /></p>
 
 **Diagram**
 

--- a/sites/es/docs/Network/Meshtastic_Network/Solar_Node/es_solar_node.md
+++ b/sites/es/docs/Network/Meshtastic_Network/Solar_Node/es_solar_node.md
@@ -8,8 +8,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/solar-node.webp
 slug: /meshtastic_solar_node
 sidebar_position: 1
 last_update:
-  date: 3/10/2026
-  author: Michelle Huang
+  date: 08/06/2026
+  author: zxw
 createdAt: '2025-04-08'
 updatedAt: '2026-05-29'
 url: https://wiki.seeedstudio.com/es/meshtastic_solar_node/
@@ -168,6 +168,7 @@ El nodo solar está disponible en dos variantes: [SenseCAP Solar Node P1](https:
 **Accesorios**
 
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/accessory.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/Instruction-solar-node.png" alt="pir" width={800} height="auto" /></p>
 
 **Diagrama**
 

--- a/sites/ja/docs/Network/Meshtastic_Network/Solar_Node/ja_solar_node.md
+++ b/sites/ja/docs/Network/Meshtastic_Network/Solar_Node/ja_solar_node.md
@@ -8,8 +8,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/solar-node.webp
 slug: /meshtastic_solar_node
 sidebar_position: 1
 last_update:
-  date: 3/10/2026
-  author: Michelle Huang
+  date: 08/06/2026
+  author: zxw
 createdAt: '2025-04-08'
 updatedAt: '2026-05-29'
 url: https://wiki.seeedstudio.com/ja/meshtastic_solar_node/
@@ -168,6 +168,7 @@ Solar Node には、[SenseCAP Solar Node P1](https://www.seeedstudio.com/SenseCA
 **付属品**
 
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/accessory.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/Instruction-solar-node.png" alt="pir" width={800} height="auto" /></p>
 
 **構成図**
 

--- a/sites/pt-BR/docs/Network/Meshtastic_Network/Solar_Node/pt_solar_node.md
+++ b/sites/pt-BR/docs/Network/Meshtastic_Network/Solar_Node/pt_solar_node.md
@@ -8,8 +8,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/solar-node.webp
 slug: /meshtastic_solar_node
 sidebar_position: 1
 last_update:
-  date: 3/10/2026
-  author: Michelle Huang
+  date: 08/06/2026
+  author: zxw
 createdAt: '2025-04-08'
 updatedAt: '2026-05-29'
 url: https://wiki.seeedstudio.com/pt-br/meshtastic_solar_node/
@@ -168,6 +168,7 @@ O Solar Node está disponível em duas variantes: [SenseCAP Solar Node P1](https
 **Acessórios**
 
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/accessory.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/Instruction-solar-node.png" alt="pir" width={800} height="auto" /></p>
 
 **Diagrama**
 

--- a/sites/zh-CN/docs/Network/Meshtastic_Network/Solar_Node/cn_solar_node.md
+++ b/sites/zh-CN/docs/Network/Meshtastic_Network/Solar_Node/cn_solar_node.md
@@ -8,8 +8,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/solar-node.webp
 slug: /meshtastic_solar_node
 sidebar_position: 1
 last_update:
-  date: 3/10/2026
-  author: Michelle Huang
+  date: 08/06/2026
+  author: zxw
 createdAt: '2025-04-08'
 updatedAt: '2026-05-29'
 url: https://wiki.seeedstudio.com/cn/meshtastic_solar_node/
@@ -168,6 +168,7 @@ Solar Node 提供两个版本：[SenseCAP Solar Node P1](https://www.seeedstudio
 **配件**
 
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/accessory.png" alt="pir" width={800} height="auto" /></p>
+<p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/Instruction-solar-node.png" alt="pir" width={800} height="auto" /></p>
 
 **结构示意图**
 


### PR DESCRIPTION
## Changes
- Added instruction image (Instruction-solar-node.png) below the Accessories section in the Solar Node introduction page.

## Validation
- Image URL verified: HTTP 200
- Local preview: passed