### PR TITLE
update B601-RS Isaac Sim docs

### DIFF
--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
@@ -15,10 +15,10 @@ slug: /rebot_b601_rs_getting_started
 translation:
   skip: [zh-CN]
 last_update:
-  date: 2026-07-28
+  date: 2026-08-17
   author: LiuJunjie
 createdAt: '2026-05-26'
-updatedAt: '2026-08-10'
+updatedAt: '2026-08-17'
 url: https://wiki.seeedstudio.com/rebot_b601_rs_getting_started/
 ---
 
@@ -349,7 +349,7 @@ sudo ip link set $PCAN_IF up
 </TabItem>
 <TabItem value="macos" label="macos">
 
-If libPCBUSB.dylib cannot be loaded, install PCBUSB first:
+If `libPCBUSB.dylib` cannot be loaded, install PCBUSB first:
 ```zsh
 curl -L -o macOS_Library_for_PCANUSB_v0.13.tar.gz \
   https://raw.githubusercontent.com/tianrking/motorbridge/main/third_party/pcan/macos/macOS_Library_for_PCANUSB_v0.13.tar.gz
@@ -358,25 +358,44 @@ cd PCBUSB
 sudo ./install.sh
 ```
 
-Configure `DYLD_LIBRARY_PATH` to ensure motorbridge-gateway can find the PCBUSB library at runtime. Create an activation script in the conda environment so it takes effect automatically each time you run `conda activate rebot`:
+`install.sh` only creates `libPCBUSB.dylib`. motorbridge's native loader `dlopen`s the bare name `PCBUSB`, so add this symlink. Without it, connecting the arm fails with `load PCBUSB failed` even when a `libPCBUSB.dylib` ctypes check would pass:
+
+```zsh
+sudo ln -sf /usr/local/lib/libPCBUSB.dylib /usr/local/lib/PCBUSB
+```
+
+Configure `DYLD_FALLBACK_LIBRARY_PATH` so motorbridge-gateway can find PCBUSB at runtime. Prefer FALLBACK over `DYLD_LIBRARY_PATH`: the latter overrides dyld's default search order for the whole process and can break unrelated software. Create an activation script in the conda environment so it takes effect automatically each time you run `conda activate rebot`:
 
 ```bash
 mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"
 cat > "$CONDA_PREFIX/etc/conda/activate.d/env_vars.sh" << 'EOF'
-export DYLD_LIBRARY_PATH="/usr/local/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH="/usr/local/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 EOF
 
-echo $DYLD_LIBRARY_PATH
+echo $DYLD_FALLBACK_LIBRARY_PATH
 ```
 
-Check if ready:
+Optional, no sudo (shared machines): install into `~/.local/lib`. If you have the motorbridge source tree:
+
+```bash
+./scripts/setup_pcbusb_macos.sh --user-local
+ln -sf "$HOME/.local/lib/libPCBUSB.dylib" "$HOME/.local/lib/PCBUSB"
+```
+
+Point the conda activate script at `$HOME/.local/lib` instead of `/usr/local/lib`.
+
+Check if ready. Plug in the PCAN adapter first. `ctypes.CDLL('libPCBUSB.dylib')` is not a valid runtime check — motorbridge never loads that name.
+
 ```zsh
 # Check Python package and CLI are ready
 python3 -c "import motorbridge; print('motorbridge OK')"
 motorbridge-cli --help
 
-# Optional: Check if PCBUSB runtime is loadable
-python3 -c "import ctypes; ctypes.CDLL('libPCBUSB.dylib'); print('PCBUSB load OK')"
+# Native loader dlopens the bare name PCBUSB
+python3 -c "import ctypes; ctypes.CDLL('PCBUSB'); print('PCBUSB load OK')"
+
+# Real runtime check (can0 maps to PCAN_USBBUS1 on macOS)
+motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 --timeout-ms 300
 ```
 
 </TabItem>
@@ -587,7 +606,7 @@ motorbridge-gateway --bind 127.0.0.1:9002
 or
 
 ```bash
-DYLD_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
+DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
 ```
 
 #### Initialize RS Motor Control Parameters

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_isaacsim.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_isaacsim.md
@@ -11,10 +11,10 @@ keywords:
 image: https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/reBot_Arm_RS_isaacsim.jpg
 slug: /rebot_arm_b601_rs_isaacsim
 last_update:
-  date: 7/7/2026
-  author: LiShanghang
+  date: 8/14/2026
+  author: LiuJunjie
 createdAt: '2026-07-07'
-updatedAt: '2026-08-10'
+updatedAt: '2026-08-14'
 url: https://wiki.seeedstudio.com/rebot_arm_b601_rs_isaacsim/
 ---
 
@@ -74,6 +74,7 @@ Add the following to `~/.bashrc` or `~/.zshrc`:
 ```Bash
 export ISAACSIM_PATH="${HOME}/isaacsim"
 export ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
+export ISAACSIM_ROOT="${HOME}/isaacsim"
 ```
 
 Then run `source ~/.bashrc` to make it take effect.
@@ -115,18 +116,43 @@ The build process might take 30-60 minutes, depending on your hardware.
 _build/linux-x86_64/release/isaac-sim.sh
 ```
 
-## Download project
-
-```Bash
-git clone https://github.com/Seeed-Projects/reBot-Isaacsim.git
-```
-
-配置 reBotArm_control_py 的 uv 环境
+After a source build, point `ISAACSIM_ROOT` at that runtime directory so `run_isaacsim_receiver.sh` can find Isaac Sim:
 
 ```bash
-cd third_party/reBotArm_control_py
+export ISAACSIM_ROOT="$PWD/_build/linux-x86_64/release"
+```
+
+## Download project
+
+This repo pulls the upstream control library `reBotArm_control_py` as a git submodule. Clone with submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/Seeed-Projects/reBot-Isaacsim.git
+```
+
+If you already cloned the repo and `third_party/reBotArm_control_py` is empty:
+
+```bash
+git submodule update --init --recursive
+```
+
+Install sender dependencies at the repo root (`run_sender.sh` and `uv run` both use the root uv workspace):
+
+```bash
+cd reBot-Isaacsim
 uv sync
 ```
+
+### Switch the hardware config to RS
+
+This repo's Isaac Sim asset is RS (`usd/RS-rebot-dev-arm`). Upstream `rebotarm.yaml` defaults to DM. Both `RebotArm()` and `load_robot_model()` follow this file, so gravity compensation, joint-reader, IK, and Traj all need RS first; leave it on DM and the motor protocol will not match, and Pinocchio will load the DM URDF. This only dirties the submodule working tree — do not commit it:
+
+```bash
+cd reBotArm_Isaacsim
+python set_hw_rs.py
+```
+
+On success it prints `.../config/rebotarm.yaml -> rebotarm_rs.yaml`.
 
 ### Overview of Functional Components
 
@@ -134,7 +160,7 @@ This project provides various senders to meet different use scenarios:
 
 | Component | Description |
 |-----------|------------|
-| `gravity_joint_sender` | **Gravity Compensation Handle Mode**: Modified robotic arm (claw removed, handle added) allows manual movement in gravity compensation mode and synchronizes joint angles to Isaac Sim in real time |
+| `gravity_joint_sender` | **Gravity Compensation + Handle Mode**: For modified robot arms (gripper removed, handle attached), hand-guided; compensation comes from upstream `GravityCompensation`, this repo only mirrors joint angles to Isaac Sim |
 | `isaacsim_ik_sender` | **Inverse Kinematics (IK) Mode**: Input the end-effector pose, use the IK solver to get joint angles, and send them to Isaac Sim |
 | `isaacsim_traj_sender` | **Trajectory Planning (Traj) Mode**: Adds joint-space trajectory planning (MIN_JERK time profile) on top of IK to achieve smooth motion control |
 | `isaacsim_joint_test_sender` | **Joint Test Mode**: Sends preset joint angle trajectories without a real robot to verify if Isaac Sim's receiver and communication are working properly |
@@ -144,26 +170,27 @@ This project provides various senders to meet different use scenarios:
 
 ```
 reBot-Isaacsim/
-├── pyproject.toml                      # uv workspace configuration
+├── pyproject.toml                           # uv workspace configuration
 ├── README.md
 ├── README_EN.md
-├── reBotArm_Isaacsim/                  # Main example directory
-│   ├── gravity_joint_sender.py         # Gravity compensation handle mode (modified robotic arm, manual manipulation)
-│   ├── isaacsim_ik_sender.py           # Inverse kinematics mode (IK control)
-│   ├── isaacsim_traj_sender.py         # Trajectory planning mode (IK joint space trajectory)
-│   ├── isaacsim_joint_test_sender.py   # Joint test mode (preset trajectory, no hardware needed)
-│   ├── joint_reader_sender.py          # Real-to-Sim mapping mode (read-only joints, sync visualization)
-│   ├── isaacsim_joint_receiver.py      # Isaac Sim receiver (joint angle synchronization)
-│   ├── live_sync.py                    # Startup instruction script
-│   ├── run_sender.sh # Start sender
-│   └── run_isaacsim_receiver.sh        # Start Isaac Sim receiver
+├── README_ES.md
+├── reBotArm_Isaacsim/                       # Main example directory
+│   ├── gravity_joint_sender.py              # Gravity-comp handle mode (upstream GravityCompensation + UDP)
+│   ├── isaacsim_ik_sender.py                # Inverse kinematics mode (IK control)
+│   ├── isaacsim_traj_sender.py              # Trajectory planning mode (IK + joint-space trajectory)
+│   ├── isaacsim_joint_test_sender.py        # Joint test mode (preset trajectory, no hardware needed)
+│   ├── joint_reader_sender.py                # Real-to-Sim mapping mode (read-only joints, sync visualization)
+│   ├── isaacsim_joint_receiver.py           # Isaac Sim receiver (joint-angle sync)
+│   ├── live_sync.py                         # Startup instruction script
+│   ├── set_hw_rs.py                         # Point submodule hardware YAML at RS (local; do not commit)
+│   ├── run_sender.sh                        # Launch the sender
+│   └── run_isaacsim_receiver.sh             # Launch the Isaac Sim receiver
+├── .gitmodules
 ├── third_party/
-│   └── reBotArm_control_py/            # Core control library (separate uv environment)
-│       ├── pyproject.toml
-│       └── ...
+│   └── reBotArm_control_py/                 # git submodule: upstream control library
 └── usd/
     └── RS-rebot-dev-arm/
-        └── 00-arm-rs_asm-v3.usda       # Isaac Sim robotic arm asset
+        └── RS-rebot-dev-arm.usda            # Isaac Sim robot asset
 ```
 
 ## Launch (Dual-Terminal Mode)
@@ -214,16 +241,15 @@ cd reBotArm_Isaacsim
 uv run python isaacsim_joint_test_sender.py
 ```
 
-The sender continuously interpolates between several predefined joint configurations and transmits them to Isaac Sim. No CAN connection is required.
+The sender continuously interpolates between several predefined joint configurations and transmits them to Isaac Sim. It does not read the hardware YAML, so neither `set_hw_rs.py` nor CAN is required.
 
 #### ② Inverse Kinematics Mode (`isaacsim_ik_sender`)
 
-Enter an end-effector pose (position/orientation). The IK solver computes the joint configuration and drives the robot arm in Isaac Sim.
-
-Run the following from the `reBotArm_Isaacsim/` directory:
+Enter an end-effector pose (position/orientation). The IK solver computes the joint configuration and drives the robot arm in Isaac Sim. `load_robot_model()` reads the submodule `rebotarm.yaml`, so switch to RS first:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_ik_sender.py
 ```
 
