### PR TITLE
docs: improve core SenseCraft SEO

### DIFF
--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Overview.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Overview.md
@@ -1,6 +1,6 @@
 ---
-description: This article is a brief introduction to the main page of SenseCraft AI.
-title: Overview
+description: Explore pretrained models, custom training, deployment, live preview, and model output workflows in SenseCraft AI for supported edge AI devices.
+title: 'SenseCraft AI: Train and Deploy Edge AI Models'
 image: https://files.seeedstudio.com/wiki/SenseCraft_AI/img2/1.webp
 slug: /sensecraft-ai/overview
 aliases:
@@ -10,12 +10,12 @@ last_update:
   date: 08/06/2026
   author: Citric
 createdAt: '2024-11-28'
-updatedAt: '2026-08-07'
+updatedAt: '2026-08-13'
 url: https://wiki.seeedstudio.com/sensecraft-ai/overview/
 ---
 
 
-# SenseCraft AI Overview
+# SenseCraft AI: Train and Deploy Edge AI Models
 
 SenseCraft AI is an all-in-one platform designed to empower developers and creators in building and deploying AI projects with ease. The website offers a wide range of tools and features to streamline the AI development process, making it accessible to users with varying levels of expertise. In this wiki, we will explore the main sections of the SenseCraft AI website, providing an overview of their key features and functionalities.
 
@@ -267,6 +267,13 @@ For instance, a user could utilize the MQTT output to send real-time object dete
 The Serial Port output provides a straightforward way to establish communication between the device and other systems, enabling users to transmit the model's results for further processing or visualization.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/img2/12.png" style={{width:1000, height:'auto'}}/></div>
+
+## Related guides
+
+- [SenseCraft AI documentation center](/sensecraft-ai/sensecraft-ai-main/)
+- [Train an image classification model](/sensecraft-ai/tutorials/sensecraft-ai-training-classification/)
+- [Train an object detection model](/sensecraft-ai/tutorials/sensecraft-ai-training-object-detection/)
+- [Get started with SenseCraft Data Platform](/cloud/sensecraft-data/sensecraft-data-platform/overview/)
 
 ## Tech Support & Product Discussion
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/SenseCraft_AI_main_page.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/SenseCraft_AI_main_page.md
@@ -1,6 +1,6 @@
 ---
-description: Catalog of SenseCraft AI Documentation
-title: Overview
+description: Find SenseCraft AI guides for pretrained models, custom training, model deployment, device workspaces, model output, and applications.
+title: SenseCraft AI Documentation Center
 image: https://files.seeedstudio.com/wiki/SenseCraft_AI/img2/55.png
 sidebar_class_name: hidden
 slug: /sensecraft-ai/sensecraft-ai-main
@@ -11,19 +11,21 @@ last_update:
   date: 11/27/2024
   author: Citrc
 createdAt: '2024-11-27'
-updatedAt: '2026-05-07'
+updatedAt: '2026-08-13'
 url: https://wiki.seeedstudio.com/sensecraft-ai/sensecraft-ai-main/
 ---
 
-# SenseCraft AI Wiki Center
+# SenseCraft AI Documentation Center
+
+Use this task-based documentation hub to find guides for pretrained models, custom training, model deployment, device workspaces, model output, and applications. To learn about SenseCraft AI capabilities and workflow, see the [platform overview](/sensecraft-ai/overview/).
 
 ## Overview
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/img2/55.png" style={{width:1000, height:'auto'}}/></div>
 
 <div class="get_one_now_container" style={{textAlign: 'center'}}>
-    <a class="get_one_now_item" href="https://wiki.seeedstudio.com/sensecraft_ai_overview/" target="_blank" rel="noopener noreferrer">
-            <strong><span><font color={'FFFFFF'} size={"4"}>Overview 🖱️</font></span></strong>
+    <a class="get_one_now_item" href="/sensecraft-ai/overview/" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>SenseCraft AI platform overview 🖱️</font></span></strong>
     </a>
 </div><br />
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Classification.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Classification.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
-description: How to use Training(Classification)
-title: Training - Classification
+description: Train, label, test, and deploy a custom image classification model in SenseCraft AI using a browser camera or a supported edge AI device.
+title: Image Classification Training with SenseCraft AI
 image: https://files.seeedstudio.com/wiki/SenseCraft_AI/img2/34.webp
 slug: /sensecraft-ai/tutorials/sensecraft-ai-training-classification
 aliases:
