### PR TITLE
docs: add MeshTracker X2 Meshtastic page

### DIFF
--- a/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X2/x2_get_started_for_meshtastic.md
+++ b/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X2/x2_get_started_for_meshtastic.md
@@ -1,0 +1,4 @@
+---
+title: SenseCAP MeshTracker X2 for Meshtastic
+slug: /x2_get_started_for_meshtastic
+---

--- a/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X2/x2_get_started_for_meshtastic.md
+++ b/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X2/x2_get_started_for_meshtastic.md
@@ -1,4 +1,7 @@
 ---
 title: SenseCAP MeshTracker X2 for Meshtastic
 slug: /x2_get_started_for_meshtastic
+last_update:
+  date: 8/28/2026
+  author: Seeed Studio
 ---

--- a/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X2/x2_get_started_for_meshtastic.md
+++ b/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X2/x2_get_started_for_meshtastic.md
@@ -1,5 +1,5 @@
 ---
-title: SenseCAP MeshTracker X2 for Meshtastic
+title: Get Started with MeshPager X2
 slug: /x2_get_started_for_meshtastic
 last_update:
   date: 8/28/2026

--- a/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X2/x2_get_started_for_meshtastic.md
+++ b/sites/en/docs/Network/Meshtastic_Network/MeshTracker_X2/x2_get_started_for_meshtastic.md
@@ -3,5 +3,5 @@ title: SenseCAP MeshTracker X2 for Meshtastic
 slug: /x2_get_started_for_meshtastic
 last_update:
   date: 8/28/2026
-  author: Seeed Studio
+  author: Yves
 ---


### PR DESCRIPTION
## Summary

- add an empty MeshTracker X2 Meshtastic documentation page
- reserve the `/x2_get_started_for_meshtastic/` wiki URL

## Verification

- `git diff --cached --check` passed before commit
- confirmed the PR contains only the new page file