@@ -238,12 +264,11 @@ gripper <0~1>               # Update gripper only
 
 #### ③ Trajectory Planning Mode (`isaacsim_traj_sender`)
 
-Adds joint-space trajectory planning (MIN_JERK) on top of IK for smooth robot motion.
-
-Run the following from the `reBotArm_Isaacsim/` directory:
+Adds joint-space trajectory planning (MIN_JERK) on top of IK for smooth robot motion. It also uses `load_robot_model()` against that YAML, so switch to RS first:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_traj_sender.py
 ```
 
@@ -264,26 +289,29 @@ Designed for modified robot arms (gripper removed and handle installed). The rob
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 ./run_sender.sh
 ```
 
 **Expected behavior:**
-- Connect to the physical robot arm and enable MIT control with gravity feedforward compensation
-- The robot arm can be freely moved by hand
-- Joint angles are continuously transmitted via UDP at 60 Hz
+- `set_hw_rs.py` points the submodule `rebotarm.yaml` at `rebotarm_rs.yaml` so motors and the gravity model share one YAML (local change; do not commit)
+- The physical arm connects and starts upstream `GravityCompensation` (same MIT + `g(q)` feed-forward as `example/9`)
+- The arm can be moved freely by hand
+- This script only forwards joint angles to Isaac Sim over UDP at 60 Hz
+- Do not also run upstream `example/9` at the same time; the two processes would contend for CAN
 
 #### ⑤ Real-to-Sim Mapping Mode (`joint_reader_sender`)
 
-Reads joint angles only and mirrors the physical robot state into Isaac Sim. This mode is intended for visualization while the real robot is controlled by another application.
-
-Run the following from the `reBotArm_Isaacsim/` directory:
+Reads joint angles only and mirrors the physical robot state into Isaac Sim. This mode is intended for visualization while the real robot is controlled by another application. `RebotArm()` reads the submodule `rebotarm.yaml`, so switch to RS first:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python joint_reader_sender.py
 ```
 
 **Expected behavior:**
+- `set_hw_rs.py` switches the motor config to RS (local change; do not commit)
 - Read joint angles only (passive feedback mode), without sending any control commands
 - Continuously transmit joint angles via UDP at 60 Hz
 - Visualize the physical robot in Isaac Sim while it is controlled by another project
@@ -308,11 +336,18 @@ UDP JSON over port `127.0.0.1:5005`.
 | `sequence` | int | Incrementing frame sequence number |
 | `timestamp` | float | Unix timestamp (seconds) |
 | `joint_positions` | float[6] | First six joint positions (rad) |
-| `gripper_position` | float | Gripper position (m), converted by the sender using `GRIPPER_POSITION_SCALE=0.03` |
+| `gripper_position` | float | Gripper finger position target (m); each sender computes it with its own mapping (see below) |
 
 **Gripper control pipeline:**
 
-Sender `gripper_q` → `gripper_position = -gripper_q × 0.03` → Receiver `× 0.01` → Dual-joint position target
+The receiver applies the received `gripper_position` directly as the position target of both prismatic finger joints, clipped per finger to `[0, upper limit]` (USD upper limits: 0.05 m on both fingers; the fingers are driven 1:1 by one motor through a single pinion). There is no extra scaling on the receiver side. The senders map their input to `gripper_position` as follows:
+
+| Sender | Mapping to `gripper_position` (m) |
+|------|------|
+| `gravity_joint_sender` | `gripper_q × 0.03` (`GRIPPER_POSITION_SCALE = 0.03`) |
+| `joint_reader_sender` | `gripper_q × 0.007` (`GRIPPER_POSITION_SCALE = 0.007`) |
+| `isaacsim_traj_sender` | `ratio × 0.045` (`gripper <0~1>` input, clipped to 0.045 m) |
+| `isaacsim_ik_sender` | raw `ratio ∈ [0, 1]` sent as meters, so any ratio ≥ a finger's upper limit fully opens that finger |
 
 ## Configuration Parameters
 
@@ -320,6 +355,7 @@ Sender `gripper_q` → `gripper_position = -gripper_q × 0.03` → Receiver `× 
 
 | Parameter | Default | Description |
 |------|--------|------|
+| Hardware YAML | `set_hw_rs.py` → `rebotarm_rs.yaml` | `RebotArm()` reads submodule `config/rebotarm.yaml`; motors and Pinocchio share it |
 | `ARM_JOINT_COUNT` | 6 | Number of arm joints |
 | `DEFAULT_PORT` | 5005 | UDP port |
 | `DEFAULT_SEND_HZ` | 60.0 | Transmission frequency (Hz) |
@@ -333,9 +369,8 @@ Sender `gripper_q` → `gripper_position = -gripper_q × 0.03` → Receiver `× 
 | `ARM_JOINT_COUNT` | 6 | Number of arm joints |
 | `DEFAULT_PORT` | 5005 | UDP port |
 | `DEFAULT_RENDER_HZ` | 120.0 | Simulation rendering frequency (Hz) |
-| `GRIPPER_POSITION_SCALE` | 0.01 | Additional gripper position scaling factor |
 | `ROBOT_PRIM_PATH` | `/World/reBotArm` | Robot Prim path in Isaac Sim |
-| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda` | Relative path to the USD asset |
+| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda` | Relative path to the USD asset |
 
 ## Troubleshooting
 
@@ -356,7 +391,7 @@ kill <PID>
 Verify that the USD asset exists and that `REPO_ROOT` is configured correctly:
 
 ```bash
-ls usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda
+ls usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda
 ```
 
 ### CAN Bus Not Ready

--- a/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_Getting_Started.md
@@ -15,10 +15,10 @@ slug: /rebot_b601_rs_getting_started
 translation:
   skip: [zh-CN]
 last_update:
-  date: 2026-07-28
+  date: 2026-08-17
   author: LiuJunjie
 createdAt: '2026-05-26'
-updatedAt: '2026-08-03'
+updatedAt: '2026-08-17'
 url: https://wiki.seeedstudio.com/es/rebot_b601_rs_getting_started/
 ---
 
@@ -349,7 +349,7 @@ sudo ip link set $PCAN_IF up
 </TabItem>
 <TabItem value="macos" label="macos">
 
-Si no se puede cargar libPCBUSB.dylib, instala primero PCBUSB:
+Si no se puede cargar `libPCBUSB.dylib`, instala primero PCBUSB:
 ```zsh
 curl -L -o macOS_Library_for_PCANUSB_v0.13.tar.gz \
   https://raw.githubusercontent.com/tianrking/motorbridge/main/third_party/pcan/macos/macOS_Library_for_PCANUSB_v0.13.tar.gz
@@ -358,25 +358,44 @@ cd PCBUSB
 sudo ./install.sh
 ```
 
-Configura `DYLD_LIBRARY_PATH` para asegurar que motorbridge-gateway pueda encontrar la biblioteca PCBUSB en tiempo de ejecución. Crea un script de activación en el entorno conda para que surta efecto automáticamente cada vez que ejecutes `conda activate rebot`:
+`install.sh` solo crea `libPCBUSB.dylib`. El cargador nativo de motorbridge hace `dlopen` del nombre desnudo `PCBUSB`, así que añade este enlace simbólico. Sin él, conectar el brazo falla con `load PCBUSB failed` aunque una comprobación ctypes de `libPCBUSB.dylib` habría pasado:
+
+```zsh
+sudo ln -sf /usr/local/lib/libPCBUSB.dylib /usr/local/lib/PCBUSB
+```
+
+Configura `DYLD_FALLBACK_LIBRARY_PATH` para que motorbridge-gateway encuentre PCBUSB en tiempo de ejecución. Prefiere FALLBACK frente a `DYLD_LIBRARY_PATH`: este último anula el orden de búsqueda predeterminado de dyld para todo el proceso y puede romper otro software. Crea un script de activación en el entorno conda para que surta efecto automáticamente cada vez que ejecutes `conda activate rebot`:
 
 ```bash
 mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"
 cat > "$CONDA_PREFIX/etc/conda/activate.d/env_vars.sh" << 'EOF'
-export DYLD_LIBRARY_PATH="/usr/local/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH="/usr/local/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 EOF
 
-echo $DYLD_LIBRARY_PATH
+echo $DYLD_FALLBACK_LIBRARY_PATH
 ```
 
-Comprueba si está listo:
+Opcional, sin sudo (máquinas compartidas): instala en `~/.local/lib`. Si tienes el árbol de código de motorbridge:
+
+```bash
+./scripts/setup_pcbusb_macos.sh --user-local
+ln -sf "$HOME/.local/lib/libPCBUSB.dylib" "$HOME/.local/lib/PCBUSB"
+```
+
+Apunta el script de activación de conda a `$HOME/.local/lib` en lugar de `/usr/local/lib`.
+
+Comprueba si está listo. Conecta primero el adaptador PCAN. `ctypes.CDLL('libPCBUSB.dylib')` no es una comprobación de runtime válida: motorbridge nunca carga ese nombre.
+
 ```zsh
 # Check Python package and CLI are ready
 python3 -c "import motorbridge; print('motorbridge OK')"
 motorbridge-cli --help
 
-# Optional: Check if PCBUSB runtime is loadable
-python3 -c "import ctypes; ctypes.CDLL('libPCBUSB.dylib'); print('PCBUSB load OK')"
+# Native loader dlopens the bare name PCBUSB
+python3 -c "import ctypes; ctypes.CDLL('PCBUSB'); print('PCBUSB load OK')"
+
+# Real runtime check (can0 maps to PCAN_USBBUS1 on macOS)
+motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 --timeout-ms 300
 ```
 
 </TabItem>
@@ -587,7 +606,7 @@ motorbridge-gateway --bind 127.0.0.1:9002
 o
 
 ```bash
-DYLD_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
+DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
 ```
 
 #### Inicializar los parámetros de control del motor RS

--- a/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_isaacsim.md
+++ b/sites/es/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/es_reBot_Arm_B601_RS_isaacsim.md
@@ -11,10 +11,10 @@ keywords:
 image: https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/reBot_Arm_RS_isaacsim.jpg
 slug: /rebot_arm_b601_rs_isaacsim
 last_update:
-  date: 7/7/2026
-  author: LiShanghang
+  date: 8/14/2026
+  author: LiuJunjie
 createdAt: '2026-07-07'
-updatedAt: '2026-07-09'
+updatedAt: '2026-08-14'
 url: https://wiki.seeedstudio.com/es/rebot_arm_b601_rs_isaacsim/
 ---
 
@@ -74,6 +74,7 @@ Añade lo siguiente a `~/.bashrc` o `~/.zshrc`:
 ```Bash
 export ISAACSIM_PATH="${HOME}/isaacsim"
 export ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
+export ISAACSIM_ROOT="${HOME}/isaacsim"
 ```
 
 Luego ejecuta `source ~/.bashrc` para que surta efecto.
@@ -115,18 +116,43 @@ El proceso de compilación puede tardar entre 30 y 60 minutos, dependiendo de tu
 _build/linux-x86_64/release/isaac-sim.sh
 ```
 
