### PR TITLE
fix(robotics): switch reBot Arm ROS2 repo links to Seeed-Projects org

### DIFF
--- a/sites/en/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
+++ b/sites/en/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
@@ -704,7 +704,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -903,7 +903,7 @@ Open the `Open WebUI` page (`http://<jetson_ip>:4000`). If you have enabled the 
 - https://docs.nvidia.com/jetson/agx-thor-devkit/user-guide/latest/index.html
 - https://github.com/Seeed-Projects/reBot-DevArm
 - https://github.com/graspnet/graspnet-baseline.git
-- https://github.com/vectorBH6/reBotArm_control_py
+- https://github.com/Seeed-Projects/reBotArm_control_py
 - https://github.com/orbbec/pyorbbecsdk.git
 - https://wiki.seeedstudio.com/install_torch_on_recomputer/
 

--- a/sites/en/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
+++ b/sites/en/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
@@ -206,7 +206,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -613,8 +613,8 @@ GraspNet runs out of memory: reduce `--num-point`, reduce `--cloud-crop-nsample`
 
 ## Resources
 
-- reBot Arm GraspNet demo reference: https://github.com/EclipseaHime017/reBot-DevArm-Grasp
-- reBot Arm SDK: https://github.com/vectorBH6/reBotArm_control_py
+- reBot Arm GraspNet demo reference: https://github.com/Seeed-Projects/reBot-DevArm-Grasp
+- reBot Arm SDK: https://github.com/Seeed-Projects/reBotArm_control_py
 - GraspNet baseline: https://github.com/graspnet/graspnet-baseline
 - GraspNet API: https://github.com/graspnet/graspnetAPI
 - Orbbec pyorbbecsdk: https://github.com/orbbec/pyorbbecsdk

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_Grasping_Demo.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_Grasping_Demo.md
@@ -61,7 +61,7 @@ YOLO is a widely used family of real-time object detection models that can local
 
 ## Project Introduction
 