@@ -10,11 +10,11 @@ last_update:
   date: 12/03/2024
   author: Citric
 createdAt: '2024-11-27'
-updatedAt: '2026-08-04'
+updatedAt: '2026-08-13'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-training-classification/
 ---
 
-# Type of training - Classification
+# Train an Image Classification Model with SenseCraft AI
 
 Classification is a powerful tool in machine learning that allows you to train a model to recognize and categorize different types of data. In the SenseCraft AI platform, classification enables you to create models that can identify and distinguish between various objects, gestures, or scenes based on the images you provide during training.
 
@@ -132,6 +132,12 @@ Feel free to experiment with training models for different objects, gestures, or
 Remember, while the platform allows you to train models using any camera, for the best results and optimal performance, we recommend using the target device (currently limited to Seeed Studio devices) to train and deploy your model.
 
 With this comprehensive guide, you should now have a solid understanding of how to train a classification model using the SenseCraft AI platform. Happy training, and enjoy creating powerful, custom AI models for your projects!
+
+## Related guides
+
+- Learn about the platform's capabilities in the [SenseCraft AI overview](/sensecraft-ai/overview/).
+- Follow the [object detection model training guide](/sensecraft-ai/tutorials/sensecraft-ai-training-object-detection/) for a different computer vision task.
+- Browse more tutorials and resources in the [SenseCraft AI documentation center](/sensecraft-ai/sensecraft-ai-main/).
 
 ## Tech Support & Product Discussion
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Object_Detection.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_AI/Tutorials/Training/Training_Object_Detection.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
-description: How to use Training(Object Detection)
-title: Training - Object Detection
+description: Create, train, test, and deploy a custom object detection model in SenseCraft AI using quick training or image collection workflows.
+title: Object Detection Training with SenseCraft AI
 image: https://files.seeedstudio.com/wiki/SenseCraft_AI/img3/object%20detection/1.9.webp
 slug: /sensecraft-ai/tutorials/sensecraft-ai-training-object-detection
 aliases:
@@ -10,11 +10,11 @@ last_update:
   date: 11/27/2024
   author: qiuyu wei
 createdAt: '2024-11-27'
-updatedAt: '2025-09-04'
+updatedAt: '2026-08-13'
 url: https://wiki.seeedstudio.com/sensecraft-ai/tutorials/sensecraft-ai-training-object-detection/
 ---
 
-# Type of training - Object Detection
+# Train an Object Detection Model with SenseCraft AI
 
 ## Features of object detection
 
@@ -34,6 +34,12 @@ Advantages: Leverages diverse image data to significantly improve the detection 
 With these two methods, the SenseCraft platform caters to diverse object detection model training needs, simplifying the complexities of AI development while ensuring both usability and precision.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/img3/object%20detection/2.0.png" style={{width:750, height:'auto'}}/></div>
+
+<div class="get_one_now_container" style={{textAlign: 'center'}}>
+    <a class="get_one_now_item" href="https://sensecraft.seeed.cc/ai/?utm_source=seeedstudio_wiki&utm_medium=referral&utm_campaign=wiki_to_sensecraft&utm_content=sensecraft_ai_training#/training" target="_blank" rel="noopener noreferrer">
+            <strong><span><font color={'FFFFFF'} size={"4"}>Open SenseCraft AI Training 🖱️</font></span></strong>
+    </a>
+</div><br />
 
 ## Quick Training
 
@@ -116,6 +122,12 @@ And finally it's time for model deployment.
 Once the above steps are completed, the model will be successfully trained and deployed.
 
 <div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/SenseCraft_AI/img3/object%20detection/3.7.gif" style={{width:1000, height:'auto'}}/></div>
+
+## Related guides
+
+- [Train a classification model with SenseCraft AI](/sensecraft-ai/tutorials/sensecraft-ai-training-classification/)
+- [Explore the SenseCraft AI platform](/sensecraft-ai/overview/)
+- [Browse the SenseCraft AI documentation center](/sensecraft-ai/sensecraft-ai-main/)
 
 ## Tech Support & Product Discussion
 