-## Descargar proyecto
-
-```Bash
-git clone https://github.com/Seeed-Projects/reBot-Isaacsim.git
-```
-
-Configurar el entorno uv de reBotArm_control_py
+Tras una compilación desde el código fuente, apunta `ISAACSIM_ROOT` a ese directorio de ejecución para que `run_isaacsim_receiver.sh` encuentre Isaac Sim:
 
 ```bash
-cd third_party/reBotArm_control_py
+export ISAACSIM_ROOT="$PWD/_build/linux-x86_64/release"
+```
+
+## Descargar proyecto
+
+Este repositorio usa como git submodule la biblioteca de control upstream `reBotArm_control_py`. Clónalo con los submódulos:
+
+```bash
+git clone --recurse-submodules https://github.com/Seeed-Projects/reBot-Isaacsim.git
+```
+
+Si ya habías clonado el repo y `third_party/reBotArm_control_py` está vacío:
+
+```bash
+git submodule update --init --recursive
+```
+
+Instala las dependencias del emisor en la raíz del repositorio (`run_sender.sh` y `uv run` usan el workspace uv de la raíz):
+
+```bash
+cd reBot-Isaacsim
 uv sync
 ```
+
+### Cambiar la configuración de hardware a RS
+
+El asset de Isaac Sim de este repo es RS (`usd/RS-rebot-dev-arm`). El `rebotarm.yaml` upstream usa DM por defecto. Tanto `RebotArm()` como `load_robot_model()` leen este archivo, así que compensación de gravedad, mapeo de solo lectura, IK y Traj necesitan RS primero; si se deja en DM, el protocolo de motores no coincidirá y Pinocchio cargará el URDF de DM. Solo ensucia el working tree del submodule: no hagas commit:
+
+```bash
+cd reBotArm_Isaacsim
+python set_hw_rs.py
+```
+
+Si va bien, imprime `.../config/rebotarm.yaml -> rebotarm_rs.yaml`.
 
 ### Descripción general de los componentes funcionales
 
@@ -134,7 +160,7 @@ Este proyecto proporciona varios emisores para satisfacer diferentes escenarios 
 
 | Componente | Descripción |
 |-----------|------------|
-| `gravity_joint_sender` | **Modo de mango con compensación de gravedad**: El brazo robótico modificado (garra retirada, mango añadido) permite el movimiento manual en modo de compensación de gravedad y sincroniza los ángulos de las articulaciones con Isaac Sim en tiempo real |
+| `gravity_joint_sender` | **Modo de compensación de gravedad + asa**: para brazos modificados (pinza retirada, asa acoplada); la compensación la aporta el `GravityCompensation` upstream y este repo solo refleja los ángulos en Isaac Sim |
 | `isaacsim_ik_sender` | **Modo de cinemática inversa (IK)**: Introduce la pose del efector final, utiliza el solucionador IK para obtener los ángulos articulares y los envía a Isaac Sim |
 | `isaacsim_traj_sender` | **Modo de planificación de trayectoria (Traj)**: Añade planificación de trayectoria en el espacio articular (perfil de tiempo MIN_JERK) sobre la base de IK para lograr un control de movimiento suave |
 | `isaacsim_joint_test_sender` | **Modo de prueba de articulaciones**: Envía trayectorias de ángulos articulares preestablecidas sin un robot real para verificar si el receptor y la comunicación de Isaac Sim funcionan correctamente |
@@ -144,26 +170,27 @@ Este proyecto proporciona varios emisores para satisfacer diferentes escenarios 
 
 ```
 reBot-Isaacsim/
-├── pyproject.toml                      # uv workspace configuration
+├── pyproject.toml                           # Configuración del workspace de uv
 ├── README.md
 ├── README_EN.md
-├── reBotArm_Isaacsim/                  # Main example directory
-│   ├── gravity_joint_sender.py         # Gravity compensation handle mode (modified robotic arm, manual manipulation)
-│   ├── isaacsim_ik_sender.py           # Inverse kinematics mode (IK control)
-│   ├── isaacsim_traj_sender.py         # Trajectory planning mode (IK joint space trajectory)
-│   ├── isaacsim_joint_test_sender.py   # Joint test mode (preset trajectory, no hardware needed)
-│   ├── joint_reader_sender.py          # Real-to-Sim mapping mode (read-only joints, sync visualization)
-│   ├── isaacsim_joint_receiver.py      # Isaac Sim receiver (joint angle synchronization)
-│   ├── live_sync.py                    # Startup instruction script
-│   ├── run_sender.sh # Start sender
-│   └── run_isaacsim_receiver.sh        # Start Isaac Sim receiver
+├── README_ES.md
+├── reBotArm_Isaacsim/                       # Directorio principal de ejemplos
+│   ├── gravity_joint_sender.py              # Modo asa (GravityCompensation upstream + UDP)
+│   ├── isaacsim_ik_sender.py                # Modo de cinemática inversa (control IK)
+│   ├── isaacsim_traj_sender.py              # Modo de planificación de trayectorias (IK + trayectoria en espacio articular)
+│   ├── isaacsim_joint_test_sender.py        # Modo de prueba de articulaciones (trayectoria predefinida, sin hardware)
+│   ├── joint_reader_sender.py                # Modo de mapeo Real-to-Sim (solo lectura, visualización sincronizada)
+│   ├── isaacsim_joint_receiver.py           # Receptor de Isaac Sim (sincronización de ángulos articulares)
+│   ├── live_sync.py                         # Script auxiliar con instrucciones de arranque
+│   ├── set_hw_rs.py                         # Cambia el YAML de hardware del submodule a RS (local; no hacer commit)
+│   ├── run_sender.sh                        # Lanza el emisor
+│   └── run_isaacsim_receiver.sh             # Lanza el receptor de Isaac Sim
+├── .gitmodules
 ├── third_party/
-│   └── reBotArm_control_py/            # Core control library (separate uv environment)
-│       ├── pyproject.toml
-│       └── ...
+│   └── reBotArm_control_py/                 # git submodule: biblioteca de control upstream
 └── usd/
     └── RS-rebot-dev-arm/
-        └── 00-arm-rs_asm-v3.usda       # Isaac Sim robotic arm asset
+        └── RS-rebot-dev-arm.usda            # Asset del robot para Isaac Sim
 ```
 
 ## Puesta en marcha (modo de doble terminal)
@@ -214,16 +241,15 @@ cd reBotArm_Isaacsim
 uv run python isaacsim_joint_test_sender.py
 ```
 
-El emisor interpola continuamente entre varias configuraciones articulares predefinidas y las transmite a Isaac Sim. No se requiere conexión CAN.
+El emisor interpola continuamente entre varias configuraciones articulares predefinidas y las transmite a Isaac Sim. No lee el YAML de hardware, así que no hacen falta `set_hw_rs.py` ni CAN.
 
 #### ② Modo de cinemática inversa (`isaacsim_ik_sender`)
 
-Introduce una pose del efector final (posición/orientación). El solucionador IK calcula la configuración articular y mueve el brazo robótico en Isaac Sim.
-
-Ejecuta lo siguiente desde el directorio `reBotArm_Isaacsim/`:
+Introduce una pose del efector final (posición/orientación). El solucionador IK calcula la configuración articular y mueve el brazo robótico en Isaac Sim. `load_robot_model()` lee el `rebotarm.yaml` del submodule, así que cambia a RS primero:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_ik_sender.py
 ```
 
@@ -238,12 +264,11 @@ gripper <0~1>               # Update gripper only
 
 #### ③ Modo de planificación de trayectoria (`isaacsim_traj_sender`)
 
-Añade planificación de trayectoria en el espacio articular (MIN_JERK) sobre la base de IK para un movimiento suave del robot.
-
-Ejecuta lo siguiente desde el directorio `reBotArm_Isaacsim/`:
+Añade planificación de trayectoria en el espacio articular (MIN_JERK) sobre la base de IK para un movimiento suave del robot. También usa `load_robot_model()` contra ese YAML, así que cambia a RS primero:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_traj_sender.py
 ```
 
@@ -264,26 +289,29 @@ Diseñado para brazos robóticos modificados (garra retirada y mango instalado).
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 ./run_sender.sh
 ```
 
 **Comportamiento esperado:**
-- Conectarse al brazo robótico físico y habilitar el control MIT con compensación de gravedad feedforward
-- El brazo robótico puede moverse libremente a mano
-- Los ángulos articulares se transmiten continuamente vía UDP a 60 Hz
+- `set_hw_rs.py` apunta el `rebotarm.yaml` del submodule a `rebotarm_rs.yaml` para que motores y el modelo de gravedad usen el mismo YAML (cambio local; no hacer commit)
+- Se conecta el brazo físico y arranca el `GravityCompensation` upstream (mismo MIT + feed-forward `g(q)` que `example/9`)
+- El brazo puede moverse libremente con la mano
+- Este script solo envía los ángulos articulares a Isaac Sim por UDP a 60 Hz
+- No ejecutes a la vez el `example/9` upstream: los dos procesos competirían por el CAN
 
 #### ⑤ Modo de mapeo del mundo real a la simulación (`joint_reader_sender`)
 
-Lee únicamente los ángulos articulares y refleja el estado del robot físico en Isaac Sim. Este modo está pensado para visualización mientras el robot real es controlado por otra aplicación.
-
-Ejecuta lo siguiente desde el directorio `reBotArm_Isaacsim/`:
+Lee únicamente los ángulos articulares y refleja el estado del robot físico en Isaac Sim. Este modo está pensado para visualización mientras el robot real es controlado por otra aplicación. `RebotArm()` lee el `rebotarm.yaml` del submodule, así que cambia a RS primero:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python joint_reader_sender.py
 ```
 
 **Comportamiento esperado:**
+- `set_hw_rs.py` cambia la configuración de motores a RS (cambio local; no hacer commit)
 - Leer solo los ángulos articulares (modo de retroalimentación pasiva), sin enviar ningún comando de control
 - Transmitir continuamente los ángulos articulares vía UDP a 60 Hz
 - Visualizar el robot físico en Isaac Sim mientras es controlado por otro proyecto
@@ -307,12 +335,19 @@ UDP JSON sobre el puerto `127.0.0.1:5005`.
 |------|------|------|
 | `sequence` | int | Número de secuencia de trama incremental |
 | `timestamp` | float | Marca de tiempo Unix (segundos) |
-| `joint_positions` | float[6] | Primeras seis posiciones de las articulaciones (rad) |
-| `gripper_position` | float | Posición de la pinza (m), convertida por el emisor usando `GRIPPER_POSITION_SCALE=0.03` |
+| `joint_positions` | float[6] | Primeras seis posiciones articulares (rad) |
+| `gripper_position` | float | Objetivo de posición de los dedos de la pinza (m); cada emisor lo calcula con su propia conversión (véase más abajo) |
 
 **Flujo de control de la pinza:**
 
-Emisor `gripper_q` → `gripper_position = -gripper_q × 0.03` → Receptor `× 0.01` → Objetivo de posición de articulación dual
+El receptor aplica el `gripper_position` recibido directamente como objetivo de posición de las dos articulaciones prismáticas de los dedos, recortado por dedo a `[0, límite superior]` (límites superiores del USD: 0,05 m en ambos dedos; los dedos se accionan 1:1 por un solo motor a través de un piñón). El receptor no aplica ninguna escala adicional. Los emisores convierten su entrada a `gripper_position` de la siguiente manera:
+
+| Emisor | Conversión a `gripper_position` (m) |
+|------|------|
+| `gravity_joint_sender` | `gripper_q × 0.03` (`GRIPPER_POSITION_SCALE = 0.03`) |
+| `joint_reader_sender` | `gripper_q × 0.007` (`GRIPPER_POSITION_SCALE = 0.007`) |
+| `isaacsim_traj_sender` | `ratio × 0.045` (entrada `gripper <0–1>`, recortado a 0,045 m) |
+| `isaacsim_ik_sender` | `ratio ∈ [0, 1]` sin convertir, enviado como metros, de modo que cualquier ratio ≥ el límite superior de un dedo abre ese dedo por completo |
 
 ## Parámetros de configuración
 
@@ -320,6 +355,7 @@ Emisor `gripper_q` → `gripper_position = -gripper_q × 0.03` → Receptor `× 
 
 | Parámetro | Predeterminado | Descripción |
 |------|--------|------|
