### PR TITLE
docs(Grove-Barometer-BMP280): update resources from Eagle to KiCad

### DIFF
--- a/sites/en/docs/Sensor/Grove/Grove_Sensors/Barometer/Grove-Barometer_Sensor-BMP280.md
+++ b/sites/en/docs/Sensor/Grove/Grove_Sensors/Barometer/Grove-Barometer_Sensor-BMP280.md
@@ -253,13 +253,11 @@ void loop()
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/Grove-Barometer_Sensor-BMP280/img/outcome.png" alt="pir" width={600} height="auto" /></p>
 
 
-## Schematic Online Viewer
-<div className="altium-ecad-viewer" data-project-src="https://files.seeedstudio.com/wiki/Grove-Barometer_Sensor-BMP280/res/Grove%20-%20Barometer%20Sensor_BMP280_Schematic.zip" style={{borderRadius: '0px 0px 4px 4px', height: 500, borderStyle: 'solid', borderWidth: 1, borderColor: 'rgb(241, 241, 241)', overflow: 'hidden', maxWidth: 1280, maxHeight: 700, boxSizing: 'border-box'}}>
-</div>
-
 ## Resources
 
-- **[Eagle]** [Grove-Barometer Sensor BMP280 Schematic](https://files.seeedstudio.com/wiki/Grove-Barometer_Sensor-BMP280/res/Grove%20-%20Barometer%20Sensor_BMP280_Schematic.zip)
+<!-- - **[Eagle]** [Grove-Barometer Sensor BMP280 Schematic](https://files.seeedstudio.com/wiki/Grove-Barometer_Sensor-BMP280/res/Grove%20-%20Barometer%20Sensor_BMP280_Schematic.zip) -->
+- **[KiCad]** [Grove-Barometer Sensor (BMP280) v1.0 Schematic (PDF)](https://files.seeedstudio.com/wiki/Grove-Barometer_Sensor-BMP280/res/Grove-Barometer_Sensor-BMP280-v1.0_SCH_20260820.pdf)
+- **[KiCad]** [Grove-Barometer Sensor (BMP280) v1.0 Schematic & PCB](https://files.seeedstudio.com/wiki/Grove-Barometer_Sensor-BMP280/res/Grove-Barometer_Sensor-BMP280-v1.0_SCH-PCB_20260820.zip)
 - **[Datasheet]** [BMP280 Datasheet](https://files.seeedstudio.com/wiki/Grove-Barometer_Sensor-BMP280/res/Grove-Barometer_Sensor-BMP280-BMP280-DS001-12_Datasheet.pdf)
 - **[References]**  [I<sup>2</sup>C how-to for Arduino](https://www.arduino.cc/en/Reference/Wire)
 


### PR DESCRIPTION
## Summary

The Grove - Barometer Sensor (BMP280) project was re-created in KiCad (previously Eagle). This PR updates the Resources section to point to the KiCad design files.

## Changes

- Removed the `## Schematic Online Viewer` section — the `altium-ecad-viewer` component does not support KiCad files (`.kicad_sch` / `.kicad_pcb`), which renders as a blank view.
- Replaced the Eagle schematic resource with:
  - KiCad schematic (PDF): `Grove-Barometer_Sensor-BMP280-v1.0_SCH_20260820.pdf`
  - KiCad schematic & PCB project: `Grove-Barometer_Sensor-BMP280-v1.0_SCH-PCB_20260820.zip`