### PR TITLE
Update: T1000-E for LoRaWAN add MeshCore to firmware flash warning

### DIFF
--- a/sites/en/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/lorawan_tracker_with_ses.md
+++ b/sites/en/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/lorawan_tracker_with_ses.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/LoRaWAN_Tracker/lorawan_opens
 slug: /open_source_lorawan
 sidebar_position: 3
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-01-09'
 updatedAt: '2026-02-04'
 url: https://wiki.seeedstudio.com/open_source_lorawan/
@@ -18,7 +18,7 @@ url: https://wiki.seeedstudio.com/open_source_lorawan/
 ## Preparation
 
 :::caution note
-Before flashing the firmware, please ensure you device is `T1000-E for LoRaWAN` version and please don't flash other Meshtastic firmware to this tracker model, it may cause the device to be completely dead.
+Before flashing the firmware, please ensure you device is `T1000-E for LoRaWAN` version and please don't flash other Meshtastic or MeshCore firmware to this tracker model, it may cause the device to be completely dead.
 :::
 
 ### Hardware Preparation

--- a/sites/en/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/t1000_e_arduino_examples.md
+++ b/sites/en/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/t1000_e_arduino_examples.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/t1000_e_arduino_ex
 slug: /t1000_e_arduino_examples
 sidebar_position: 4
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-03-24'
 updatedAt: '2026-02-04'
 url: https://wiki.seeedstudio.com/t1000_e_arduino_examples/
@@ -16,7 +16,7 @@ url: https://wiki.seeedstudio.com/t1000_e_arduino_examples/
 
 
 :::caution note
-Before flashing the firmware, please ensure you device is `T1000-E for LoRaWAN` version and please don't flash other Meshtastic firmware to this tracker model, it may cause the device to be completely dead.
+Before flashing the firmware, please ensure you device is `T1000-E for LoRaWAN` version and please don't flash other Meshtastic or MeshCore firmware to this tracker model, it may cause the device to be completely dead.
 :::
 
 The following Arduino examples are available:

--- a/sites/en/docs/Sensor/SenseCAP/LoRaWAN_Tracker/introduction.md
+++ b/sites/en/docs/Sensor/SenseCAP/LoRaWAN_Tracker/introduction.md
@@ -9,8 +9,8 @@ slug: /t1000e_for_lorawan_introduction
 sku: 114993591
 sidebar_position: 1
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2026-01-09'
 updatedAt: '2026-05-21'
 url: https://wiki.seeedstudio.com/t1000e_for_lorawan_introduction/