+| YAML de hardware | `set_hw_rs.py` → `rebotarm_rs.yaml` | `RebotArm()` lee `config/rebotarm.yaml` del submodule; motores y Pinocchio lo comparten |
 | `ARM_JOINT_COUNT` | 6 | Número de articulaciones del brazo |
 | `DEFAULT_PORT` | 5005 | Puerto UDP |
 | `DEFAULT_SEND_HZ` | 60.0 | Frecuencia de transmisión (Hz) |
@@ -333,9 +369,8 @@ Emisor `gripper_q` → `gripper_position = -gripper_q × 0.03` → Receptor `× 
 | `ARM_JOINT_COUNT` | 6 | Número de articulaciones del brazo |
 | `DEFAULT_PORT` | 5005 | Puerto UDP |
 | `DEFAULT_RENDER_HZ` | 120.0 | Frecuencia de renderizado de la simulación (Hz) |
-| `GRIPPER_POSITION_SCALE` | 0.01 | Factor adicional de escala de la posición de la pinza |
 | `ROBOT_PRIM_PATH` | `/World/reBotArm` | Ruta del Prim del robot en Isaac Sim |
-| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda` | Ruta relativa al recurso USD |
+| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda` | Ruta relativa al recurso USD |
 
 ## Solución de problemas
 
@@ -356,7 +391,7 @@ kill <PID>
 Verifica que el recurso USD exista y que `REPO_ROOT` esté configurado correctamente:
 
 ```bash
-ls usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda
+ls usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda
 ```
 
 ### Bus CAN no listo

--- a/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_Getting_Started.md
@@ -15,10 +15,10 @@ slug: /rebot_b601_rs_getting_started
 translation:
   skip: [zh-CN]
 last_update:
-  date: 2026-07-28
+  date: 2026-08-17
   author: LiuJunjie
 createdAt: '2026-05-26'
-updatedAt: '2026-08-03'
+updatedAt: '2026-08-17'
 url: https://wiki.seeedstudio.com/ja/rebot_b601_rs_getting_started/
 ---
 
@@ -349,7 +349,7 @@ sudo ip link set $PCAN_IF up
 </TabItem>
 <TabItem value="macos" label="macos">
 
-libPCBUSB.dylib をロードできない場合は、まず PCBUSB をインストールしてください：
+`libPCBUSB.dylib` をロードできない場合は、まず PCBUSB をインストールしてください：
 ```zsh
 curl -L -o macOS_Library_for_PCANUSB_v0.13.tar.gz \
   https://raw.githubusercontent.com/tianrking/motorbridge/main/third_party/pcan/macos/macOS_Library_for_PCANUSB_v0.13.tar.gz
@@ -358,25 +358,44 @@ cd PCBUSB
 sudo ./install.sh
 ```
 
-`DYLD_LIBRARY_PATH` を設定して、motorbridge-gateway が実行時に PCBUSB ライブラリを見つけられるようにします。`conda activate rebot` を実行するたびに自動的に有効になるよう、conda 環境内にアクティベーションスクリプトを作成します：
+`install.sh` が作成するのは `libPCBUSB.dylib` だけです。motorbridge のネイティブローダは裸の名前 `PCBUSB` を `dlopen` するため、次のシンボリックリンクを追加してください。これがないと、`libPCBUSB.dylib` の ctypes チェックは通っても、アーム接続時に `load PCBUSB failed` になります：
+
+```zsh
+sudo ln -sf /usr/local/lib/libPCBUSB.dylib /usr/local/lib/PCBUSB
+```
+
+`DYLD_FALLBACK_LIBRARY_PATH` を設定して、motorbridge-gateway が実行時に PCBUSB を見つけられるようにします。`DYLD_LIBRARY_PATH` ではなく FALLBACK を使ってください。前者はプロセス全体の dyld 既定検索順を上書きし、他のソフトウェアを壊すことがあります。`conda activate rebot` のたびに自動適用されるよう、conda 環境にアクティベーションスクリプトを作成します：
 
 ```bash
 mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"
 cat > "$CONDA_PREFIX/etc/conda/activate.d/env_vars.sh" << 'EOF'
-export DYLD_LIBRARY_PATH="/usr/local/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH="/usr/local/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 EOF
 
-echo $DYLD_LIBRARY_PATH
+echo $DYLD_FALLBACK_LIBRARY_PATH
 ```
 
-準備ができているか確認します：
+任意、sudo なし（共有マシン向け）：`~/.local/lib` にインストールします。motorbridge のソースツリーがある場合：
+
+```bash
+./scripts/setup_pcbusb_macos.sh --user-local
+ln -sf "$HOME/.local/lib/libPCBUSB.dylib" "$HOME/.local/lib/PCBUSB"
+```
+
+conda のアクティベーションスクリプトのパスを `/usr/local/lib` ではなく `$HOME/.local/lib` にしてください。
+
+準備ができているか確認します。先に PCAN アダプタを接続してください。`ctypes.CDLL('libPCBUSB.dylib')` は実行時チェックになりません。motorbridge はその名前をロードしません。
+
 ```zsh
 # Check Python package and CLI are ready
 python3 -c "import motorbridge; print('motorbridge OK')"
 motorbridge-cli --help
 
-# Optional: Check if PCBUSB runtime is loadable
-python3 -c "import ctypes; ctypes.CDLL('libPCBUSB.dylib'); print('PCBUSB load OK')"
+# Native loader dlopens the bare name PCBUSB
+python3 -c "import ctypes; ctypes.CDLL('PCBUSB'); print('PCBUSB load OK')"
+
+# Real runtime check (can0 maps to PCAN_USBBUS1 on macOS)
+motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 --timeout-ms 300
 ```
 
 </TabItem>
@@ -587,7 +606,7 @@ motorbridge-gateway --bind 127.0.0.1:9002
 または
 
 ```bash
-DYLD_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
+DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
 ```
 
 #### RS モーター制御パラメータの初期化

--- a/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_isaacsim.md
+++ b/sites/ja/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/ja_reBot_Arm_B601_RS_isaacsim.md
@@ -11,10 +11,10 @@ keywords:
 image: https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/reBot_Arm_RS_isaacsim.jpg
 slug: /rebot_arm_b601_rs_isaacsim
 last_update:
-  date: 7/7/2026
-  author: LiShanghang
+  date: 8/14/2026
+  author: LiuJunjie
 createdAt: '2026-07-07'
-updatedAt: '2026-07-09'
+updatedAt: '2026-08-14'
 url: https://wiki.seeedstudio.com/ja/rebot_arm_b601_rs_isaacsim/
 ---
 
@@ -74,6 +74,7 @@ cd ~/isaacsim
 ```Bash
 export ISAACSIM_PATH="${HOME}/isaacsim"
 export ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
+export ISAACSIM_ROOT="${HOME}/isaacsim"
 ```
 
 その後 `source ~/.bashrc` を実行して反映させます。
@@ -115,18 +116,43 @@ cd IsaacSim
 _build/linux-x86_64/release/isaac-sim.sh
 ```
 
-## プロジェクトのダウンロード
-
-```Bash
-git clone https://github.com/Seeed-Projects/reBot-Isaacsim.git
-```
-
-reBotArm_control_py の uv 環境を構成する
+ソースからビルドした場合は、`run_isaacsim_receiver.sh` が Isaac Sim を見つけられるよう `ISAACSIM_ROOT` をその実行ディレクトリに設定します:
 
 ```bash
-cd third_party/reBotArm_control_py
+export ISAACSIM_ROOT="$PWD/_build/linux-x86_64/release"
+```
+
+## プロジェクトのダウンロード
+
+このリポジトリは上流の制御ライブラリ `reBotArm_control_py` を git submodule として参照します。サブモジュール付きでクローンしてください:
+
+```bash
+git clone --recurse-submodules https://github.com/Seeed-Projects/reBot-Isaacsim.git
+```
+
+すでにクローン済みで `third_party/reBotArm_control_py` が空の場合:
+
+```bash
+git submodule update --init --recursive
+```
+
+リポジトリルートで sender の依存関係をインストールします（`run_sender.sh` と `uv run` はルートの uv ワークスペースを使用します）:
+
+```bash
+cd reBot-Isaacsim
 uv sync
 ```
+
+### ハードウェア設定を RS に切り替える
+
+このリポジトリの Isaac Sim アセットは RS（`usd/RS-rebot-dev-arm`）です。上流の `rebotarm.yaml` はデフォルトで DM です。`RebotArm()` と `load_robot_model()` の両方がこのファイルを読むため、重力補償、読み取り専用マッピング、IK、Traj は先に RS へ切り替える必要があります。DM のままだとモータプロトコルが合わず、Pinocchio も DM の URDF を読みます。submodule の作業ツリーだけが汚れるので、コミットしないでください:
+
+```bash
+cd reBotArm_Isaacsim
+python set_hw_rs.py
+```
+
+成功すると `.../config/rebotarm.yaml -> rebotarm_rs.yaml` と表示されます。
 
 ### 機能コンポーネントの概要
 
@@ -134,7 +160,7 @@ uv sync
 
 | コンポーネント | 説明 |
 |-----------|------------|
-| `gravity_joint_sender` | **重力補償ハンドルモード**: 改造済みロボットアーム（クローを取り外し、ハンドルを追加）を重力補償モードで手動操作し、その関節角度を Isaac Sim にリアルタイムで同期します |
+| `gravity_joint_sender` | **重力補償ハンドルモード**: 改造済みロボットアーム（クローを取り外し、ハンドルを追加）を手動操作します。補償は上流の `GravityCompensation` が行い、本リポジトリは関節角度を Isaac Sim にミラーするだけです |
 | `isaacsim_ik_sender` | **逆運動学 (IK) モード**: エンドエフェクタの姿勢を入力し、IK ソルバで関節角度を算出して Isaac Sim に送信します |
 | `isaacsim_traj_sender` | **軌道計画 (Traj) モード**: IK の上に関節空間の軌道計画（MIN_JERK 時間プロファイル）を追加し、スムーズな動作制御を実現します |
 | `isaacsim_joint_test_sender` | **関節テストモード**: 実機ロボットなしで、あらかじめ設定された関節角度軌道を送信し、Isaac Sim の receiver と通信が正しく動作しているかを検証します |