-**reBot Arm B601 Visual Grasping Demo** is a visual grasping algorithm demonstration project based on the [reBot Arm B601](https://github.com/vectorBH6/reBotArm_control_py) robotic arm control library and RGB-D depth camera. The system supports both DM and RS configurations for the B601 arm. It uses the YOLO model for real-time desktop object detection, estimates grasp poses via OBB minimum-area rectangles, performs hand-eye calibration to transform grasp points from the camera frame to the robot base frame, and drives the robotic arm to complete autonomous grasping.
+**reBot Arm B601 Visual Grasping Demo** is a visual grasping algorithm demonstration project based on the [reBot Arm B601](https://github.com/Seeed-Projects/reBotArm_control_py) robotic arm control library and RGB-D depth camera. The system supports both DM and RS configurations for the B601 arm. It uses the YOLO model for real-time desktop object detection, estimates grasp poses via OBB minimum-area rectangles, performs hand-eye calibration to transform grasp points from the camera frame to the robot base frame, and drives the robotic arm to complete autonomous grasping.
 
 ### Core Features
 
@@ -107,13 +107,6 @@ git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
 
-You can also use the current development repository:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### Step 2. Create and Configure the conda Environment
 
 ```bash
@@ -129,7 +122,7 @@ If you want to use a different environment name, replace `rebotarm` in the comma
 ### Step 3. Install the Robotic Arm Control Library
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -603,7 +596,7 @@ If the output is `False`, you need to fix the CUDA / PyTorch installation first;
 
 ## 📄 References
 
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py) — Robotic arm control library
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py) — Robotic arm control library
 - [reBot-DevArm](https://github.com/Seeed-Projects/reBot-DevArm) — reBot robotic arm open source project
 - [Orbbec Gemini 2 Product Page](https://www.orbbec.com.cn/index/Product/info.html?cate=38&id=51)
 - [Orbbec SDK v2](https://github.com/orbbec/OrbbecSDK_v2)

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_ROS2_Integration.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_ROS2_Integration.md
@@ -210,13 +210,6 @@ git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm
 cd rebotarm_ros2
 ```
 
-You can also use the current development repository:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
-
 ### Step 4. Install motorbridge
 
 Install `motorbridge` from the official PyPI source:
@@ -229,7 +222,7 @@ python3 -m pip install --user --break-system-packages --index-url https://pypi.o
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### Step 6. Build the Workspace
@@ -817,8 +810,8 @@ After sourcing Jazzy, you should see a path similar to
 
 ## Contact
 
-- Technical Support: [Submit an Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- Project Repository: [Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- Technical Support: [Submit an Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- Project Repository: [Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - Forum: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## References
@@ -829,4 +822,4 @@ After sourcing Jazzy, you should see a path similar to
 - [reBot Arm B601-DM LeRobot Tutorial](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/)
 - [ROS2 Humble Documentation](https://docs.ros.org/en/humble/)
 - [ROS2 Jazzy Documentation](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_pinocchio.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/reBot_Arm_B601_DM_pinocchio.md
@@ -731,8 +731,8 @@ viz.draw_path(points, "path_name", color)  # Draw path
 
 ## Contact
 
-- **Technical Support**: [Submit Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **Project Repository**: [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **Technical Support**: [Submit Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **Project Repository**: [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **Forum**: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Grasping_Demo.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Grasping_Demo.md
@@ -159,13 +159,6 @@ git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
 
-You can also use the current development repository:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### Step 2. Create and configure the conda environment
 
 ```bash
@@ -178,7 +171,7 @@ If you want to use a different environment name, replace `rebotarm` in the comma
 ### Step 3. Install the robotic arm SDK
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -652,8 +645,8 @@ If the output is `False`, fix the CUDA / PyTorch installation first. If it is `T
 
 ## Contact
 
-- Technical support: [Submit an Issue](https://github.com/EclipseaHime017/reBot-DevArm-Grasp/issues)
-- Project page: [GitHub](https://github.com/EclipseaHime017/reBot-DevArm-Grasp)
+- Technical support: [Submit an Issue](https://github.com/Seeed-Projects/reBot-DevArm-Grasp/issues)
+- Project page: [GitHub](https://github.com/Seeed-Projects/reBot-DevArm-Grasp)
 - Forum: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## References

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_ROS2_Integration.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_ROS2_Integration.md
@@ -170,12 +170,7 @@ git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm
 cd rebotarm_ros2
 ```
 
-You can also use the current development repository:
 
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
 
 ### Step 4. Install motorbridge
 
@@ -195,7 +190,7 @@ python3 -m pip install --user --index-url https://pypi.org/simple motorbridge
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### Step 6. Build the Workspace
@@ -819,8 +814,8 @@ After sourcing Jazzy, you should see a path similar to `/opt/ros/jazzy/lib/pytho
 
 ## Contact
 
-- Technical Support: [Submit an Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- Project Repository: [Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- Technical Support: [Submit an Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- Project Repository: [Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - Forum: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## References
@@ -828,5 +823,5 @@ After sourcing Jazzy, you should see a path similar to `/opt/ros/jazzy/lib/pytho
 - [reBot Arm B601-RS Quick Start](https://wiki.seeedstudio.com/rebot_b601_rs_getting_started/)
 - [ROS2 Humble Documentation](https://docs.ros.org/en/humble/)
 - [ROS2 Jazzy Documentation](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)
 - [MoveIt 2 Documentation](https://moveit.picknik.ai/main/index.html)

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_pinocchio.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_pinocchio.md
@@ -739,8 +739,8 @@ viz.draw_path(points, "path_name", color)  # Draw path
 
 ## Contact
 
-- **Technical Support**: [Submit Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **Project Repository**: [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **Technical Support**: [Submit Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **Project Repository**: [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **Forum**: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/en/docs/Sensor/reSpeaker_flex/reSpeaker_flex_rebot_arm.md
+++ b/sites/en/docs/Sensor/reSpeaker_flex/reSpeaker_flex_rebot_arm.md
@@ -624,7 +624,7 @@ uv is a very fast Python package management tool that can be used to install pac
 
 ```bash
 # Cloning robotic arm control library
-git clone https://github.com/vectorBH6/reBotArm_control_py.git
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git
 
 # Enter the robotic arm control library directory
 cd reBotArm_control_py
@@ -1854,7 +1854,7 @@ This ensures that the robot arm does not exceed physical limits, avoiding damage
 | Resource | Link | Description |
 |-----|-----|-----|
 | Main Warehouse of the Project | https://github.com/xr686/reBot-Arm-reSpeaker-Flex | Sound Control Master Program |
-| Robot Arm Control Library | https://github.com/vectorBH6/reBotArm_control_py | Robot Arm Python Control Library |
+| Robot Arm Control Library | https://github.com/Seeed-Projects/reBotArm_control_py | Robot Arm Python Control Library |
 | reBot Arm Official | https://www.rebotix.com/ | Robot Arm Official Website |
 | Seeed Studio | https://www.seeedstudio.com/ | reSpeaker Flex Purchase and Technical Support |
 

--- a/sites/es/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/es_Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
+++ b/sites/es/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/es_Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
@@ -704,7 +704,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -903,7 +903,7 @@ Abre la página `Open WebUI` (`http://<jetson_ip>:4000`). Si has habilitado las 
 - https://docs.nvidia.com/jetson/agx-thor-devkit/user-guide/latest/index.html
 - https://github.com/Seeed-Projects/reBot-DevArm
 - https://github.com/graspnet/graspnet-baseline.git
-- https://github.com/vectorBH6/reBotArm_control_py
+- https://github.com/Seeed-Projects/reBotArm_control_py
 - https://github.com/orbbec/pyorbbecsdk.git
 - https://wiki.seeedstudio.com/es/install_torch_on_recomputer/
 

--- a/sites/es/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/es_reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
+++ b/sites/es/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/es_reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
@@ -206,7 +206,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -613,8 +613,8 @@ GraspNet se queda sin memoria: reduce `--num-point`, reduce `--cloud-crop-nsampl
 
 ## Recursos
 
-- Referencia de la demostración GraspNet de reBot Arm: https://github.com/EclipseaHime017/reBot-DevArm-Grasp
-- SDK de reBot Arm: https://github.com/vectorBH6/reBotArm_control_py
+- Referencia de la demostración GraspNet de reBot Arm: https://github.com/Seeed-Projects/reBot-DevArm-Grasp
+- SDK de reBot Arm: https://github.com/Seeed-Projects/reBotArm_control_py
 - GraspNet baseline: https://github.com/graspnet/graspnet-baseline
 - GraspNet API: https://github.com/graspnet/graspnetAPI
 - Orbbec pyorbbecsdk: https://github.com/orbbec/pyorbbecsdk

--- a/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/es_reBot_Arm_B601_DM_Grasping_Demo.md
+++ b/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/es_reBot_Arm_B601_DM_Grasping_Demo.md
@@ -61,7 +61,7 @@ YOLO es una familia ampliamente utilizada de modelos de detección de objetos en
 
 ## Introducción al proyecto
 
-**Demo de agarre visual con reBot Arm B601** es un proyecto de demostración de algoritmos de agarre visual basado en la biblioteca de control del brazo robótico [reBot Arm B601](https://github.com/vectorBH6/reBotArm_control_py) y una cámara de profundidad RGB-D. El sistema admite configuraciones DM y RS para el brazo B601. Utiliza el modelo YOLO para la detección de objetos de escritorio en tiempo real, estima las poses de agarre mediante rectángulos de área mínima OBB, realiza la calibración mano-ojo para transformar los puntos de agarre del marco de la cámara al marco base del robot y acciona el brazo robótico para completar el agarre autónomo.
+**Demo de agarre visual con reBot Arm B601** es un proyecto de demostración de algoritmos de agarre visual basado en la biblioteca de control del brazo robótico [reBot Arm B601](https://github.com/Seeed-Projects/reBotArm_control_py) y una cámara de profundidad RGB-D. El sistema admite configuraciones DM y RS para el brazo B601. Utiliza el modelo YOLO para la detección de objetos de escritorio en tiempo real, estima las poses de agarre mediante rectángulos de área mínima OBB, realiza la calibración mano-ojo para transformar los puntos de agarre del marco de la cámara al marco base del robot y acciona el brazo robótico para completar el agarre autónomo.
 
 ### Funciones principales
 
@@ -106,14 +106,6 @@ Da preferencia al repositorio oficial de Seeed-Projects:
 git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
-
-También puedes usar el repositorio de desarrollo actual:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### Paso 2. Crear y configurar el entorno conda
 
 ```bash
@@ -129,7 +121,7 @@ Si quieres usar un nombre de entorno diferente, reemplaza `rebotarm` en el coman
 ### Paso 3. Instalar la biblioteca de control del brazo robótico
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -603,7 +595,7 @@ Si la salida es `False`, primero debes corregir la instalación de CUDA / PyTorc
 
 ## 📄 Referencias
 
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py) — Biblioteca de control de brazo robótico
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py) — Biblioteca de control de brazo robótico
 - [reBot-DevArm](https://github.com/Seeed-Projects/reBot-DevArm) — Proyecto de código abierto del brazo robótico reBot
 - [Página de producto Orbbec Gemini 2](https://www.orbbec.com.cn/index/Product/info.html?cate=38&id=51)
 - [Orbbec SDK v2](https://github.com/orbbec/OrbbecSDK_v2)

--- a/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/es_reBot_Arm_B601_DM_ROS2_Integration.md
+++ b/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/es_reBot_Arm_B601_DM_ROS2_Integration.md
@@ -209,14 +209,6 @@ Usa por defecto el repositorio oficial de Seeed-Projects:
 git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm_ros2
 cd rebotarm_ros2
 ```
-
-También puedes usar el repositorio de desarrollo actual:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
-
 ### Paso 4. Instalar motorbridge
 
 Instala `motorbridge` desde la fuente oficial de PyPI:
@@ -229,7 +221,7 @@ python3 -m pip install --user --break-system-packages --index-url https://pypi.o
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### Paso 6. Compilar el espacio de trabajo
@@ -837,8 +829,8 @@ Después de cargar Jazzy, deberías ver una ruta similar a
 
 ## Contacto
 
-- Soporte técnico: [Submit an Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- Repositorio del proyecto: [Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- Soporte técnico: [Submit an Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- Repositorio del proyecto: [Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - Foro: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## Referencias
@@ -849,4 +841,4 @@ Después de cargar Jazzy, deberías ver una ruta similar a
 - [reBot Arm B601-DM Tutorial de LeRobot](https://wiki.seeedstudio.com/es/rebot_arm_b601_dm_lerobot/)
 - [Documentación de ROS2 Humble](https://docs.ros.org/en/humble/)
 - [Documentación de ROS2 Jazzy](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)

--- a/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/es_reBot_Arm_B601_DM_pinocchio.md
+++ b/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/es_reBot_Arm_B601_DM_pinocchio.md
@@ -731,8 +731,8 @@ viz.draw_path(points, "path_name", color)  # Draw path
 
 ## Contacto
 
-- **Soporte técnico**: [Submit Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **Repositorio del proyecto**: [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **Soporte técnico**: [Submit Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **Repositorio del proyecto**: [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **Foro**: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_Grasping_Demo.md
+++ b/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_Grasping_Demo.md
@@ -158,14 +158,6 @@ Da preferencia al repositorio oficial Seeed-Projects:
 git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
-
-También puedes usar el repositorio de desarrollo actual:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### Paso 2. Crear y configurar el entorno conda
 
 ```bash
@@ -178,7 +170,7 @@ Si quieres usar un nombre de entorno diferente, reemplaza `rebotarm` en el coman
 ### Paso 3. Instalar el SDK del brazo robótico
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -652,8 +644,8 @@ Si la salida es `False`, corrige primero la instalación de CUDA / PyTorch. Si e
 
 ## Contacto
 
-- Soporte técnico: [Submit an Issue](https://github.com/EclipseaHime017/reBot-DevArm-Grasp/issues)
-- Página del proyecto: [GitHub](https://github.com/EclipseaHime017/reBot-DevArm-Grasp)
+- Soporte técnico: [Submit an Issue](https://github.com/Seeed-Projects/reBot-DevArm-Grasp/issues)
+- Página del proyecto: [GitHub](https://github.com/Seeed-Projects/reBot-DevArm-Grasp)
 - Foro: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## Referencias

--- a/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_ROS2_Integration.md
+++ b/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_ROS2_Integration.md
@@ -169,14 +169,6 @@ Se prefiere el repositorio oficial Seeed-Projects:
 git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm_ros2
 cd rebotarm_ros2
 ```
-
-También puedes usar el repositorio de desarrollo actual:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
-
 ### Paso 4. Instalar motorbridge
 
 Instala `motorbridge` desde la fuente oficial de PyPI:
@@ -195,7 +187,7 @@ python3 -m pip install --user --index-url https://pypi.org/simple motorbridge
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### Paso 6. Compilar el espacio de trabajo
@@ -819,8 +811,8 @@ Después de cargar Jazzy, deberías ver una ruta similar a `/opt/ros/jazzy/lib/p
 
 ## Contacto
 
-- Soporte técnico: [Submit an Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- Repositorio del proyecto: [Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- Soporte técnico: [Submit an Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- Repositorio del proyecto: [Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - Foro: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## Referencias
@@ -828,5 +820,5 @@ Después de cargar Jazzy, deberías ver una ruta similar a `/opt/ros/jazzy/lib/p
 - [reBot Arm B601-RS Quick Start](https://wiki.seeedstudio.com/es/rebot_b601_rs_getting_started/)
 - [Documentación de ROS2 Humble](https://docs.ros.org/en/humble/)
 - [Documentación de ROS2 Jazzy](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)
 - [Documentación de MoveIt 2](https://moveit.picknik.ai/main/index.html)

--- a/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_pinocchio.md
+++ b/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_pinocchio.md
@@ -739,8 +739,8 @@ viz.draw_path(points, "path_name", color)  # Draw path
 
 ## Contacto
 
-- **Soporte técnico**: [Submit Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **Repositorio del proyecto**: [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **Soporte técnico**: [Submit Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **Repositorio del proyecto**: [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **Foro**: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/es/docs/Sensor/reSpeaker_flex/es_reSpeaker_flex_rebot_arm.md
+++ b/sites/es/docs/Sensor/reSpeaker_flex/es_reSpeaker_flex_rebot_arm.md
@@ -624,7 +624,7 @@ uv es una herramienta de gestión de paquetes de Python muy rápida que se puede
 
 ```bash
 # Cloning robotic arm control library
-git clone https://github.com/vectorBH6/reBotArm_control_py.git
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git
 
 # Enter the robotic arm control library directory
 cd reBotArm_control_py
@@ -1854,7 +1854,7 @@ Esto garantiza que el brazo robótico no exceda los límites físicos, evitando 
 | Recurso | Enlace | Descripción |
 |-----|-----|-----|
 | Repositorio principal del proyecto | https://github.com/xr686/reBot-Arm-reSpeaker-Flex | Programa maestro de control por sonido |
-| Biblioteca de control del brazo robótico | https://github.com/vectorBH6/reBotArm_control_py | Biblioteca de control del brazo robótico en Python |
+| Biblioteca de control del brazo robótico | https://github.com/Seeed-Projects/reBotArm_control_py | Biblioteca de control del brazo robótico en Python |
 | reBot Arm Oficial | https://www.rebotix.com/ | Sitio web oficial del brazo robótico |
 | Seeed Studio | https://www.seeedstudio.com/ | Compra de reSpeaker Flex y soporte técnico |
 

--- a/sites/ja/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/ja_Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
+++ b/sites/ja/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/ja_Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
@@ -704,7 +704,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -903,7 +903,7 @@ http://<jetson_ip>:8000
 - https://docs.nvidia.com/jetson/agx-thor-devkit/user-guide/latest/index.html
 - https://github.com/Seeed-Projects/reBot-DevArm
 - https://github.com/graspnet/graspnet-baseline.git
-- https://github.com/vectorBH6/reBotArm_control_py
+- https://github.com/Seeed-Projects/reBotArm_control_py
 - https://github.com/orbbec/pyorbbecsdk.git
 - https://wiki.seeedstudio.com/ja/install_torch_on_recomputer/
 

--- a/sites/ja/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/ja_reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
+++ b/sites/ja/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/ja_reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
@@ -206,7 +206,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -613,8 +613,8 @@ GraspNet がメモリ不足になる：`--num-point` を減らし、`--cloud-cro
 
 ## リソース
 
-- reBot Arm GraspNet デモのリファレンス: https://github.com/EclipseaHime017/reBot-DevArm-Grasp
-- reBot Arm SDK: https://github.com/vectorBH6/reBotArm_control_py
+- reBot Arm GraspNet デモのリファレンス: https://github.com/Seeed-Projects/reBot-DevArm-Grasp
+- reBot Arm SDK: https://github.com/Seeed-Projects/reBotArm_control_py
 - GraspNet ベースライン: https://github.com/graspnet/graspnet-baseline
 - GraspNet API: https://github.com/graspnet/graspnetAPI
 - Orbbec pyorbbecsdk: https://github.com/orbbec/pyorbbecsdk

--- a/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/ja_reBot_Arm_B601_DM_Grasping_Demo.md
+++ b/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/ja_reBot_Arm_B601_DM_Grasping_Demo.md
@@ -61,7 +61,7 @@ YOLO は、単一のフォワードパスでターゲットの位置特定と分
 
 ## プロジェクト概要
 
-**reBot Arm B601 ビジュアル把持デモ** は、[reBot Arm B601](https://github.com/vectorBH6/reBotArm_control_py) ロボットアーム制御ライブラリと RGB-D 深度カメラに基づくビジュアル把持アルゴリズムのデモプロジェクトです。本システムは B601 アームの DM / RS 構成の両方をサポートします。YOLO モデルを用いてデスクトップ上の物体をリアルタイム検出し、OBB 最小外接矩形から把持姿勢を推定し、ハンドアイキャリブレーションによって把持点をカメラ座標系からロボットベース座標系へ変換し、ロボットアームを駆動して自律把持を完了させます。
+**reBot Arm B601 ビジュアル把持デモ** は、[reBot Arm B601](https://github.com/Seeed-Projects/reBotArm_control_py) ロボットアーム制御ライブラリと RGB-D 深度カメラに基づくビジュアル把持アルゴリズムのデモプロジェクトです。本システムは B601 アームの DM / RS 構成の両方をサポートします。YOLO モデルを用いてデスクトップ上の物体をリアルタイム検出し、OBB 最小外接矩形から把持姿勢を推定し、ハンドアイキャリブレーションによって把持点をカメラ座標系からロボットベース座標系へ変換し、ロボットアームを駆動して自律把持を完了させます。
 
 ### コア機能
 
@@ -106,14 +106,6 @@ sudo chmod 666 /dev/ttyUSB0        # USB2CAN (adjust port number as needed)
 git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
-
-現在の開発用リポジトリを使用することもできます：
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### ステップ 2. conda 環境を作成・設定する
 
 ```bash
@@ -129,7 +121,7 @@ conda activate rebotarm
 ### ステップ 3. ロボットアーム制御ライブラリをインストールする
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -603,7 +595,7 @@ python -c "import torch; print(torch.cuda.is_available())"
 
 ## 📄 参考文献
 
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py) — ロボットアーム制御ライブラリ
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py) — ロボットアーム制御ライブラリ
 - [reBot-DevArm](https://github.com/Seeed-Projects/reBot-DevArm) — reBot ロボットアームオープンソースプロジェクト
 - [Orbbec Gemini 2 Product Page](https://www.orbbec.com.cn/index/Product/info.html?cate=38&id=51)
 - [Orbbec SDK v2](https://github.com/orbbec/OrbbecSDK_v2)

--- a/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/ja_reBot_Arm_B601_DM_ROS2_Integration.md
+++ b/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/ja_reBot_Arm_B601_DM_ROS2_Integration.md
@@ -209,14 +209,6 @@ source `/opt/ros/humble/setup.bash`.
 git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm_ros2
 cd rebotarm_ros2
 ```
-
-現在の開発用リポジトリを使用することもできます：
-
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
-
 ### ステップ 4. motorbridge をインストールする
 
 公式 PyPI ソースから `motorbridge` をインストールします：
@@ -229,7 +221,7 @@ python3 -m pip install --user --break-system-packages --index-url https://pypi.o
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### ステップ 6. ワークスペースをビルドする
@@ -817,8 +809,8 @@ Jazzy を source した後は、
 
 ## 連絡先
 
-- 技術サポート：[Submit an Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- プロジェクトリポジトリ：[Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- 技術サポート：[Submit an Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- プロジェクトリポジトリ：[Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - フォーラム：[Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## 参考資料
@@ -829,4 +821,4 @@ Jazzy を source した後は、
 - [reBot Arm B601-DM LeRobot チュートリアル](https://wiki.seeedstudio.com/ja/rebot_arm_b601_dm_lerobot/)
 - [ROS2 Humble ドキュメント](https://docs.ros.org/en/humble/)
 - [ROS2 Jazzy ドキュメント](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)

--- a/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/ja_reBot_Arm_B601_DM_pinocchio.md
+++ b/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/ja_reBot_Arm_B601_DM_pinocchio.md
@@ -731,8 +731,8 @@ viz.draw_path(points, "path_name", color)  # Draw path
 
 ## 連絡先
 
-- **技術サポート**： [Submit Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **プロジェクトリポジトリ**： [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **技術サポート**： [Submit Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **プロジェクトリポジトリ**： [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **フォーラム**： [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_Grasping_Demo.md
+++ b/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_Grasping_Demo.md
@@ -158,14 +158,6 @@ sudo chmod 666 /dev/ttyUSB0
 git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
-
-現在の開発用リポジトリを使用することもできます：
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### ステップ 2. conda 環境を作成して設定する
 
 ```bash
@@ -178,7 +170,7 @@ conda activate rebotarm
 ### ステップ 3. ロボットアーム SDK をインストールする
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -652,8 +644,8 @@ python -c "import torch; print(torch.cuda.is_available())"
 
 ## 連絡先
 
-- 技術サポート: [Submit an Issue](https://github.com/EclipseaHime017/reBot-DevArm-Grasp/issues)
-- プロジェクトページ: [GitHub](https://github.com/EclipseaHime017/reBot-DevArm-Grasp)
+- 技術サポート: [Submit an Issue](https://github.com/Seeed-Projects/reBot-DevArm-Grasp/issues)
+- プロジェクトページ: [GitHub](https://github.com/Seeed-Projects/reBot-DevArm-Grasp)
 - フォーラム: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## 参考文献

--- a/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_ROS2_Integration.md
+++ b/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_ROS2_Integration.md
@@ -169,14 +169,6 @@ python3 -c "import pinocchio; print('pinocchio', pinocchio.__version__)"
 git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm_ros2
 cd rebotarm_ros2
 ```
-
-現在の開発用リポジトリを使用することもできます：
-
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
-
 ### ステップ 4. motorbridge をインストールする
 
 公式の PyPI ソースから `motorbridge` をインストールします：
@@ -195,7 +187,7 @@ python3 -m pip install --user --index-url https://pypi.org/simple motorbridge
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### ステップ 6. ワークスペースをビルドする
@@ -819,8 +811,8 @@ Jazzy を source した後は、`/opt/ros/jazzy/lib/python3.12/site-packages` �
 
 ## 連絡先
 
-- 技術サポート: [Submit an Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- プロジェクトリポジトリ: [Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- 技術サポート: [Submit an Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- プロジェクトリポジトリ: [Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - フォーラム: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## 参考文献
@@ -828,5 +820,5 @@ Jazzy を source した後は、`/opt/ros/jazzy/lib/python3.12/site-packages` �
 - [reBot Arm B601-RS クイックスタート](https://wiki.seeedstudio.com/ja/rebot_b601_rs_getting_started/)
 - [ROS2 Humble ドキュメント](https://docs.ros.org/en/humble/)
 - [ROS2 Jazzy ドキュメント](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)
 - [MoveIt 2 ドキュメント](https://moveit.picknik.ai/main/index.html)

--- a/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_pinocchio.md
+++ b/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_pinocchio.md
@@ -739,8 +739,8 @@ viz.draw_path(points, "path_name", color)  # Draw path
 
 ## 連絡先
 
-- **技術サポート**： [Submit Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **プロジェクトリポジトリ**： [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **技術サポート**： [Submit Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **プロジェクトリポジトリ**： [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **フォーラム**： [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/ja/docs/Sensor/reSpeaker_flex/ja_reSpeaker_flex_rebot_arm.md
+++ b/sites/ja/docs/Sensor/reSpeaker_flex/ja_reSpeaker_flex_rebot_arm.md
@@ -624,7 +624,7 @@ uv は非常に高速な Python パッケージ管理ツールで、pip 形式�
 
 ```bash
 # Cloning robotic arm control library
-git clone https://github.com/vectorBH6/reBotArm_control_py.git
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git
 
 # Enter the robotic arm control library directory
 cd reBotArm_control_py
@@ -1854,7 +1854,7 @@ np.clip(target_angle, JOINT_LIMITS_MIN, JOINT_LIMITS_MAX)
 | リソース | リンク | 説明 |
 |-----|-----|-----|
 | プロジェクトのメインリポジトリ | https://github.com/xr686/reBot-Arm-reSpeaker-Flex | 音声制御メインプログラム |
-| ロボットアーム制御ライブラリ | https://github.com/vectorBH6/reBotArm_control_py | ロボットアーム Python 制御ライブラリ |
+| ロボットアーム制御ライブラリ | https://github.com/Seeed-Projects/reBotArm_control_py | ロボットアーム Python 制御ライブラリ |
 | reBot Arm 公式 | https://www.rebotix.com/ | ロボットアーム公式サイト |
 | Seeed Studio | https://www.seeedstudio.com/ | reSpeaker Flex の購入および技術サポート |
 

--- a/sites/pt-BR/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/pt_Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
+++ b/sites/pt-BR/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/pt_Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
@@ -704,7 +704,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -903,7 +903,7 @@ Abra a página `Open WebUI` (`http://<jetson_ip>:4000`). Se você tiver habilita
 - https://docs.nvidia.com/jetson/agx-thor-devkit/user-guide/latest/index.html
 - https://github.com/Seeed-Projects/reBot-DevArm
 - https://github.com/graspnet/graspnet-baseline.git
-- https://github.com/vectorBH6/reBotArm_control_py
+- https://github.com/Seeed-Projects/reBotArm_control_py
 - https://github.com/orbbec/pyorbbecsdk.git
 - https://wiki.seeedstudio.com/pt-br/install_torch_on_recomputer/
 

--- a/sites/pt-BR/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/pt_reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
+++ b/sites/pt-BR/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/pt_reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
@@ -206,7 +206,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -613,8 +613,8 @@ O GraspNet fica sem memória: reduza `--num-point`, reduza `--cloud-crop-nsample
 
 ## Recursos
 
-- Referência da demonstração GraspNet do reBot Arm: https://github.com/EclipseaHime017/reBot-DevArm-Grasp
-- SDK do reBot Arm: https://github.com/vectorBH6/reBotArm_control_py
+- Referência da demonstração GraspNet do reBot Arm: https://github.com/Seeed-Projects/reBot-DevArm-Grasp
+- SDK do reBot Arm: https://github.com/Seeed-Projects/reBotArm_control_py
 - GraspNet baseline: https://github.com/graspnet/graspnet-baseline
 - GraspNet API: https://github.com/graspnet/graspnetAPI
 - Orbbec pyorbbecsdk: https://github.com/orbbec/pyorbbecsdk

--- a/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/pt_reBot_Arm_B601_DM_Grasping_Demo.md
+++ b/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/pt_reBot_Arm_B601_DM_Grasping_Demo.md
@@ -61,7 +61,7 @@ YOLO é uma família amplamente utilizada de modelos de detecção de objetos em
 
 ## Introdução ao Projeto
 
-**Demonstração de Preensão Visual com reBot Arm B601** é um projeto de demonstração de algoritmo de preensão visual baseado na biblioteca de controle do braço robótico [reBot Arm B601](https://github.com/vectorBH6/reBotArm_control_py) e em câmera de profundidade RGB-D. O sistema suporta as configurações DM e RS para o braço B601. Ele usa o modelo YOLO para detecção de objetos em tempo real na mesa, estima poses de preensão via retângulos de área mínima OBB, realiza calibração mão-olho para transformar pontos de preensão do referencial da câmera para o referencial da base do robô e aciona o braço robótico para completar a preensão autônoma.
+**Demonstração de Preensão Visual com reBot Arm B601** é um projeto de demonstração de algoritmo de preensão visual baseado na biblioteca de controle do braço robótico [reBot Arm B601](https://github.com/Seeed-Projects/reBotArm_control_py) e em câmera de profundidade RGB-D. O sistema suporta as configurações DM e RS para o braço B601. Ele usa o modelo YOLO para detecção de objetos em tempo real na mesa, estima poses de preensão via retângulos de área mínima OBB, realiza calibração mão-olho para transformar pontos de preensão do referencial da câmera para o referencial da base do robô e aciona o braço robótico para completar a preensão autônoma.
 
 ### Funcionalidades Principais
 
@@ -106,14 +106,6 @@ Dê preferência ao repositório oficial Seeed-Projects:
 git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
-
-Você também pode usar o repositório de desenvolvimento atual:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### Etapa 2. Criar e Configurar o Ambiente conda
 
 ```bash
@@ -129,7 +121,7 @@ Se você quiser usar um nome de ambiente diferente, substitua `rebotarm` no coma
 ### Etapa 3. Instalar a Biblioteca de Controle do Braço Robótico
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -603,7 +595,7 @@ Se a saída for `False`, você precisa corrigir primeiro a instalação do CUDA 
 
 ## 📄 Referências
 
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py) — Biblioteca de controle de braço robótico
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py) — Biblioteca de controle de braço robótico
 - [reBot-DevArm](https://github.com/Seeed-Projects/reBot-DevArm) — Projeto de código aberto do braço robótico reBot
 - [Página do Produto Orbbec Gemini 2](https://www.orbbec.com.cn/index/Product/info.html?cate=38&id=51)
 - [Orbbec SDK v2](https://github.com/orbbec/OrbbecSDK_v2)

--- a/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/pt_reBot_Arm_B601_DM_ROS2_Integration.md
+++ b/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/pt_reBot_Arm_B601_DM_ROS2_Integration.md
@@ -209,14 +209,6 @@ Use por padrão o repositório oficial Seeed-Projects:
 git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm_ros2
 cd rebotarm_ros2
 ```
-
-Você também pode usar o repositório de desenvolvimento atual:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
-
 ### Etapa 4. Instalar o motorbridge
 
 Instale `motorbridge` a partir da fonte oficial do PyPI:
@@ -229,7 +221,7 @@ python3 -m pip install --user --break-system-packages --index-url https://pypi.o
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### Etapa 6. Compilar o Workspace
@@ -837,8 +829,8 @@ Após carregar o Jazzy, você deverá ver um caminho semelhante a
 
 ## Contato
 
-- Suporte técnico: [Submit an Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- Repositório do projeto: [Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- Suporte técnico: [Submit an Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- Repositório do projeto: [Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - Fórum: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## Referências
@@ -849,4 +841,4 @@ Após carregar o Jazzy, você deverá ver um caminho semelhante a
 - [reBot Arm B601-DM Tutorial LeRobot](https://wiki.seeedstudio.com/pt-br/rebot_arm_b601_dm_lerobot/)
 - [Documentação do ROS2 Humble](https://docs.ros.org/en/humble/)
 - [Documentação do ROS2 Jazzy](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)

--- a/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/pt_reBot_Arm_B601_DM_pinocchio.md
+++ b/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/pt_reBot_Arm_B601_DM_pinocchio.md
@@ -731,8 +731,8 @@ viz.draw_path(points, "path_name", color)  # Draw path
 
 ## Contato
 
-- **Suporte Técnico**: [Submit Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **Repositório do Projeto**: [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **Suporte Técnico**: [Submit Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **Repositório do Projeto**: [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **Fórum**: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_Grasping_Demo.md
+++ b/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_Grasping_Demo.md
@@ -158,14 +158,6 @@ Dê preferência ao repositório oficial Seeed-Projects:
 git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
-
-Você também pode usar o repositório de desenvolvimento atual:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### Etapa 2. Criar e configurar o ambiente conda
 
 ```bash
@@ -178,7 +170,7 @@ Se você quiser usar um nome de ambiente diferente, substitua `rebotarm` no coma
 ### Etapa 3. Instalar o SDK do braço robótico
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -652,8 +644,8 @@ Se a saída for `False`, corrija primeiro a instalação do CUDA / PyTorch. Se f
 
 ## Contato
 
-- Suporte técnico: [Submit an Issue](https://github.com/EclipseaHime017/reBot-DevArm-Grasp/issues)
-- Página do projeto: [GitHub](https://github.com/EclipseaHime017/reBot-DevArm-Grasp)
+- Suporte técnico: [Submit an Issue](https://github.com/Seeed-Projects/reBot-DevArm-Grasp/issues)
+- Página do projeto: [GitHub](https://github.com/Seeed-Projects/reBot-DevArm-Grasp)
 - Fórum: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## Referências

--- a/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_ROS2_Integration.md
+++ b/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_ROS2_Integration.md
@@ -169,14 +169,6 @@ Dê preferência ao repositório oficial Seeed-Projects:
 git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm_ros2
 cd rebotarm_ros2
 ```
-
-Você também pode usar o repositório de desenvolvimento atual:
-
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
-
 ### Etapa 4. Instalar o motorbridge
 
 Instale `motorbridge` a partir da fonte oficial do PyPI:
@@ -195,7 +187,7 @@ python3 -m pip install --user --index-url https://pypi.org/simple motorbridge
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### Etapa 6. Compilar o Workspace
@@ -819,8 +811,8 @@ Após carregar o Jazzy, você deverá ver um caminho semelhante a `/opt/ros/jazz
 
 ## Contato
 
-- Suporte técnico: [Submit an Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- Repositório do projeto: [Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- Suporte técnico: [Submit an Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- Repositório do projeto: [Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - Fórum: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## Referências
@@ -828,5 +820,5 @@ Após carregar o Jazzy, você deverá ver um caminho semelhante a `/opt/ros/jazz
 - [reBot Arm B601-RS Quick Start](https://wiki.seeedstudio.com/pt-br/rebot_b601_rs_getting_started/)
 - [Documentação do ROS2 Humble](https://docs.ros.org/en/humble/)
 - [Documentação do ROS2 Jazzy](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)
 - [Documentação do MoveIt 2](https://moveit.picknik.ai/main/index.html)

--- a/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_pinocchio.md
+++ b/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_pinocchio.md
@@ -739,8 +739,8 @@ viz.draw_path(points, "path_name", color)  # Draw path
 
 ## Contato
 
-- **Suporte Técnico**: [Submit Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **Repositório do Projeto**: [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **Suporte Técnico**: [Submit Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **Repositório do Projeto**: [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **Fórum**: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/pt-BR/docs/Sensor/reSpeaker_flex/pt_reSpeaker_flex_rebot_arm.md
+++ b/sites/pt-BR/docs/Sensor/reSpeaker_flex/pt_reSpeaker_flex_rebot_arm.md
@@ -624,7 +624,7 @@ uv é uma ferramenta de gerenciamento de pacotes Python muito rápida que pode s
 
 ```bash
 # Cloning robotic arm control library
-git clone https://github.com/vectorBH6/reBotArm_control_py.git
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git
 
 # Enter the robotic arm control library directory
 cd reBotArm_control_py
@@ -1854,7 +1854,7 @@ Isso garante que o braço robótico não exceda os limites físicos, evitando da
 | Recurso | Link | Descrição |
 |-----|-----|-----|
 | Repositório principal do projeto | https://github.com/xr686/reBot-Arm-reSpeaker-Flex | Programa principal de controle por som |
-| Biblioteca de controle do braço robótico | https://github.com/vectorBH6/reBotArm_control_py | Biblioteca de controle do braço robótico em Python |
+| Biblioteca de controle do braço robótico | https://github.com/Seeed-Projects/reBotArm_control_py | Biblioteca de controle do braço robótico em Python |
 | reBot Arm Oficial | https://www.rebotix.com/ | Site oficial do braço robótico |
 | Seeed Studio | https://www.seeedstudio.com/ | Compra do reSpeaker Flex e suporte técnico |
 

--- a/sites/zh-CN/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/cn_Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
+++ b/sites/zh-CN/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/cn_Voice_Control_reBot_Arm_B601_by_Nvidia_Jetson_Thor.md
@@ -704,7 +704,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -903,7 +903,7 @@ http://<jetson_ip>:8000
 - https://docs.nvidia.com/jetson/agx-thor-devkit/user-guide/latest/index.html
 - https://github.com/Seeed-Projects/reBot-DevArm
 - https://github.com/graspnet/graspnet-baseline.git
-- https://github.com/vectorBH6/reBotArm_control_py
+- https://github.com/Seeed-Projects/reBotArm_control_py
 - https://github.com/orbbec/pyorbbecsdk.git
 - https://wiki.seeedstudio.com/cn/install_torch_on_recomputer/
 

--- a/sites/zh-CN/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/cn_reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
+++ b/sites/zh-CN/docs/Edge/NVIDIA_Jetson/Application/Physical_AI/cn_reBot_Arm_B601_DM_GraspNet_Visual_Grasping.md
@@ -206,7 +206,7 @@ pip install -r requirements-graspnet-jetson.txt
 ```bash
 mkdir -p sdk
 
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 pip install -e sdk/reBotArm_control_py
 
 git clone https://github.com/graspnet/graspnet-baseline.git sdk/graspnet-baseline
@@ -613,8 +613,8 @@ GraspNet 内存不足：请减小 `--num-point`，减小 `--cloud-crop-nsample`�
 
 ## 资源
 
-- reBot Arm GraspNet 演示参考：https://github.com/EclipseaHime017/reBot-DevArm-Grasp
-- reBot Arm SDK：https://github.com/vectorBH6/reBotArm_control_py
+- reBot Arm GraspNet 演示参考：https://github.com/Seeed-Projects/reBot-DevArm-Grasp
+- reBot Arm SDK：https://github.com/Seeed-Projects/reBotArm_control_py
 - GraspNet baseline：https://github.com/graspnet/graspnet-baseline
 - GraspNet API：https://github.com/graspnet/graspnetAPI
 - Orbbec pyorbbecsdk：https://github.com/orbbec/pyorbbecsdk

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_Grasping_Demo.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_Grasping_Demo.md
@@ -55,7 +55,7 @@ YOLO 是一类广泛使用的实时目标检测模型，能够在单次前向推
 
 ##  项目介绍
 
-**reBot Arm B601 视觉夹取 Demo** 是基于 [reBot Arm B601](https://github.com/vectorBH6/reBotArm_control_py) 机械臂控制库与 RGB-D 深度相机的视觉抓取算法演示项目。系统支持 B601 的 DM 与 RS 两种机械臂配置，通过 YOLO 模型实时识别桌面物体，利用 OBB 最小外接矩形估计夹取姿态，经手眼标定将相机坐标系下的抓取点变换到机械臂基坐标系，最终驱动机械臂完成自主抓取。
+**reBot Arm B601 视觉夹取 Demo** 是基于 [reBot Arm B601](https://github.com/Seeed-Projects/reBotArm_control_py) 机械臂控制库与 RGB-D 深度相机的视觉抓取算法演示项目。系统支持 B601 的 DM 与 RS 两种机械臂配置，通过 YOLO 模型实时识别桌面物体，利用 OBB 最小外接矩形估计夹取姿态，经手眼标定将相机坐标系下的抓取点变换到机械臂基坐标系，最终驱动机械臂完成自主抓取。
 
 ###  核心功能
 
@@ -109,13 +109,6 @@ git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
 
-也可以使用当前开发仓库：
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### Step 2. 创建并配置 conda 环境
 
 ```bash
@@ -131,7 +124,7 @@ conda activate rebotarm
 ### Step 3. 安装机械臂控制库
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -630,7 +623,7 @@ python -c "import torch; print(torch.cuda.is_available())"
 
 ## 📄 参考资料
 
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py) — 机械臂控制库
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py) — 机械臂控制库
 - [reBot-DevArm](https://github.com/Seeed-Projects/reBot-DevArm) — reBot 机械臂开源项目
 - [Orbbec Gemini 2 产品页](https://www.orbbec.com.cn/index/Product/info.html?cate=38&id=51)
 - [Orbbec SDK v2](https://github.com/orbbec/OrbbecSDK_v2)

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_ROS2_Integration.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_ROS2_Integration.md
@@ -195,13 +195,6 @@ git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm
 cd rebotarm_ros2
 ```
 
-也可以使用当前开发仓库：
-
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
-
 ### 步骤 4. 安装 motorbridge
 
 `motorbridge` 从 PyPI 官方源安装：
@@ -220,7 +213,7 @@ python3 -m pip install --user --index-url https://pypi.org/simple motorbridge
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### 步骤 6. 构建工作空间
@@ -847,8 +840,8 @@ python3 -c "import sys; print('\n'.join(sys.path))"
 
 ## 联系方式
 
-- 技术支持：[提交 Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- 项目地址：[Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- 技术支持：[提交 Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- 项目地址：[Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - 论坛：[Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## 参考文档
@@ -859,5 +852,5 @@ python3 -c "import sys; print('\n'.join(sys.path))"
 - [reBot Arm B601-DM LeRobot 教程](https://wiki.seeedstudio.com/cn/rebot_arm_b601_dm_lerobot/)
 - [ROS2 Humble 文档](https://docs.ros.org/en/humble/)
 - [ROS2 Jazzy 文档](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)
 - [MoveIt 2 文档](https://moveit.picknik.ai/main/index.html)

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_pinocchio.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_DM/cn_reBot_Arm_B601_DM_pinocchio.md
@@ -731,8 +731,8 @@ viz.draw_path(points, "path_name", color)  # 绘制路径
 
 ## 联系方式
 
-- **技术支持**: [提交 Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **项目仓库**: [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **技术支持**: [提交 Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **项目仓库**: [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **论坛**: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Grasping_Demo.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Grasping_Demo.md
@@ -153,13 +153,6 @@ git clone https://github.com/Seeed-Projects/reBot-DevArm-Grasp.git rebot_grasp
 cd rebot_grasp
 ```
 
-也可以使用当前开发仓库：
-
-```bash
-git clone https://github.com/EclipseaHime017/reBot-DevArm-Grasp.git rebot_grasp
-cd rebot_grasp
-```
-
 ### 步骤 2. 创建并配置 conda 环境
 
 ```bash
@@ -172,7 +165,7 @@ conda activate rebotarm
 ### 步骤 3. 安装机械臂 SDK
 
 ```bash
-git clone https://github.com/vectorBH6/reBotArm_control_py.git sdk/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git sdk/reBotArm_control_py
 cd sdk/reBotArm_control_py
 pip install -e .
 cd ../..
@@ -641,8 +634,8 @@ python -c "import torch; print(torch.cuda.is_available())"
 
 ## 联系方式
 
-- 技术支持：[提交 Issue](https://github.com/EclipseaHime017/reBot-DevArm-Grasp/issues)
-- 项目地址：[Github](https://github.com/EclipseaHime017/reBot-DevArm-Grasp)
+- 技术支持：[提交 Issue](https://github.com/Seeed-Projects/reBot-DevArm-Grasp/issues)
+- 项目地址：[Github](https://github.com/Seeed-Projects/reBot-DevArm-Grasp)
 - 论坛：[Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## 参考文档

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_ROS2_Integration.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_ROS2_Integration.md
@@ -164,12 +164,7 @@ git clone https://github.com/Seeed-Projects/reBotArmController_ROS2.git rebotarm
 cd rebotarm_ros2
 ```
 
-也可以使用当前开发仓库：
 
-```bash
-git clone https://github.com/EclipseaHime017/reBotArmController_ROS2.git rebotarm_ros2
-cd rebotarm_ros2
-```
 
 ### 步骤 4. 安装 motorbridge
 
@@ -189,7 +184,7 @@ python3 -m pip install --user --index-url https://pypi.org/simple motorbridge
 
 ```bash
 mkdir -p third_party
-git clone https://github.com/vectorBH6/reBotArm_control_py.git third_party/reBotArm_control_py
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git third_party/reBotArm_control_py
 ```
 
 ### 步骤 6. 构建工作空间
@@ -816,8 +811,8 @@ python3 -c "import sys; print('\n'.join(sys.path))"
 
 ## 联系方式
 
-- 技术支持：[提交 Issue](https://github.com/EclipseaHime017/reBotArmController_ROS2/issues)
-- 项目地址：[Github](https://github.com/EclipseaHime017/reBotArmController_ROS2)
+- 技术支持：[提交 Issue](https://github.com/Seeed-Projects/reBotArmController_ROS2/issues)
+- 项目地址：[Github](https://github.com/Seeed-Projects/reBotArmController_ROS2)
 - 论坛：[Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ## 参考文档
@@ -825,5 +820,5 @@ python3 -c "import sys; print('\n'.join(sys.path))"
 - [reBot Arm B601-RS 快速入门](https://wiki.seeedstudio.com/cn/rebot_b601_rs_getting_started/)
 - [ROS2 Humble 文档](https://docs.ros.org/en/humble/)
 - [ROS2 Jazzy 文档](https://docs.ros.org/en/jazzy/)
-- [reBotArm_control_py](https://github.com/vectorBH6/reBotArm_control_py)
+- [reBotArm_control_py](https://github.com/Seeed-Projects/reBotArm_control_py)
 - [MoveIt 2 文档](https://moveit.picknik.ai/main/index.html)

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_pinocchio.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_pinocchio.md
@@ -659,8 +659,8 @@ viz.draw_path(points, "path_name", color)  # 绘制路径
 
 ## 联系方式
 
-- **技术支持**: [提交 Issue](https://github.com/vectorBH6/reBotArm_control_py/issues)
-- **项目仓库**: [GitHub](https://github.com/vectorBH6/reBotArm_control_py)
+- **技术支持**: [提交 Issue](https://github.com/Seeed-Projects/reBotArm_control_py/issues)
+- **项目仓库**: [GitHub](https://github.com/Seeed-Projects/reBotArm_control_py)
 - **论坛**: [Seeed Studio Forum](https://forum.seeedstudio.com/)
 
 ---

--- a/sites/zh-CN/docs/Sensor/reSpeaker_flex/cn_reSpeaker_flex_rebot_arm.md
+++ b/sites/zh-CN/docs/Sensor/reSpeaker_flex/cn_reSpeaker_flex_rebot_arm.md
@@ -624,7 +624,7 @@ uv 是一个非常快速的 Python 包管理工具，可用于安装 pip 格式�
 
 ```bash
 # Cloning robotic arm control library
-git clone https://github.com/vectorBH6/reBotArm_control_py.git
+git clone https://github.com/Seeed-Projects/reBotArm_control_py.git
 
 # Enter the robotic arm control library directory
 cd reBotArm_control_py
@@ -1854,7 +1854,7 @@ np.clip(target_angle, JOINT_LIMITS_MIN, JOINT_LIMITS_MAX)
 | 资源 | 链接 | 说明 |
 |-----|-----|-----|
 | 项目主仓库 | https://github.com/xr686/reBot-Arm-reSpeaker-Flex | 声控主程序 |
-| 机械臂控制库 | https://github.com/vectorBH6/reBotArm_control_py | 机械臂 Python 控制库 |
+| 机械臂控制库 | https://github.com/Seeed-Projects/reBotArm_control_py | 机械臂 Python 控制库 |
 | reBot Arm 官方 | https://www.rebotix.com/ | 机械臂官方网站 |
 | Seeed Studio | https://www.seeedstudio.com/ | reSpeaker Flex 购买与技术支持 |
 


### PR DESCRIPTION
- Remove personal fork (EclipseaHime017) as an alternative clone source
- Update reBotArm_control_py from vectorBH6 to Seeed-Projects
- Update support links and reference docs to point to Seeed-Projects