--- a/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/Overview.md
+++ b/sites/en/docs/Cloud_Chain/SenseCraft_Data_Platform/Overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
-title: Overview
-description: Quick start guide for SenseCraft Data Platform — manage your SenseCAP devices and visualize sensor data with a secure and reliable cloud platform.
+title: SenseCraft Data Platform Quick Start
+description: Create an account, bind a SenseCAP device, and view sensor data in SenseCraft Data Platform with this step-by-step quick-start guide.
 keywords:
   - Cloud and Chain
 image: https://files.seeedstudio.com/wiki/wiki-platform/S-tempor.png
@@ -12,7 +12,7 @@ last_update:
   date: 06/06/2025
   author: Matthew
 createdAt: '2023-03-01'
-updatedAt: '2026-07-13'
+updatedAt: '2026-08-13'
 url: https://wiki.seeedstudio.com/cloud/sensecraft-data/sensecraft-data-platform/overview/
 ---
 
@@ -22,6 +22,8 @@ url: https://wiki.seeedstudio.com/cloud/sensecraft-data/sensecraft-data-platform
 **Notice:**  
 Starting from 2025, **SenseCAP Portal** has been officially renamed to **SenseCraft Data Platform**. The functionality remains the same, with ongoing enhancements to better support AIoT and multi-sensor scenarios.
 :::
+
+This guide covers account setup, app access, device binding, and sensor-data verification.
 
 How to work with SenseCraft Data Platform? Let’s go!
 
@@ -81,3 +83,9 @@ Enter the device EUI and KEY to complete the binding.
 Log in to `SenseCraft Data Platform`, check the device status and basic information in the “Device/Sensor Node” section, and view the sensor data in the “Data/Table” section.
 
 <div align="left"><img width={1000} src="https://files.seeedstudio.com/wiki/SenseCraft_Data_Platform/Overview/SenseCAP-Platform-overview4.png" /></div>
+
+## Related guides
+
+- [Manage gateways and sensor nodes](/sensecraft-data-platform/tutorials/device-management/)
+- [Monitor device status and sensor data in the Dashboard](/sensecraft-data-platform/tutorials/dashboard/)
+- [Make your first SenseCraft Data Platform HTTP API request](/sensecraft-data-platform/api/http-api/quick-start/)


### PR DESCRIPTION
## Summary

Improve search-result clarity and task navigation for five core, non-HMI SenseCraft Wiki pages.

## Changes

- Differentiate the SenseCraft AI platform overview from the task-based documentation center.
- Replace generic training metadata with intent-specific image-classification and object-detection titles, descriptions, and H1s.
- Add a current, tracked SenseCraft AI Training CTA to the object-detection tutorial.
- Rename the Data Platform `Overview` result to `SenseCraft Data Platform Quick Start`.
- Add focused related-guide clusters:
  - SenseCraft AI overview ↔ documentation center ↔ training tutorials;
  - Data Platform quick start → device management, Dashboard, and HTTP API quick start.
- Refresh all five pages to `updatedAt: '2026-08-13'`.

## Compatibility and scope

- Preserved all filenames, `slug` values, aliases, canonical `url` fields, and `createdAt` values.
- Preserved existing images, technical instructions, device/model compatibility statements, and existing external links except the explicitly canonicalized Overview CTA.
- No HMI / SenseCraft Seeedash primary page was modified.
- No localized source, sidebar, product route, platform-wide robots/sitemap configuration, or generated social image is included.

## SEO checks

- Rendered title lengths including ` | Seeed Studio Wiki`: **54–68 characters**.
- Meta description lengths: **132–144 characters**.
- Five canonical routes, five preserved legacy aliases, and three newly linked Data Platform routes return HTTP 200.
- New internal destinations were verified from current source frontmatter and live routes.

## Validation

- Read-only batch validator: PASS; exact five-path manifest, metadata, route fields, aliases, images, approved external-link changes, title/description lengths, and route reachability.
- `git diff --check upstream/docusaurus-version`: PASS.
- Standalone MDX compile with `@mdx-js/mdx@3.1.0`: PASS for all five pages.
- Markdown lint:
  - 4 pages: PASS.
  - Data Platform Quick Start: no new lint findings; the base and edited page both report the same pre-existing `use-standard-ellipsis` finding.
- Full multilingual Docusaurus builds: pending required PR checks `Test deployment` and `test-deploy`.

Fixes #5373