@@ -144,26 +170,27 @@ uv sync
 
 ```
 reBot-Isaacsim/
-├── pyproject.toml                      # uv workspace configuration
+├── pyproject.toml                           # uv ワークスペース設定
 ├── README.md
 ├── README_EN.md
-├── reBotArm_Isaacsim/                  # Main example directory
-│   ├── gravity_joint_sender.py         # Gravity compensation handle mode (modified robotic arm, manual manipulation)
-│   ├── isaacsim_ik_sender.py           # Inverse kinematics mode (IK control)
-│   ├── isaacsim_traj_sender.py         # Trajectory planning mode (IK joint space trajectory)
-│   ├── isaacsim_joint_test_sender.py   # Joint test mode (preset trajectory, no hardware needed)
-│   ├── joint_reader_sender.py          # Real-to-Sim mapping mode (read-only joints, sync visualization)
-│   ├── isaacsim_joint_receiver.py      # Isaac Sim receiver (joint angle synchronization)
-│   ├── live_sync.py                    # Startup instruction script
-│   ├── run_sender.sh # Start sender
-│   └── run_isaacsim_receiver.sh        # Start Isaac Sim receiver
+├── README_ES.md
+├── reBotArm_Isaacsim/                       # メインのサンプルディレクトリ
+│   ├── gravity_joint_sender.py              # 重力補償ハンドルモード（上流 GravityCompensation + UDP）
+│   ├── isaacsim_ik_sender.py                # 逆運動学モード（IK 制御）
+│   ├── isaacsim_traj_sender.py              # 軌道計画モード（IK + 関節空間軌道）
+│   ├── isaacsim_joint_test_sender.py        # 関節テストモード（プリセット軌道、ハードウェア不要）
+│   ├── joint_reader_sender.py                # Real-to-Sim マッピングモード（読み取り専用、同期可視化）
+│   ├── isaacsim_joint_receiver.py           # Isaac Sim 受信側（関節角度同期）
+│   ├── live_sync.py                         # 起動手順の補助スクリプト
+│   ├── set_hw_rs.py                         # submodule のハードウェア YAML を RS に向ける（ローカル; コミットしない）
+│   ├── run_sender.sh                        # sender を起動
+│   └── run_isaacsim_receiver.sh             # Isaac Sim receiver を起動
+├── .gitmodules
 ├── third_party/
-│   └── reBotArm_control_py/            # Core control library (separate uv environment)
-│       ├── pyproject.toml
-│       └── ...
+│   └── reBotArm_control_py/                 # git submodule: 上流制御ライブラリ
 └── usd/
     └── RS-rebot-dev-arm/
-        └── 00-arm-rs_asm-v3.usda       # Isaac Sim robotic arm asset
+        └── RS-rebot-dev-arm.usda            # Isaac Sim ロボットアセット
 ```
 
 ## 起動方法（デュアルターミナルモード）
@@ -214,16 +241,15 @@ cd reBotArm_Isaacsim
 uv run python isaacsim_joint_test_sender.py
 ```
 
-sender は、いくつかの事前定義された関節構成間を連続的に補間し、それらを Isaac Sim に送信します。CAN 接続は不要です。
+sender は複数の事前定義された関節構成間を連続的に補間し、それらを Isaac Sim に送信します。ハードウェア YAML は読まないため、`set_hw_rs.py` も CAN も不要です。
 
 #### ② 逆運動学モード (`isaacsim_ik_sender`)
 
-エンドエフェクタの姿勢（位置/姿勢）を入力します。IK ソルバが関節構成を計算し、Isaac Sim 上のロボットアームを駆動します。
-
-`reBotArm_Isaacsim/` ディレクトリから次を実行します:
+エンドエフェクタの姿勢（位置/姿勢）を入力します。IK ソルバが関節構成を計算し、Isaac Sim 内のロボットアームを駆動します。`load_robot_model()` は submodule の `rebotarm.yaml` を読むため、先に RS へ切り替えてください:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_ik_sender.py
 ```
 
@@ -238,12 +264,11 @@ gripper <0~1>               # Update gripper only
 
 #### ③ 軌道計画モード (`isaacsim_traj_sender`)
 
-IK の上に関節空間の軌道計画（MIN_JERK）を追加し、ロボットのスムーズな動作を実現します。
-
-`reBotArm_Isaacsim/` ディレクトリから次を実行します:
+IK の上に関節空間の軌道計画（MIN_JERK）を追加し、ロボットのスムーズな動作を実現します。同じく `load_robot_model()` がその YAML を読むため、先に RS へ切り替えてください:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_traj_sender.py
 ```
 
@@ -264,29 +289,32 @@ resync                      # Re-read the current joint state from Isaac Sim
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 ./run_sender.sh
 ```
 
 **期待される動作:**
-- 実機ロボットアームに接続し、重力フィードフォワード補償付き MIT 制御を有効化する
-- ロボットアームを手で自由に動かすことができる
-- 関節角度が UDP により 60 Hz で連続送信される
+- `set_hw_rs.py` が submodule の `rebotarm.yaml` を `rebotarm_rs.yaml` に向け、モータと重力モデルが同じ YAML を共有します（ローカル変更; コミットしない）
+- 実機アームに接続し、上流の `GravityCompensation` を起動します（`example/9` と同じ MIT + `g(q)` フィードフォワード）
+- アームを手で自由に動かすことができます
+- このスクリプトは関節角度を 60 Hz で UDP 経由で Isaac Sim に転送するだけです
+- 上流の `example/9` を同時に実行しないでください。2 つのプロセスが CAN を奪い合います
 
 #### ⑤ 実機からシミュレーションへのマッピングモード (`joint_reader_sender`)
 
-関節角度のみを読み取り、実機ロボットの状態を Isaac Sim にミラーリングします。このモードは、実機ロボットが別のアプリケーションによって制御されている間の可視化を目的としています。
-
-`reBotArm_Isaacsim/` ディレクトリから次を実行します:
+関節角度のみを読み取り、実機ロボットの状態を Isaac Sim 内にミラーリングします。このモードは、実機が別のアプリケーションによって制御されている間の可視化を目的としています。`RebotArm()` は submodule の `rebotarm.yaml` を読むため、先に RS へ切り替えてください:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python joint_reader_sender.py
 ```
 
 **期待される動作:**
-- 関節角度のみを読み取る（パッシブフィードバックモード）だけで、制御コマンドは一切送信しない
-- 関節角度を UDP により 60 Hz で連続送信する
-- 別のプロジェクトによって制御されている間、Isaac Sim 上で実機ロボットを可視化する
+- `set_hw_rs.py` がモータ設定を RS に切り替えます（ローカル変更; コミットしない）
+- 制御コマンドを一切送信せず、関節角度のみを読み取る（パッシブフィードバックモード）
+- 関節角度を 60 Hz で UDP により連続送信する
+- 別プロジェクトによって制御されている実機ロボットを、Isaac Sim 上で可視化する
 
 ## 通信プロトコル
 
@@ -307,12 +335,19 @@ UDP JSON（ポート `127.0.0.1:5005`）を使用します。
 |------|------|------|
 | `sequence` | int | インクリメントされるフレームシーケンス番号 |
 | `timestamp` | float | Unix タイムスタンプ（秒） |
-| `joint_positions` | float[6] | 最初の 6 つの関節位置（rad） |
-| `gripper_position` | float | 送信側で `GRIPPER_POSITION_SCALE=0.03` を用いて変換されたグリッパ位置（m） |
+| `joint_positions` | float[6] | 最初の 6 関節の位置（rad） |
+| `gripper_position` | float | グリッパ指の位置目標（m）。各 sender が独自の換算で算出します（下表参照） |
 
 **グリッパ制御パイプライン：**
 
-送信側 `gripper_q` → `gripper_position = -gripper_q × 0.03` → 受信側 `× 0.01` → デュアルジョイント位置ターゲット
+受信側は受け取った `gripper_position` を左右の直動関節の位置目標としてそのまま適用し、指ごとに `[0, 上限]` にクリップします（USD 上限: 両指とも 0.05 m。両指は 1 つのモータとピニオンで 1:1 駆動）。受信側での追加スケーリングはありません。各 sender から `gripper_position` への換算は次のとおりです:
+
+| Sender | `gripper_position`（m）への換算 |
+|------|------|
+| `gravity_joint_sender` | `gripper_q × 0.03`（`GRIPPER_POSITION_SCALE = 0.03`） |
+| `joint_reader_sender` | `gripper_q × 0.007`（`GRIPPER_POSITION_SCALE = 0.007`） |
+| `isaacsim_traj_sender` | `ratio × 0.045`（`gripper <0~1>` 入力、0.045 m にクリップ） |
+| `isaacsim_ik_sender` | 生の `ratio ∈ [0, 1]` をメートルとして送信。ratio が指の上限以上ならその指は全開 |
 
 ## 設定パラメータ
 
@@ -320,6 +355,7 @@ UDP JSON（ポート `127.0.0.1:5005`）を使用します。
 
 | パラメータ | デフォルト | 説明 |
 |------|--------|------|
+| ハードウェア YAML | `set_hw_rs.py` → `rebotarm_rs.yaml` | `RebotArm()` は submodule の `config/rebotarm.yaml` を読む。モータと Pinocchio が共有する |
 | `ARM_JOINT_COUNT` | 6 | アーム関節数 |
 | `DEFAULT_PORT` | 5005 | UDP ポート |
 | `DEFAULT_SEND_HZ` | 60.0 | 送信周波数（Hz） |
@@ -333,9 +369,8 @@ UDP JSON（ポート `127.0.0.1:5005`）を使用します。
 | `ARM_JOINT_COUNT` | 6 | アーム関節数 |
 | `DEFAULT_PORT` | 5005 | UDP ポート |
 | `DEFAULT_RENDER_HZ` | 120.0 | シミュレーション描画周波数（Hz） |
-| `GRIPPER_POSITION_SCALE` | 0.01 | 追加のグリッパ位置スケーリング係数 |
 | `ROBOT_PRIM_PATH` | `/World/reBotArm` | Isaac Sim 内の Robot Prim パス |
-| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda` | USD アセットへの相対パス |
+| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda` | USD アセットへの相対パス |
 
 ## トラブルシューティング
 
@@ -356,7 +391,7 @@ kill <PID>
 USD アセットが存在し、`REPO_ROOT` が正しく設定されていることを確認します：
 
 ```bash
-ls usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda
+ls usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda
 ```
 
 ### CAN バスが Ready にならない

--- a/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_Getting_Started.md
@@ -15,10 +15,10 @@ slug: /rebot_b601_rs_getting_started
 translation:
   skip: [zh-CN]
 last_update:
-  date: 2026-07-28
+  date: 2026-08-17
   author: LiuJunjie
 createdAt: '2026-05-26'
-updatedAt: '2026-08-03'
+updatedAt: '2026-08-17'
 url: https://wiki.seeedstudio.com/pt-br/rebot_b601_rs_getting_started/
 ---
 
@@ -358,25 +358,44 @@ cd PCBUSB
 sudo ./install.sh
 ```
 
-Configure `DYLD_LIBRARY_PATH` para garantir que o motorbridge-gateway possa encontrar a biblioteca PCBUSB em tempo de execução. Crie um script de ativação no ambiente conda para que ele tenha efeito automaticamente sempre que você executar `conda activate rebot`:
+O `install.sh` só cria `libPCBUSB.dylib`. O loader nativo do motorbridge faz `dlopen` do nome simples `PCBUSB`, então adicione este symlink. Sem ele, conectar o braço falha com `load PCBUSB failed` mesmo quando um check ctypes de `libPCBUSB.dylib` teria passado:
+
+```zsh
+sudo ln -sf /usr/local/lib/libPCBUSB.dylib /usr/local/lib/PCBUSB
+```
+
+Configure `DYLD_FALLBACK_LIBRARY_PATH` para o motorbridge-gateway encontrar o PCBUSB em tempo de execução. Prefira FALLBACK a `DYLD_LIBRARY_PATH`: este último sobrescreve a ordem de busca padrão do dyld para o processo inteiro e pode quebrar outro software. Crie um script de ativação no ambiente conda para valer automaticamente sempre que você executar `conda activate rebot`:
 
 ```bash
 mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"
 cat > "$CONDA_PREFIX/etc/conda/activate.d/env_vars.sh" << 'EOF'
-export DYLD_LIBRARY_PATH="/usr/local/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH="/usr/local/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 EOF
 
-echo $DYLD_LIBRARY_PATH
+echo $DYLD_FALLBACK_LIBRARY_PATH
 ```
 
