### PR TITLE
fix(reCamera Pro): correct Debian 13 image Google Drive link across 5…

### DIFF
--- a/sites/en/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/recamera_pro_debian13.md
+++ b/sites/en/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/recamera_pro_debian13.md
@@ -10,7 +10,7 @@ slug: /recamera_pro_debian
 sku: 10003420
 sidebar_position: 2
 last_update:
-  date: 09/04/2026
+  date: 09/07/2026
   author: yylin
 createdAt: '2026-08-04'
 updatedAt: '2026-08-04'
@@ -31,7 +31,7 @@ This firmware is currently experimental. Seeed does not maintain it at this time
 
 ### Download the Image
 
-[Download the Debian 13 image from Google Drive](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-Decl8XBZgr7EI/view?usp=drive_link).
+[Download the Debian 13 image from Google Drive](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link).
 
 ### Download the Flashing Tool and Driver
 

--- a/sites/es/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/es_recamera_pro_debian13.md
+++ b/sites/es/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/es_recamera_pro_debian13.md
@@ -10,7 +10,7 @@ slug: /recamera_pro_debian
 sku: 10003420
 sidebar_position: 2
 last_update:
-  date: 09/04/2026
+  date: 09/07/2026
   author: yylin
 createdAt: '2026-08-04'
 updatedAt: '2026-08-04'
@@ -31,7 +31,7 @@ Este firmware es actualmente experimental. Seeed no lo mantiene por el momento; 
 
 ### Descargar la imagen
 
-[Descarga la imagen de Debian 13 desde Google Drive](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-Decl8XBZgr7EI/view?usp=drive_link).
+[Descarga la imagen de Debian 13 desde Google Drive](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link).
 
 ### Descargar la herramienta de flasheo y el controlador
 

--- a/sites/ja/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/ja_recamera_pro_debian13.md
+++ b/sites/ja/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/ja_recamera_pro_debian13.md
@@ -10,7 +10,7 @@ slug: /recamera_pro_debian
 sku: 10003420
 sidebar_position: 2
 last_update:
-  date: 09/04/2026
+  date: 09/07/2026
   author: yylin
 createdAt: '2026-08-04'
 updatedAt: '2026-08-04'
@@ -31,7 +31,7 @@ Debian 13 イメージを書き込んだ後は、CMake を使って独自アプ�
 
 ### イメージをダウンロード
 
-[Google Drive から Debian 13 イメージをダウンロードします](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-Decl8XBZgr7EI/view?usp=drive_link)。
+[Google Drive から Debian 13 イメージをダウンロードします](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link)。
 
 ### 書き込みツールとドライバをダウンロード
 

--- a/sites/pt-BR/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/pt_recamera_pro_debian13.md
+++ b/sites/pt-BR/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/pt_recamera_pro_debian13.md
@@ -10,7 +10,7 @@ slug: /recamera_pro_debian
 sku: 10003420
 sidebar_position: 2
 last_update:
-  date: 09/04/2026
+  date: 09/07/2026
   author: yylin
 createdAt: '2026-08-04'
 updatedAt: '2026-08-04'
@@ -31,7 +31,7 @@ Este firmware é atualmente experimental. A Seeed não o mantém neste momento; 
 
 ### Baixar a imagem
 
-[Baixe a imagem Debian 13 do Google Drive](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-Decl8XBZgr7EI/view?usp=drive_link).
+[Baixe a imagem Debian 13 do Google Drive](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link).
 
 ### Baixar a ferramenta de gravação e o driver
 

--- a/sites/zh-CN/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/cn_recamera_pro_debian13.md
+++ b/sites/zh-CN/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/cn_recamera_pro_debian13.md
@@ -10,7 +10,7 @@ slug: /recamera_pro_debian
 sku: 10003420
 sidebar_position: 2
 last_update:
-  date: 09/04/2026
+  date: 09/07/2026
   author: yylin
 createdAt: '2026-08-04'
 updatedAt: '2026-08-04'
@@ -31,7 +31,7 @@ reCamera Pro 由 RV1126B 芯片驱动，提供 2 GB 或 4 GB 内存版本。其�
 
 ### 下载镜像
 
-[从 Google Drive 下载 Debian 13 镜像](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-Decl8XBZgr7EI/view?usp=drive_link)。
+[从 Google Drive 下载 Debian 13 镜像](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link)。
 
 ### 下载烧录工具和驱动
 


### PR DESCRIPTION
… locales

- fix broken Google Drive file ID (missing underscore) so the image download link works
- bump last_update date to 09/07/2026
- en/es/ja/pt-BR/zh-CN