### PR TITLE
Fix: Seeeduino-XIAO.md - define RGB LED power pin

### DIFF
--- a/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_SAMD21/Seeeduino-XIAO.md
+++ b/sites/en/docs/Sensor/SeeedStudio_XIAO/SeeedStudio_XIAO_SAMD21/Seeeduino-XIAO.md
@@ -7,7 +7,7 @@ image: https://files.seeedstudio.com/wiki/Seeeduino-XIAO/img/get_sarted.webp
 slug: /Seeeduino-XIAO
 sku: 110010004, 102010388, 102010328
 last_update:
-  date: 6/30/2026
+  date: 9/7/2026
   author: shuxu hu
 createdAt: '2023-01-16'
 updatedAt: '2026-08-25'
@@ -461,7 +461,7 @@ On the XIAO SAMD21 Plus, the L (LED) pin has been removed. It is replaced by the
 
 <p style={{textAlign: 'center'}}><img src="https://files.seeedstudio.com/wiki/Seeeduino-XIAO/img/gst_2.png" alt="pir" width={800} height="auto" /></p>
 
-‑ Replace the code with the snippet below. The pin for RGB_LED is PA27, which has been redefined as PIN_LED_RGB.
+‑ Replace the code with the snippet below. RGB_LED's data pin is PA27 (PIN_NEOPIXEL). The power-control pin is D11 — please add '#define NEOPIXEL_POWER 11' to your sketch.
 
 :::caution
 
@@ -471,6 +471,7 @@ The RGB LEDs may cause eye strain or injury if operated at excessive brightness;
 
 ```cpp
 #include <Adafruit_NeoPixel.h>
+#define NEOPIXEL_POWER 11
 
 #define NUMPIXELS 1
 


### PR DESCRIPTION
## Summary
- define NEOPIXEL_POWER as D11 in the XIAO SAMD21 Plus Blink example
- align the RGB LED pin description with PIN_NEOPIXEL and document the power-control pin
- update last_update.date to 9/7/2026

## Validation
- yarn build