-Verifique se está pronto:
+Opcional, sem sudo (máquinas compartilhadas): instale em `~/.local/lib`. Se você tiver a árvore de código do motorbridge:
+
+```bash
+./scripts/setup_pcbusb_macos.sh --user-local
+ln -sf "$HOME/.local/lib/libPCBUSB.dylib" "$HOME/.local/lib/PCBUSB"
+```
+
+Aponte o script de ativação do conda para `$HOME/.local/lib` em vez de `/usr/local/lib`.
+
+Verifique se está pronto. Conecte primeiro o adaptador PCAN. `ctypes.CDLL('libPCBUSB.dylib')` não é uma verificação de runtime válida — o motorbridge nunca carrega esse nome.
+
 ```zsh
 # Check Python package and CLI are ready
 python3 -c "import motorbridge; print('motorbridge OK')"
 motorbridge-cli --help
 
-# Optional: Check if PCBUSB runtime is loadable
-python3 -c "import ctypes; ctypes.CDLL('libPCBUSB.dylib'); print('PCBUSB load OK')"
+# Native loader dlopens the bare name PCBUSB
+python3 -c "import ctypes; ctypes.CDLL('PCBUSB'); print('PCBUSB load OK')"
+
+# Real runtime check (can0 maps to PCAN_USBBUS1 on macOS)
+motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 --timeout-ms 300
 ```
 
 </TabItem>
@@ -587,7 +606,7 @@ motorbridge-gateway --bind 127.0.0.1:9002
 ou
 
 ```bash
-DYLD_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
+DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
 ```
 
 #### Inicializar parâmetros de controle do motor RS

--- a/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_isaacsim.md
+++ b/sites/pt-BR/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/pt_reBot_Arm_B601_RS_isaacsim.md
@@ -11,10 +11,10 @@ keywords:
 image: https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/reBot_Arm_RS_isaacsim.jpg
 slug: /rebot_arm_b601_rs_isaacsim
 last_update:
-  date: 7/7/2026
-  author: LiShanghang
+  date: 8/14/2026
+  author: LiuJunjie
 createdAt: '2026-07-07'
-updatedAt: '2026-07-09'
+updatedAt: '2026-08-14'
 url: https://wiki.seeedstudio.com/pt-br/rebot_arm_b601_rs_isaacsim/
 ---
 
@@ -74,6 +74,7 @@ Adicione o seguinte a `~/.bashrc` ou `~/.zshrc`:
 ```Bash
 export ISAACSIM_PATH="${HOME}/isaacsim"
 export ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
+export ISAACSIM_ROOT="${HOME}/isaacsim"
 ```
 
 Em seguida, execute `source ~/.bashrc` para que tenha efeito.
@@ -115,18 +116,43 @@ O processo de compilação pode levar de 30 a 60 minutos, dependendo do seu hard
 _build/linux-x86_64/release/isaac-sim.sh
 ```
 
-## Baixar o projeto
-
-```Bash
-git clone https://github.com/Seeed-Projects/reBot-Isaacsim.git
-```
-
-Configurar o ambiente uv do reBotArm_control_py
+Após uma compilação a partir do código-fonte, aponte `ISAACSIM_ROOT` para esse diretório de execução para que `run_isaacsim_receiver.sh` encontre o Isaac Sim:
 
 ```bash
-cd third_party/reBotArm_control_py
+export ISAACSIM_ROOT="$PWD/_build/linux-x86_64/release"
+```
+
+## Baixar o projeto
+
+Este repositório referencia a biblioteca de controle upstream `reBotArm_control_py` como git submodule. Clone com os submódulos:
+
+```bash
+git clone --recurse-submodules https://github.com/Seeed-Projects/reBot-Isaacsim.git
+```
+
+Se você já clonou o repositório e `third_party/reBotArm_control_py` estiver vazio:
+
+```bash
+git submodule update --init --recursive
+```
+
+Instale as dependências do sender na raiz do repositório (`run_sender.sh` e `uv run` usam o workspace uv da raiz):
+
+```bash
+cd reBot-Isaacsim
 uv sync
 ```
+
+### Alternar a configuração de hardware para RS
+
+O asset do Isaac Sim deste repositório é RS (`usd/RS-rebot-dev-arm`). O `rebotarm.yaml` upstream usa DM por padrão. Tanto `RebotArm()` quanto `load_robot_model()` leem este arquivo, então compensação de gravidade, mapeamento somente leitura, IK e Traj precisam de RS primeiro; se ficar em DM, o protocolo dos motores não coincidirá e o Pinocchio carregará o URDF de DM. Isso apenas suja o working tree do submodule — não faça commit:
+
+```bash
+cd reBotArm_Isaacsim
+python set_hw_rs.py
+```
+
+Em caso de sucesso, imprime `.../config/rebotarm.yaml -> rebotarm_rs.yaml`.
 
 ### Visão geral dos componentes funcionais
 
@@ -134,7 +160,7 @@ Este projeto fornece vários senders para atender a diferentes cenários de uso:
 
 | Componente | Descrição |
 |-----------|------------|
-| `gravity_joint_sender` | **Modo de manuseio com compensação de gravidade**: braço robótico modificado (garra removida, alça adicionada) permite movimento manual em modo de compensação de gravidade e sincroniza os ângulos das juntas com o Isaac Sim em tempo real |
+| `gravity_joint_sender` | **Modo de compensação de gravidade + alça**: para braços modificados (garra removida, alça acoplada); a compensação vem do `GravityCompensation` upstream e este repositório apenas espelha os ângulos das juntas no Isaac Sim |
 | `isaacsim_ik_sender` | **Modo de cinemática inversa (IK)**: insira a pose do efetuador final, use o solucionador de IK para obter os ângulos das juntas e envie-os para o Isaac Sim |
 | `isaacsim_traj_sender` | **Modo de planejamento de trajetória (Traj)**: adiciona planejamento de trajetória no espaço de juntas (perfil de tempo MIN_JERK) sobre o IK para obter controle de movimento suave |
 | `isaacsim_joint_test_sender` | **Modo de teste de juntas**: envia trajetórias de ângulos de juntas predefinidas sem um robô real para verificar se o receptor e a comunicação do Isaac Sim estão funcionando corretamente |
@@ -144,26 +170,27 @@ Este projeto fornece vários senders para atender a diferentes cenários de uso:
 
 ```
 reBot-Isaacsim/
-├── pyproject.toml                      # uv workspace configuration
+├── pyproject.toml                           # Configuração do workspace uv
 ├── README.md
 ├── README_EN.md
-├── reBotArm_Isaacsim/                  # Main example directory
-│   ├── gravity_joint_sender.py         # Gravity compensation handle mode (modified robotic arm, manual manipulation)
-│   ├── isaacsim_ik_sender.py           # Inverse kinematics mode (IK control)
-│   ├── isaacsim_traj_sender.py         # Trajectory planning mode (IK joint space trajectory)
-│   ├── isaacsim_joint_test_sender.py   # Joint test mode (preset trajectory, no hardware needed)
-│   ├── joint_reader_sender.py          # Real-to-Sim mapping mode (read-only joints, sync visualization)
-│   ├── isaacsim_joint_receiver.py      # Isaac Sim receiver (joint angle synchronization)
-│   ├── live_sync.py                    # Startup instruction script
-│   ├── run_sender.sh # Start sender
-│   └── run_isaacsim_receiver.sh        # Start Isaac Sim receiver
+├── README_ES.md
+├── reBotArm_Isaacsim/                       # Diretório principal de exemplos
+│   ├── gravity_joint_sender.py              # Modo alça (GravityCompensation upstream + UDP)
+│   ├── isaacsim_ik_sender.py                # Modo de cinemática inversa (controle IK)
+│   ├── isaacsim_traj_sender.py              # Modo de planejamento de trajetória (IK + trajetória no espaço de juntas)
+│   ├── isaacsim_joint_test_sender.py        # Modo de teste de juntas (trajetória predefinida, sem hardware)
+│   ├── joint_reader_sender.py                # Modo de mapeamento Real-to-Sim (somente leitura, visualização sincronizada)
+│   ├── isaacsim_joint_receiver.py           # Receptor do Isaac Sim (sincronização de ângulos das juntas)
+│   ├── live_sync.py                         # Script auxiliar com instruções de inicialização
+│   ├── set_hw_rs.py                         # Aponta o YAML de hardware do submodule para RS (local; não fazer commit)
+│   ├── run_sender.sh                        # Inicia o sender
+│   └── run_isaacsim_receiver.sh             # Inicia o receptor do Isaac Sim
+├── .gitmodules
 ├── third_party/
-│   └── reBotArm_control_py/            # Core control library (separate uv environment)
-│       ├── pyproject.toml
-│       └── ...
+│   └── reBotArm_control_py/                 # git submodule: biblioteca de controle upstream
 └── usd/
     └── RS-rebot-dev-arm/
-        └── 00-arm-rs_asm-v3.usda       # Isaac Sim robotic arm asset
+        └── RS-rebot-dev-arm.usda            # Asset do robô para Isaac Sim
 ```
 
 ## Inicialização (modo de dois terminais)
@@ -214,16 +241,15 @@ cd reBotArm_Isaacsim
 uv run python isaacsim_joint_test_sender.py
 ```
 
-O sender interpola continuamente entre várias configurações de juntas predefinidas e as transmite para o Isaac Sim. Nenhuma conexão CAN é necessária.
+O sender interpola continuamente entre várias configurações de juntas predefinidas e as transmite para o Isaac Sim. Não lê o YAML de hardware, então nem `set_hw_rs.py` nem CAN são necessários.
 
 #### ② Modo de cinemática inversa (`isaacsim_ik_sender`)
 
-Insira uma pose do efetuador final (posição/orientação). O solucionador de IK calcula a configuração das juntas e move o braço robótico no Isaac Sim.
-
-Execute o seguinte a partir do diretório `reBotArm_Isaacsim/`:
+Insira uma pose do efetuador final (posição/orientação). O solucionador de IK calcula a configuração das juntas e move o braço robótico no Isaac Sim. `load_robot_model()` lê o `rebotarm.yaml` do submodule, então mude para RS primeiro:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_ik_sender.py
 ```
 
@@ -238,12 +264,11 @@ gripper <0~1>               # Update gripper only
 
 #### ③ Modo de planejamento de trajetória (`isaacsim_traj_sender`)
 
-Adiciona planejamento de trajetória no espaço de juntas (MIN_JERK) sobre o IK para um movimento suave do robô.
-
-Execute o seguinte a partir do diretório `reBotArm_Isaacsim/`:
+Adiciona planejamento de trajetória no espaço de juntas (MIN_JERK) sobre o IK para um movimento suave do robô. Também usa `load_robot_model()` contra esse YAML, então mude para RS primeiro:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_traj_sender.py
 ```
 
@@ -264,26 +289,29 @@ Projetado para braços robóticos modificados (garra removida e alça instalada)
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 ./run_sender.sh
 ```
 
 **Comportamento esperado:**
-- Conectar ao braço robótico físico e habilitar o controle MIT com compensação de gravidade feedforward
-- O braço robótico pode ser movido livremente à mão
-- Os ângulos das juntas são continuamente transmitidos via UDP a 60 Hz
+- `set_hw_rs.py` aponta o `rebotarm.yaml` do submodule para `rebotarm_rs.yaml` para que motores e o modelo de gravidade usem o mesmo YAML (alteração local; não fazer commit)
+- O braço físico conecta e inicia o `GravityCompensation` upstream (mesmo MIT + feed-forward `g(q)` que o `example/9`)
+- O braço pode ser movido livremente à mão
+- Este script apenas encaminha os ângulos das juntas para o Isaac Sim via UDP a 60 Hz
+- Não execute também o `example/9` upstream ao mesmo tempo; os dois processos disputariam o CAN
 
 #### ⑤ Modo de mapeamento Real-para-Sim (`joint_reader_sender`)
 
-Lê apenas os ângulos das juntas e espelha o estado do robô físico no Isaac Sim. Este modo é destinado à visualização enquanto o robô real é controlado por outra aplicação.
-
-Execute o seguinte a partir do diretório `reBotArm_Isaacsim/`:
+Lê apenas os ângulos das juntas e espelha o estado do robô físico no Isaac Sim. Este modo é destinado à visualização enquanto o robô real é controlado por outra aplicação. `RebotArm()` lê o `rebotarm.yaml` do submodule, então mude para RS primeiro:
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python joint_reader_sender.py
 ```
 
 **Comportamento esperado:**