@@ -33,7 +33,7 @@ Available customization options: logo branding, packaging, and firmware flashing
 T1000-E for LoRaWAN comes with fully open-source firmware. To enhance the user experience, we provide demo firmware pre-installed on factory-produced devices. Users can explore the demo firmware for an initial experience and also develop your own custom firmware. For details on custom development, please refer to the [LoRaWAN Open Source Firmware](https://wiki.seeedstudio.com/open_source_lorawan/).
 
 :::caution note
-Before flashing the firmware, please ensure you device is `T1000-E for LoRaWAN` version and please don't flash other Meshtastic firmware to this tracker model, it may cause the device to be completely dead.
+Before flashing the firmware, please ensure you device is `T1000-E for LoRaWAN` version and please don't flash other Meshtastic or MeshCore firmware to this tracker model, it may cause the device to be completely dead.
 :::
 
 **T1000 Series Version Comparison**

--- a/sites/es/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/es_lorawan_tracker_with_ses.md
+++ b/sites/es/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/es_lorawan_tracker_with_ses.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/LoRaWAN_Tracker/lorawan_opens
 slug: /open_source_lorawan
 sidebar_position: 3
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-09-03'
 updatedAt: '2026-02-04'
 url: https://wiki.seeedstudio.com/es/open_source_lorawan/
@@ -18,7 +18,7 @@ url: https://wiki.seeedstudio.com/es/open_source_lorawan/
 ## Preparación
 
 :::caution note
-Antes de flashear el firmware, asegúrese de que su dispositivo sea la versión `T1000-E for LoRaWAN` y por favor no flashee otro firmware Meshtastic a este modelo de tracker, puede causar que el dispositivo quede completamente inoperativo.
+Antes de flashear el firmware, asegúrese de que su dispositivo sea la versión `T1000-E for LoRaWAN` y por favor no flashee otro firmware Meshtastic o MeshCore a este modelo de tracker, puede causar que el dispositivo quede completamente inoperativo.
 :::
 
 ### Preparación de Hardware

--- a/sites/es/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/es_t1000_e_arduino_examples.md
+++ b/sites/es/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/es_t1000_e_arduino_examples.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/t1000_e_arduino_ex
 slug: /t1000_e_arduino_examples
 sidebar_position: 4
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-09-03'
 updatedAt: '2026-02-04'
 url: https://wiki.seeedstudio.com/es/t1000_e_arduino_examples/
@@ -16,7 +16,7 @@ url: https://wiki.seeedstudio.com/es/t1000_e_arduino_examples/
 
 
 :::caution note
-Antes de flashear el firmware, asegúrese de que su dispositivo sea la versión `T1000-E for LoRaWAN` y por favor no flashee otro firmware de Meshtastic a este modelo de tracker, ya que puede causar que el dispositivo quede completamente inoperativo.
+Antes de flashear el firmware, asegúrese de que su dispositivo sea la versión `T1000-E for LoRaWAN` y por favor no flashee otro firmware de Meshtastic o MeshCore a este modelo de tracker, ya que puede causar que el dispositivo quede completamente inoperativo.
 :::
 
 Los siguientes ejemplos de Arduino están disponibles:

--- a/sites/es/docs/Sensor/SenseCAP/LoRaWAN_Tracker/es_introduction.md
+++ b/sites/es/docs/Sensor/SenseCAP/LoRaWAN_Tracker/es_introduction.md
@@ -9,8 +9,8 @@ slug: /t1000e_for_lorawan_introduction
 sku: 114993591
 sidebar_position: 1
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2026-01-09'
 updatedAt: '2026-05-21'
 url: https://wiki.seeedstudio.com/es/t1000e_for_lorawan_introduction/
@@ -33,7 +33,7 @@ Opciones de personalización disponibles: branding del logotipo, embalaje y flas
 T1000-E para LoRaWAN viene con firmware totalmente de código abierto. Para mejorar la experiencia del usuario, proporcionamos firmware de demostración preinstalado en los dispositivos producidos en fábrica. Los usuarios pueden explorar el firmware de demostración para una experiencia inicial y también desarrollar su propio firmware personalizado. Para obtener detalles sobre el desarrollo personalizado, consulta el [LoRaWAN Open Source Firmware](https://wiki.seeedstudio.com/es/open_source_lorawan/).
 
 :::caution note
-Antes de grabar el firmware, asegúrate de que tu dispositivo sea la versión `T1000-E for LoRaWAN` y no grabes otro firmware Meshtastic en este modelo de rastreador, ya que podría hacer que el dispositivo quede completamente inservible.
+Antes de grabar el firmware, asegúrate de que tu dispositivo sea la versión `T1000-E for LoRaWAN` y no grabes otro firmware Meshtastic o MeshCore en este modelo de rastreador, ya que podría hacer que el dispositivo quede completamente inservible.
 :::
 
 **Comparación de versiones de la Serie T1000**

--- a/sites/ja/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/ja_lorawan_tracker_with_ses.md
+++ b/sites/ja/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/ja_lorawan_tracker_with_ses.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/LoRaWAN_Tracker/lorawan_opens
 slug: /open_source_lorawan
 sidebar_position: 3
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-05-27'
 updatedAt: '2026-02-04'
 url: https://wiki.seeedstudio.com/ja/open_source_lorawan/
@@ -18,7 +18,7 @@ url: https://wiki.seeedstudio.com/ja/open_source_lorawan/
 ## 準備
 
 :::caution note
-ファームウェアをフラッシュする前に、お使いのデバイスが `T1000-E for LoRaWAN` バージョンであることを確認してください。このトラッカーモデルに他の Meshtastic ファームウェアをフラッシュしないでください。デバイスが完全に動作しなくなる可能性があります。
+ファームウェアをフラッシュする前に、お使いのデバイスが `T1000-E for LoRaWAN` バージョンであることを確認してください。このトラッカーモデルに他の Meshtastic または MeshCore ファームウェアをフラッシュしないでください。デバイスが完全に動作しなくなる可能性があります。
 :::
 
 ### ハードウェアの準備

--- a/sites/ja/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/ja_t1000_e_arduino_examples.md
+++ b/sites/ja/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/ja_t1000_e_arduino_examples.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/t1000_e_arduino_ex
 slug: /t1000_e_arduino_examples
 sidebar_position: 4
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-05-27'
 updatedAt: '2026-02-04'
 url: https://wiki.seeedstudio.com/ja/t1000_e_arduino_examples/
@@ -16,7 +16,7 @@ url: https://wiki.seeedstudio.com/ja/t1000_e_arduino_examples/
 
 
 :::caution note
-ファームウェアをフラッシュする前に、お使いのデバイスが `T1000-E for LoRaWAN` バージョンであることを確認し、このトラッカーモデルに他の Meshtastic ファームウェアをフラッシュしないでください。デバイスが完全に動作しなくなる可能性があります。
+ファームウェアをフラッシュする前に、お使いのデバイスが `T1000-E for LoRaWAN` バージョンであることを確認し、このトラッカーモデルに他の Meshtastic または MeshCore ファームウェアをフラッシュしないでください。デバイスが完全に動作しなくなる可能性があります。
 :::
 
 以下の Arduino サンプルが利用可能です：

--- a/sites/ja/docs/Sensor/SenseCAP/LoRaWAN_Tracker/ja_introduction.md
+++ b/sites/ja/docs/Sensor/SenseCAP/LoRaWAN_Tracker/ja_introduction.md
@@ -9,8 +9,8 @@ slug: /t1000e_for_lorawan_introduction
 sku: 114993591
 sidebar_position: 1
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2026-01-09'
 updatedAt: '2026-05-21'
 url: https://wiki.seeedstudio.com/ja/t1000e_for_lorawan_introduction/
@@ -33,7 +33,7 @@ url: https://wiki.seeedstudio.com/ja/t1000e_for_lorawan_introduction/
 LoRaWAN 向け T1000-E は、完全なオープンソースファームウェアを備えています。ユーザー体験を向上させるため、工場出荷時のデバイスにはデモファームウェアをプリインストールしています。ユーザーはまずデモファームウェアで体験したうえで、独自のカスタムファームウェアを開発することもできます。カスタム開発の詳細については、[LoRaWAN Open Source Firmware](https://wiki.seeedstudio.com/ja/open_source_lorawan/) を参照してください。
 
 :::caution note
-ファームウェアを書き込む前に、お使いのデバイスが `T1000-E for LoRaWAN` バージョンであることを必ず確認し、このトラッカーモデルに他の Meshtastic ファームウェアを書き込まないでください。デバイスが完全に動作不能になる可能性があります。
+ファームウェアを書き込む前に、お使いのデバイスが `T1000-E for LoRaWAN` バージョンであることを必ず確認し、このトラッカーモデルに他の Meshtastic または MeshCore ファームウェアを書き込まないでください。デバイスが完全に動作不能になる可能性があります。
 :::
 
 **T1000 シリーズ バージョン比較**

--- a/sites/pt-BR/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/pt_lorawan_tracker_with_ses.md
+++ b/sites/pt-BR/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/pt_lorawan_tracker_with_ses.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/LoRaWAN_Tracker/lorawan_opens
 slug: /open_source_lorawan
 sidebar_position: 3
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-01-09'
 updatedAt: '2026-03-16'
 url: https://wiki.seeedstudio.com/pt-br/open_source_lorawan/
@@ -18,7 +18,7 @@ url: https://wiki.seeedstudio.com/pt-br/open_source_lorawan/
 ## Preparação
 
 :::caution note
-Antes de gravar o firmware, certifique-se de que seu dispositivo é a versão `T1000-E for LoRaWAN` e não grave outro firmware Meshtastic neste modelo de tracker, pois isso pode fazer com que o dispositivo pare de funcionar completamente.
+Antes de gravar o firmware, certifique-se de que seu dispositivo é a versão `T1000-E for LoRaWAN` e não grave outro firmware Meshtastic ou MeshCore neste modelo de tracker, pois isso pode fazer com que o dispositivo pare de funcionar completamente.
 :::
 
 ### Preparação de Hardware

--- a/sites/pt-BR/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/pt_t1000_e_arduino_examples.md
+++ b/sites/pt-BR/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/pt_t1000_e_arduino_examples.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/t1000_e_arduino_ex
 slug: /t1000_e_arduino_examples
 sidebar_position: 4
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-03-24'
 updatedAt: '2026-03-16'
 url: https://wiki.seeedstudio.com/pt-br/t1000_e_arduino_examples/
@@ -16,7 +16,7 @@ url: https://wiki.seeedstudio.com/pt-br/t1000_e_arduino_examples/
 
 
 :::caution note
-Antes de gravar o firmware, certifique-se de que seu dispositivo é a versão `T1000-E for LoRaWAN` e não grave outro firmware Meshtastic neste modelo de rastreador, pois isso pode fazer com que o dispositivo fique completamente inutilizado.
+Antes de gravar o firmware, certifique-se de que seu dispositivo é a versão `T1000-E for LoRaWAN` e não grave outro firmware Meshtastic ou MeshCore neste modelo de rastreador, pois isso pode fazer com que o dispositivo fique completamente inutilizado.
 :::
 
 Os seguintes exemplos de Arduino estão disponíveis:

--- a/sites/pt-BR/docs/Sensor/SenseCAP/LoRaWAN_Tracker/pt_introduction.md
+++ b/sites/pt-BR/docs/Sensor/SenseCAP/LoRaWAN_Tracker/pt_introduction.md
@@ -9,8 +9,8 @@ slug: /t1000e_for_lorawan_introduction
 sku: 114993591
 sidebar_position: 1
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2026-01-09'
 updatedAt: '2026-05-21'
 url: https://wiki.seeedstudio.com/pt-br/t1000e_for_lorawan_introduction/
@@ -33,7 +33,7 @@ Opções de personalização disponíveis: identidade visual com logotipo, embal
 T1000-E para LoRaWAN vem com firmware totalmente open-source. Para aprimorar a experiência do usuário, fornecemos firmware de demonstração pré-instalado nos dispositivos produzidos em fábrica. Os usuários podem explorar o firmware de demonstração para uma experiência inicial e também desenvolver seu próprio firmware personalizado. Para detalhes sobre desenvolvimento personalizado, consulte o [LoRaWAN Open Source Firmware](https://wiki.seeedstudio.com/pt-br/open_source_lorawan/).
 
 :::caution note
-Antes de gravar o firmware, certifique-se de que seu dispositivo é a versão `T1000-E for LoRaWAN` e não grave outro firmware Meshtastic neste modelo de tracker, pois isso pode fazer com que o dispositivo pare de funcionar completamente.
+Antes de gravar o firmware, certifique-se de que seu dispositivo é a versão `T1000-E for LoRaWAN` e não grave outro firmware Meshtastic ou MeshCore neste modelo de tracker, pois isso pode fazer com que o dispositivo pare de funcionar completamente.
 :::
 
 **Comparação de Versões da Série T1000**

--- a/sites/zh-CN/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/cn_lorawan_tracker_with_ses.md
+++ b/sites/zh-CN/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/cn_lorawan_tracker_with_ses.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/LoRaWAN_Tracker/lorawan_opens
 slug: /open_source_lorawan
 sidebar_position: 3
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-05-30'
 updatedAt: '2026-02-04'
 url: https://wiki.seeedstudio.com/cn/open_source_lorawan/
@@ -18,7 +18,7 @@ url: https://wiki.seeedstudio.com/cn/open_source_lorawan/
 ## 准备工作
 
 :::caution note
-在刷写固件之前，请确保您的设备是 `T1000-E for LoRaWAN` 版本，请不要将其他 Meshtastic 固件刷写到此追踪器型号，这可能导致设备完全损坏。
+在刷写固件之前，请确保您的设备是 `T1000-E for LoRaWAN` 版本，请不要将其他 Meshtastic 或 MeshCore 固件刷写到此追踪器型号，这可能导致设备完全损坏。
 :::
 
 ### 硬件准备

--- a/sites/zh-CN/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/cn_t1000_e_arduino_examples.md
+++ b/sites/zh-CN/docs/Sensor/SenseCAP/LoRaWAN_Tracker/Open_Source_FW/cn_t1000_e_arduino_examples.md
@@ -7,8 +7,8 @@ image: https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/t1000_e_arduino_ex
 slug: /t1000_e_arduino_examples
 sidebar_position: 4
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2025-05-30'
 updatedAt: '2026-02-04'
 url: https://wiki.seeedstudio.com/cn/t1000_e_arduino_examples/
@@ -16,7 +16,7 @@ url: https://wiki.seeedstudio.com/cn/t1000_e_arduino_examples/
 
 
 :::caution note
-在刷写固件之前，请确保您的设备是 `T1000-E for LoRaWAN` 版本，请不要将其他 Meshtastic 固件刷写到此追踪器型号，这可能导致设备完全损坏。
+在刷写固件之前，请确保您的设备是 `T1000-E for LoRaWAN` 版本，请不要将其他 Meshtastic 或 MeshCore 固件刷写到此追踪器型号，这可能导致设备完全损坏。
 :::
 
 以下 Arduino 示例可供使用：

--- a/sites/zh-CN/docs/Sensor/SenseCAP/LoRaWAN_Tracker/cn_introduction.md
+++ b/sites/zh-CN/docs/Sensor/SenseCAP/LoRaWAN_Tracker/cn_introduction.md
@@ -9,8 +9,8 @@ slug: /t1000e_for_lorawan_introduction
 sku: 114993591
 sidebar_position: 1
 last_update:
-  date: 2/4/2026
-  author: Janet
+  date: 9/1/2026
+  author: Advent Jiang
 createdAt: '2026-01-09'
 updatedAt: '2026-05-21'
 url: https://wiki.seeedstudio.com/cn/t1000e_for_lorawan_introduction/
@@ -33,7 +33,7 @@ url: https://wiki.seeedstudio.com/cn/t1000e_for_lorawan_introduction/
 T1000-E for LoRaWAN 搭载完全开源的固件。为提升用户体验，我们在出厂设备中预装了演示固件。用户可以先体验演示固件的功能，也可以开发自己的自定义固件。关于自定义开发的详细信息，请参考 [LoRaWAN Open Source Firmware](https://wiki.seeedstudio.com/cn/open_source_lorawan/)。
 
 :::caution note
-在烧录固件之前，请确保您的设备是 `T1000-E for LoRaWAN` 版本，并且不要将其他 Meshtastic 固件烧录到此追踪器型号上，否则可能导致设备完全损坏。
+在烧录固件之前，请确保您的设备是 `T1000-E for LoRaWAN` 版本，并且不要将其他 Meshtastic 或 MeshCore 固件烧录到此追踪器型号上，否则可能导致设备完全损坏。
 :::
 
 **T1000 系列版本对比**


### PR DESCRIPTION
## Changes
- Add "MeshCore" to the firmware flash warning in the T1000-E for LoRaWAN introduction
- Apply the same warning update to the Arduino examples and SES pages for consistency

## Validation
- Markdown preview: passed