### PR TITLE
Fix: ma_deploy_yolov8 + pin ultralytics to v8.2.8

### DIFF
--- a/sites/en/docs/Topics/TinyML/ModelAssistant/deploy/ma_deploy_yolov8.md
+++ b/sites/en/docs/Topics/TinyML/ModelAssistant/deploy/ma_deploy_yolov8.md
@@ -40,9 +40,9 @@ Install the `ultralytics` package, or by running `pip install -U ultralytics`. P
 
 ```bash
 # Install using pip
-pip install ultralytics
+pip install ultralytics==8.2.8
 # Chinese users can use mirror acceleration
-# pip install ultralytics -i https://pypi.tuna.tsinghua.edu.cn/simple
+# pip install ultralytics==8.2.8 -i https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 </TabItem>
@@ -53,7 +53,7 @@ pip install ultralytics
 
 ```bash
 # Install using conda
-conda install -c conda-forge ultralytics
+conda install -c conda-forge ultralytics=8.2.8
 ```
 
 </TabItem>
@@ -64,7 +64,7 @@ Clone `ultralytics` If you are interested in participating in development, or wi
 
 ```bash
 # Clone the official repository
-git clone https://github.com/ultralytics/ultralytics
+git clone -b v8.2.8 https://github.com/ultralytics/ultralytics
 
 # Go into the cloned folder
 cd ultralytics


### PR DESCRIPTION
## Summary

Pin the Ultralytics install commands in the "Install YOLOv8 command line tool" section to a fixed version `8.2.8`. Previously the three install methods (pip / conda / Git) had no version constraint, so `pip install ultralytics` would pull the latest release, which can drift from the rest of the tutorial.

## Changes

- **pip**: `pip install ultralytics` → `pip install ultralytics==8.2.8` (mirror line updated too)
- **conda**: `conda install -c conda-forge ultralytics` → `conda install -c conda-forge ultralytics=8.2.8`
- **Git**: `git clone https://github.com/ultralytics/ultralytics` → `git clone -b v8.2.8 https://github.com/ultralytics/ultralytics`

## File

`ma_deploy_yolov8.md` (Model Assistant → deploy)