+- `set_hw_rs.py` altera a configuração dos motores para RS (alteração local; não fazer commit)
 - Ler apenas os ângulos das juntas (modo de feedback passivo), sem enviar nenhum comando de controle
 - Transmitir continuamente os ângulos das juntas via UDP a 60 Hz
 - Visualizar o robô físico no Isaac Sim enquanto ele é controlado por outro projeto
@@ -307,12 +335,19 @@ UDP JSON na porta `127.0.0.1:5005`.
 |------|------|------|
 | `sequence` | int | Número de sequência de quadro incremental |
 | `timestamp` | float | Timestamp Unix (segundos) |
-| `joint_positions` | float[6] | Primeiras seis posições das juntas (rad) |
-| `gripper_position` | float | Posição do gripper (m), convertida pelo remetente usando `GRIPPER_POSITION_SCALE=0.03` |
+| `joint_positions` | float[6] | Primeiras seis posições de juntas (rad) |
+| `gripper_position` | float | Alvo de posição dos dedos da garra (m); cada sender calcula com o próprio mapeamento (veja abaixo) |
 
 **Pipeline de controle do gripper:**
 
-Remetente `gripper_q` → `gripper_position = -gripper_q × 0.03` → Receptor `× 0.01` → Alvo de posição de junta dupla
+O receptor aplica o `gripper_position` recebido diretamente como alvo de posição das duas juntas prismáticas dos dedos, recortado por dedo para `[0, limite superior]` (limites superiores do USD: 0,05 m em ambos os dedos; os dedos são acionados 1:1 por um único motor através de um pinhão). Não há escala extra no lado do receptor. Os senders convertem a entrada para `gripper_position` da seguinte forma:
+
+| Sender | Conversão para `gripper_position` (m) |
+|------|------|
+| `gravity_joint_sender` | `gripper_q × 0.03` (`GRIPPER_POSITION_SCALE = 0.03`) |
+| `joint_reader_sender` | `gripper_q × 0.007` (`GRIPPER_POSITION_SCALE = 0.007`) |
+| `isaacsim_traj_sender` | `ratio × 0.045` (entrada `gripper <0~1>`, recortado para 0,045 m) |
+| `isaacsim_ik_sender` | `ratio ∈ [0, 1]` bruto enviado como metros, de modo que qualquer ratio ≥ o limite superior de um dedo abre esse dedo por completo |
 
 ## Parâmetros de Configuração
 
@@ -320,6 +355,7 @@ Remetente `gripper_q` → `gripper_position = -gripper_q × 0.03` → Receptor `
 
 | Parâmetro | Padrão | Descrição |
 |------|--------|------|
+| YAML de hardware | `set_hw_rs.py` → `rebotarm_rs.yaml` | `RebotArm()` lê `config/rebotarm.yaml` do submodule; motores e Pinocchio compartilham |
 | `ARM_JOINT_COUNT` | 6 | Número de juntas do braço |
 | `DEFAULT_PORT` | 5005 | Porta UDP |
 | `DEFAULT_SEND_HZ` | 60.0 | Frequência de transmissão (Hz) |
@@ -333,9 +369,8 @@ Remetente `gripper_q` → `gripper_position = -gripper_q × 0.03` → Receptor `
 | `ARM_JOINT_COUNT` | 6 | Número de juntas do braço |
 | `DEFAULT_PORT` | 5005 | Porta UDP |
 | `DEFAULT_RENDER_HZ` | 120.0 | Frequência de renderização da simulação (Hz) |
-| `GRIPPER_POSITION_SCALE` | 0.01 | Fator adicional de escala da posição do gripper |
 | `ROBOT_PRIM_PATH` | `/World/reBotArm` | Caminho do Prim do robô no Isaac Sim |
-| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda` | Caminho relativo para o asset USD |
+| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda` | Caminho relativo para o asset USD |
 
 ## Solução de Problemas
 
@@ -356,7 +391,7 @@ kill <PID>
 Verifique se o asset USD existe e se `REPO_ROOT` está configurado corretamente:
 
 ```bash
-ls usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda
+ls usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda
 ```
 
 ### Barramento CAN Não Pronto

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
@@ -15,10 +15,10 @@ slug: /rebot_b601_rs_getting_started
 translation:
   skip: [zh-CN]
 last_update:
-  date: 2026-07-28
+  date: 2026-08-17
   author: LiuJunjie
 createdAt: '2026-05-26'
-updatedAt: '2026-07-28'
+updatedAt: '2026-08-17'
 url: https://wiki.seeedstudio.com/cn/rebot_b601_rs_getting_started/
 ---
 import '/src/css/rebot-wiki-style.css';
@@ -343,7 +343,7 @@ sudo ip link set $PCAN_IF up
 
 </TabItem>
 <TabItem value="macos" label="macos">
-libPCBUSB.dylib 无法加载，请先安装 PCBUSB
+`libPCBUSB.dylib` 无法加载时，请先安装 PCBUSB：
 
 ```bash
 curl -L -o macOS_Library_for_PCANUSB_v0.13.tar.gz \
@@ -353,25 +353,44 @@ cd PCBUSB
 sudo ./install.sh
 ```
 
-配置 `DYLD_LIBRARY_PATH`，确保 motorbridge-gateway 运行时能找到 PCBUSB 库。在 conda 环境中创建激活脚本，每次 `conda activate rebot` 自动生效：
+`install.sh` 只会安装 `libPCBUSB.dylib`。motorbridge 的原生加载器 `dlopen` 的是裸名 `PCBUSB`，因此需要补这个符号链接。否则即使 `libPCBUSB.dylib` 的 ctypes 检查能通过，连接机械臂仍会报 `load PCBUSB failed`：
+
+```bash
+sudo ln -sf /usr/local/lib/libPCBUSB.dylib /usr/local/lib/PCBUSB
+```
+
+配置 `DYLD_FALLBACK_LIBRARY_PATH`，确保 motorbridge-gateway 运行时能找到 PCBUSB 库。请优先使用 FALLBACK，不要用 `DYLD_LIBRARY_PATH`：后者会覆盖整个进程的 dyld 默认搜索顺序，可能影响其他软件。在 conda 环境中创建激活脚本，每次 `conda activate rebot` 自动生效：
 
 ```bash
 mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"
 cat > "$CONDA_PREFIX/etc/conda/activate.d/env_vars.sh" << 'EOF'
-export DYLD_LIBRARY_PATH="/usr/local/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH="/usr/local/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 EOF
 
-echo $DYLD_LIBRARY_PATH
+echo $DYLD_FALLBACK_LIBRARY_PATH
 ```
 
-检查是否就绪
+可选、无需 sudo（适合共用开发机）：安装到 `~/.local/lib`。若本地已有 motorbridge 源码树：
+
+```bash
+./scripts/setup_pcbusb_macos.sh --user-local
+ln -sf "$HOME/.local/lib/libPCBUSB.dylib" "$HOME/.local/lib/PCBUSB"
+```
+
+将上面 conda 激活脚本中的路径改为 `$HOME/.local/lib`，而不是 `/usr/local/lib`。
+
+检查是否就绪。请先插入 PCAN 适配器。`ctypes.CDLL('libPCBUSB.dylib')` 不能作为运行时检查，motorbridge 实际不会加载这个名字。
+
 ```bash
 # 检查 Python 包和 CLI 是否就绪
 python3 -c "import motorbridge; print('motorbridge OK')"
 motorbridge-cli --help
 
-# 可选：检查 PCBUSB 运行时是否可加载
-python3 -c "import ctypes; ctypes.CDLL('libPCBUSB.dylib'); print('PCBUSB load OK')"
+# 原生加载器 dlopen 的是裸名 PCBUSB
+python3 -c "import ctypes; ctypes.CDLL('PCBUSB'); print('PCBUSB load OK')"
+
+# 真实运行时检查（macOS 上 can0 对应 PCAN_USBBUS1）
+motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 --timeout-ms 300
 ```
 
 </TabItem>
@@ -587,7 +606,7 @@ or
 
 
 ```bash
-DYLD_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
+DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
 ```
 
 #### 初始化 RS 电机控制参数

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_isaacsim.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_isaacsim.md
@@ -11,10 +11,10 @@ keywords:
 image: https://files.seeedstudio.com//wiki/robotics/projects/rebot_arm/reBot_Arm_RS_isaacsim.webp
 slug: /rebot_arm_b601_rs_isaacsim
 last_update:
-  date: 7/7/2026
-  author: LiShanghang
+  date: 8/14/2026
+  author: LiuJunjie
 createdAt: '2026-07-07'
-updatedAt: '2026-07-09'
+updatedAt: '2026-08-14'
 url: https://wiki.seeedstudio.com/cn/rebot_arm_b601_rs_isaacsim/
 ---
 
@@ -69,6 +69,7 @@ cd ~/isaacsim
 ```Bash
 export ISAACSIM_PATH="${HOME}/isaacsim"
 export ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
+export ISAACSIM_ROOT="${HOME}/isaacsim"
 ```
 
 然后执行 `source ~/.bashrc` 使其生效。
@@ -110,18 +111,43 @@ cd IsaacSim
 _build/linux-x86_64/release/isaac-sim.sh
 ```
 
-## 下载项目
-
-```Bash
-git clone https://github.com/Seeed-Projects/reBot-Isaacsim.git
-```
-
-配置 reBotArm_control_py 的 uv 环境
+源码构建完成后，将 `ISAACSIM_ROOT` 指向该运行目录，供 `run_isaacsim_receiver.sh` 使用：
 
 ```bash
-cd third_party/reBotArm_control_py
+export ISAACSIM_ROOT="$PWD/_build/linux-x86_64/release"
+```
+
+## 下载项目
+
+本仓通过 git submodule 引用上游控制库 `reBotArm_control_py`。克隆时需一并拉取子模块：
+
+```bash
+git clone --recurse-submodules https://github.com/Seeed-Projects/reBot-Isaacsim.git
+```
+
+若已经 clone 过且 `third_party/reBotArm_control_py` 为空：
+
+```bash
+git submodule update --init --recursive
+```
+
+在仓库根目录安装发送端依赖（`run_sender.sh` 与 `uv run` 都使用根目录的 uv 工作空间）：
+
+```bash
+cd reBot-Isaacsim
 uv sync
 ```
+
+### 将硬件配置切到 RS
+
+本仓 Isaac Sim 资产是 RS（`usd/RS-rebot-dev-arm`）。上游 `rebotarm.yaml` 默认是 DM。`RebotArm()` 和 `load_robot_model()` 都读这一份，所以重力补偿、只读映射、IK、Traj 都要先切到 RS；不切的话电机协议会对不上，Pinocchio 也会用 DM URDF。只改 submodule 工作区，不要提交：
+
+```bash
+cd reBotArm_Isaacsim
+python set_hw_rs.py
+```
+
+成功时会打印 `.../config/rebotarm.yaml -> rebotarm_rs.yaml`。
 
 ### 功能组件概览
 
@@ -129,7 +155,7 @@ uv sync
 
 | 组件 | 说明 |
 |------|------|
-| `gravity_joint_sender` | **重力补偿手柄模式**：改装机械臂（拆卸夹爪，加装手柄），通过重力补偿模式允许手动掰动，实时同步关节角到 Isaac Sim |
+| `gravity_joint_sender` | **重力补偿手柄模式**：改装机械臂（拆卸夹爪，加装手柄），手动掰动；补偿由上游 `GravityCompensation` 提供，本仓只镜像关节角到 Isaac Sim |
 | `isaacsim_ik_sender` | **逆运动学（IK）模式**：输入末端位姿，通过 IK 求解器得到关节角，发送到 Isaac Sim |
 | `isaacsim_traj_sender` | **轨迹规划（Traj）模式**：在 IK 基础上增加关节空间轨迹规划（MIN_JERK 时间剖面），实现平滑运动控制 |
 | `isaacsim_joint_test_sender` | **关节测试模式**：无需真实机械臂，发送预设关节角轨迹，用于验证 Isaac Sim 接收端和通讯是否正常 |
@@ -142,23 +168,24 @@ reBot-Isaacsim/
 ├── pyproject.toml                           # uv 工作空间配置
 ├── README.md
 ├── README_EN.md
+├── README_ES.md
 ├── reBotArm_Isaacsim/                       # 主示例目录
-│   ├── gravity_joint_sender.py              # 重力补偿手柄模式（改装机械臂，手动掰动）
+│   ├── gravity_joint_sender.py              # 重力补偿手柄模式（调用上游 GravityCompensation + UDP）
 │   ├── isaacsim_ik_sender.py                # 逆运动学模式（IK 控制）
 │   ├── isaacsim_traj_sender.py              # 轨迹规划模式（IK + 关节空间轨迹）
 │   ├── isaacsim_joint_test_sender.py        # 关节测试模式（预设轨迹，无需硬件）
 │   ├── joint_reader_sender.py                # Real-to-Sim 映射模式（只读关节，同步可视化）
 │   ├── isaacsim_joint_receiver.py           # Isaac Sim 接收端（关节角同步）
 │   ├── live_sync.py                         # 启动说明脚本
+│   ├── set_hw_rs.py                         # 将 submodule 硬件配置切到 RS（本机，勿提交）
 │   ├── run_sender.sh                        # 启动发送端
 │   └── run_isaacsim_receiver.sh             # 启动 Isaac Sim 接收端
+├── .gitmodules
 ├── third_party/
-│   └── reBotArm_control_py/                 # 核心控制库（独立 uv 环境）
-│       ├── pyproject.toml
-│       └── ...
+│   └── reBotArm_control_py/                 # git submodule：上游控制库
 └── usd/
     └── RS-rebot-dev-arm/
-        └── 00-arm-rs_asm-v3.usda            # Isaac Sim 机械臂资产
+        └── RS-rebot-dev-arm.usda            # Isaac Sim 机械臂资产
 ```
 
 
@@ -209,14 +236,15 @@ cd reBotArm_Isaacsim
 uv run python isaacsim_joint_test_sender.py
 ```
 
-测试发送端在几个预设关节姿态之间缓慢插值循环发送，无需 CAN 连接。
+测试发送端在几个预设关节姿态之间缓慢插值循环发送，不读硬件 YAML，无需 `set_hw_rs.py` 或 CAN。
 
 #### ② 逆运动学模式（`isaacsim_ik_sender`）
 
-输入末端位姿（位置/姿态），IK 求解后驱动 Isaac Sim 仿真机械臂。在 `reBotArm_Isaacsim/` 目录下直接 `uv run`：
+输入末端位姿（位置/姿态），IK 求解后驱动 Isaac Sim 仿真机械臂。`load_robot_model()` 读 submodule 的 `rebotarm.yaml`，需先切到 RS：
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_ik_sender.py
 ```
 
@@ -230,10 +258,11 @@ gripper <0~1>                # 单独更新夹爪
 
 #### ③ 轨迹规划模式（`isaacsim_traj_sender`）
 
-在 IK 基础上增加关节空间轨迹规划（MIN_JERK），实现平滑运动。在 `reBotArm_Isaacsim/` 目录下直接 `uv run`：
+在 IK 基础上增加关节空间轨迹规划（MIN_JERK），实现平滑运动。同样通过 `load_robot_model()` 读那份 YAML，需先切到 RS：
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python isaacsim_traj_sender.py
 ```
 
@@ -253,24 +282,29 @@ resync                       # 重新从仿真端读取当前关节角
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 ./run_sender.sh
 ```
 
 **预期行为：**
-- 连接真实机械臂，启用 MIT + 重力前馈补偿
+- `set_hw_rs.py` 把 submodule 的 `rebotarm.yaml` 指到 `rebotarm_rs.yaml`，电机和重力模型共用这一份（本机改动，勿提交）
+- 连接真实机械臂，启动上游 `GravityCompensation`（与 `example/9` 同一套 MIT + `g(q)` 前馈）
 - 机械臂可自由掰动
-- 关节角以 60 Hz 持续通过 UDP 发送
+- 本脚本只把关节角以 60 Hz 通过 UDP 发给 Isaac Sim
+- 不要同时再运行上游 `example/9`，以免抢 CAN
 
 #### ⑤ Real-to-Sim 映射模式（`joint_reader_sender`）
 
-只读关节角并映射到 Isaac Sim，适合实际机械臂在运行其他任务时同步映射可视化。在 `reBotArm_Isaacsim/` 目录下直接 `uv run`：
+只读关节角并映射到 Isaac Sim，适合实际机械臂在运行其他任务时同步映射可视化。`RebotArm()` 读 submodule 的 `rebotarm.yaml`，需先切到 RS：
 
 ```bash
 cd reBotArm_Isaacsim
+python set_hw_rs.py
 uv run python joint_reader_sender.py
 ```
 
 **预期行为：**
+- `set_hw_rs.py` 把电机配置切到 RS（本机改动，勿提交）
 - 仅读取关节角（被动反馈模式），不发送任何控制指令
 - 关节角以 60 Hz 持续通过 UDP 发送
 - 实际机械臂由其他项目控制时，可同时在 Isaac Sim 中可视化
@@ -295,10 +329,17 @@ UDP JSON，端口 `127.0.0.1:5005`。
 | `sequence` | int | 递增序号 |
 | `timestamp` | float | Unix 时间戳（秒） |
 | `joint_positions` | float[6] | 前 6 个关节角（rad） |
-| `gripper_position` | float | 夹爪位置（m），由发送端通过 `GRIPPER_POSITION_SCALE=0.03` 转换 |
+| `gripper_position` | float | 夹爪指位置目标（m），各发送端有各自的换算方式（见下表） |
 
 **夹爪控制链：**
-发送端 `gripper_q` → `gripper_position = -gripper_q × 0.03` → 接收端 `× 0.01` → 双关节位置目标
+接收端将收到的 `gripper_position` 直接作为左右两个滑动关节的位置目标，并按各指裁剪到 `[0, 上限]`（USD 上限：两指均为 0.05 m；两指由同一电机通过单个小齿轮驱动，行程严格 1:1）。接收端不做额外缩放。各发送端到 `gripper_position` 的换算如下：
+
+| 发送端 | 到 `gripper_position`（m）的换算 |
+|------|------|
+| `gravity_joint_sender` | `gripper_q × 0.03`（`GRIPPER_POSITION_SCALE = 0.03`） |
+| `joint_reader_sender` | `gripper_q × 0.007`（`GRIPPER_POSITION_SCALE = 0.007`） |
+| `isaacsim_traj_sender` | `ratio × 0.045`（`gripper <0~1>` 输入，裁剪到 0.045 m） |
+| `isaacsim_ik_sender` | 原始 `ratio ∈ [0, 1]` 直接按米发送，因此 ratio ≥ 某指上限时该指完全打开 |
 
 ## 配置参数
 
@@ -306,6 +347,7 @@ UDP JSON，端口 `127.0.0.1:5005`。
 
 | 参数 | 默认值 | 说明 |
 |------|--------|------|
+| 硬件 YAML | `set_hw_rs.py` → `rebotarm_rs.yaml` | `RebotArm()` 读取 submodule `config/rebotarm.yaml`；电机与 Pinocchio 共用 |
 | `ARM_JOINT_COUNT` | 6 | 关节数 |
 | `DEFAULT_PORT` | 5005 | UDP 端口 |
 | `DEFAULT_SEND_HZ` | 60.0 | 发送频率（Hz） |
@@ -319,9 +361,8 @@ UDP JSON，端口 `127.0.0.1:5005`。
 | `ARM_JOINT_COUNT` | 6 | 关节数 |
 | `DEFAULT_PORT` | 5005 | UDP 端口 |
 | `DEFAULT_RENDER_HZ` | 120.0 | 仿真渲染频率（Hz） |
-| `GRIPPER_POSITION_SCALE` | 0.01 | 夹爪位置再缩放系数 |
 | `ROBOT_PRIM_PATH` | `/World/reBotArm` | Isaac Sim 中的机械臂 Prim 路径 |
-| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda` | USD 资产相对路径 |
+| `ASSET_RELATIVE_PATH` | `usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda` | USD 资产相对路径 |
 
 
 ## 常见问题
@@ -343,7 +384,7 @@ kill <PID>
 确认 USD 资产路径存在，或检查 `REPO_ROOT` 是否正确：
 
 ```bash
-ls usd/RS-rebot-dev-arm/00-arm-rs_asm-v3.usda
+ls usd/RS-rebot-dev-arm/RS-rebot-dev-arm.usda
 ```
 
 ### CAN 总线未就绪


### PR DESCRIPTION
## Summary
- Sync `update-rs` with the latest `docusaurus-version` from Seeed-Studio/wiki-documents
- Update EN/ES/JA/PT-BR/ZH Isaac Sim wiki for reBot Arm B601-RS: clone with git submodules, switch hardware YAML to RS via `set_hw_rs.py`, and document the current gripper UDP protocol
- Fix B601-RS getting started macOS PCAN-USB setup for current motorbridge ([#5363](https://github.com/Seeed-Studio/wiki-documents/issues/5363)): add the bare-name `PCBUSB` symlink, use `DYLD_FALLBACK_LIBRARY_PATH`, document a no-sudo `~/.local/lib` install, and verify with `motorbridge-cli scan` instead of `ctypes.CDLL('libPCBUSB.dylib')`

Fixes #5363

## Test plan
- [ ] Confirm EN/CN/ES/JA/PT-BR Isaac Sim pages render without broken headings or leftover conflict markers
- [ ] Follow clone + `uv sync` + `set_hw_rs.py` steps against Seeed-Projects/reBot-Isaacsim
- [ ] Check sender/receiver command blocks still match the repo layout (`run_sender.sh`, `run_isaacsim_receiver.sh`, USD path `RS-rebot-dev-arm.usda`)
- [ ] On macOS, after `install.sh`, confirm `sudo ln -sf /usr/local/lib/libPCBUSB.dylib /usr/local/lib/PCBUSB` is documented
- [ ] Confirm conda activate script and gateway one-liner use `DYLD_FALLBACK_LIBRARY_PATH`, not `DYLD_LIBRARY_PATH`
- [ ] Confirm the ctypes check uses `PCBUSB` and the real check is `motorbridge-cli scan`