### PR TITLE
Add XIAO nRF52840 Series display docs (0.96" / 1.14" / 1.47")

### DIFF
--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/_category_.yml
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/_category_.yml
@@ -1,0 +1,4 @@
+position: 3
+label: "XIAO 0.96'' IPS Display (nRF52840)"
+collapsible: true
+collapsed: true

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_0.96_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_0.96_inch_display_nrf52840.md
@@ -1,0 +1,601 @@
+---
+description: Standalone function-level demos for each onboard peripheral of the XIAO 0.96'' IPS Display (nRF52840). Covers screen, IMU, PDM microphone, internal Flash recording and I2S audio playback, buttons, and battery.
+title: Onboard Peripheral Usage
+keywords:
+  - XIAO
+  - nRF52840
+  - Display
+  - LCD
+  - Function
+  - 0.96
+  - I2S
+  - Audio
+image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+slug: /function_0.96_inch_display_nrf52840
+sku: 100063377
+sidebar_label: Function
+sidebar_position: 2
+last_update:
+  date: 08/25/2026
+  author: FaiyuetCik
+createdAt: '2026-08-13'
+updatedAt: '2026-08-24'
+url: https://wiki.seeedstudio.com/function_0.96_inch_display_nrf52840/
+---
+
+# Onboard Peripheral Usage
+
+This page collects standalone function-level demos for each onboard peripheral of the 0.96'' IPS Display. Each section is self-contained — you can pick the one that matches your use case without reading through the others.
+
+:::tip
+The demo GIFs on this page are sped up to keep them short.
+:::
+
+:::note
+All demos in this page require **Seeed nRF52 Boards (1.1.13)** as described in [Getting Started](/getting_started_0.96_inch_display_nrf52840), plus the **Seeed_GFX2** library installed manually as described below.
+:::
+
+- **Library Manager** — go to **Sketch > Include Library > Manage Libraries...**, search for and install:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Library</th><th>Search Keyword</th><th>Author</th><th>Required by</th></tr>
+    <tr><td><strong>Seeed Arduino LSM6DS3</strong></td><td><code>Seeed Arduino LSM6DS3</code></td><td>Seeed Studio</td><td>Quicksand, Wake</td></tr>
+  </table>
+</div>
+
+- **Seeed_GFX2 (Manual Installation)** — this library is not available in Library Manager and must be installed manually:
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Studio/Seeed_GFX2/archive/refs/tags/v1.0.0.zip" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> Download Seeed_GFX2</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+**Step 1.** Click the button above to download `Seeed_GFX2` v1.0.0 as a ZIP file (pinned to a release tag so the tutorial stays reproducible). Alternatively, clone the repository from [Seeed-Studio/Seeed_GFX2](https://github.com/Seeed-Studio/Seeed_GFX2).
+
+**Step 2.** In the Arduino IDE, go to **Sketch > Include Library > Add .ZIP Library...** and select the downloaded ZIP. The IDE reads `library.properties` and installs it into the correct `Seeed_GFX2` folder automatically — you do not need to rename the extracted folder. (To install manually instead, unzip the archive and rename the extracted folder to `Seeed_GFX2` before placing it in `Documents/Arduino/libraries/`.)
+
+**Step 3.** Restart the Arduino IDE so the new library is detected.
+
+:::tip
+- **Seeed_GFX2** is Seeed Studio's graphics library built on a layered `Board` + `Panel Config` architecture. Each demo initializes the display with a single `display.begin<Board_XIAO_0inch96_LCD<38, 37>, Config_Seeed_0inch96_LCD_ST7789>()` call — the **Board** template owns the pin map (CS/DC/SCK/MOSI/RST/BL), and the **Panel Config** bakes in the 80×160 resolution, BGR color order, and rotation 2. Seeed_GFX2 drives this panel with a conservative 10 MHz hardware SPI, which avoids the signal-margin problem that required software SPI in older demos.
+- The 0.96'' IPS Display has **no touch controller and no SD card slot**, so no touch or SD libraries are needed.
+:::
+
+## Getting the Demo Code
+
+Every demo on this page lives in the [Display-Gadgets](https://github.com/Seeed-Projects/Display-Gadgets) repository, under the `code_GFX2/Function/` directory. Each demo is a folder containing a single `.ino` sketch. **Always download the complete folder** rather than copying the `.ino` source from the GitHub web view.
+
+**Option A — Download the repository as a ZIP (recommended):**
+
+1. Open [github.com/Seeed-Projects/Display-Gadgets](https://github.com/Seeed-Projects/Display-Gadgets) and click **Code > Download ZIP**, then extract the archive anywhere convenient.
+2. Navigate into `code_GFX2/Function/` and open the folder shown in each demo's **Code location** line. For example, the GraphicTest demo for this board lives in `code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_graphictest/`.
+3. **Double-click the `.ino` file** to open it in the Arduino IDE.
+
+**Option B — git clone:**
+
+```sh
+git clone https://github.com/Seeed-Projects/Display-Gadgets.git
+```
+
+Then open the demo's `.ino` file from the cloned `code_GFX2/Function/...` folder.
+
+## Screen Display — GraphicTest
+
+This demo runs a full graphics benchmark on the 0.96-inch ST7789 IPS panel (80×160), covering color bars, lines, rectangles, circles, triangles, rounded rectangles, text, and a pixel gradient. Use it to verify that the screen is wired correctly and that all draw calls work as expected.
+
+**Code location:** `code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_graphictest/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_graphictest" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The sketch initializes the ST7789 IPS panel via **Seeed_GFX2**, then runs through ten graphics primitives in sequence, measuring the execution time of each one via `micros()` and printing the result to the serial monitor.
+
+The display is initialized with a single template call:
+
+```cpp
+display.begin<Board_XIAO_0inch96_LCD<38, 37>,
+              Config_Seeed_0inch96_LCD_ST7789>();
+```
+
+The **Board** template owns the pin map — CS=D2, DC=D3, SCK=D8, MOSI=D10 — and its `<RST, BL>` template parameters take bare GPIO numbers, so `<38, 37>` sets RST=GPIO38 and BL=GPIO37. The **Panel Config** bakes in the 80×160 resolution, BGR color order, and rotation 2 — no `driver.h` or manual `invertDisplay()` call is needed. Seeed_GFX2 drives the panel with a conservative 10 MHz hardware SPI, avoiding the signal-margin problem that forced software SPI in older demos.
+
+:::note
+**Color order (BGR panel).** This 0.96-inch panel physically swaps the red and blue channels. The demo aliases colors accordingly (e.g. a wire-level red `0xF800` appears blue on screen). If you write your own drawing code, use the demo's color aliases or account for the BGR order — otherwise reds and blues will appear swapped.
+:::
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_096_graphictest.ino` in Arduino IDE.
+
+**Step 2.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**.
+
+**Step 3.** Click **Upload**.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud). You should see timing output for each test:
+
+```
+=== XIAO nRF52840 Plus 0.96 graphic test ===
+LCD: 80x160
+Color bars: 13.67 ms
+Lines: 1712.89 ms
+Fast lines: 25.39 ms
+Rectangles: 23.44 ms
+Filled rects: 47.85 ms
+Circles: 207.03 ms
+Triangles: 166.99 ms
+Round rects: 48.83 ms
+Text: 539.06 ms
+Pixel gradient: 1907.23 ms
+Graphic test finished.
+```
+
+On the screen, you will see each test pattern displayed for about one second before the next one starts. When all tests complete, a "Done! All tests OK" screen appears.
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_function_graphictest.gif" style={{width:500, height:'auto'}}/></div>
+
+After the sketch runs through all patterns, the screen shows a "Done!" message. Reset the board to run the test again.
+
+---
+
+## IMU
+
+The 0.96'' IPS Display features an onboard 6-axis IMU (**LSM6DS3**) connected via I2C on D4/D5. The motion interrupt line on **D14** supports hardware wake-up and gesture detection.
+
+Both demos below use the LSM6DS3 at I2C address **0x6A**.
+
+<a id="imu-quicksand"></a>
+
+### Demo 1: Electronic Quicksand
+
+This demo turns the screen into an interactive fluid simulation — golden sand particles that flow and settle according to gravity, as measured by the onboard 6-axis IMU. Tilt the board and the sand shifts direction in real time.
+
+**Code location:** `code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_electronic_quicksand/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_electronic_quicksand" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The simulation uses a **13×26 occupancy grid** overlaid on the 80×160 screen, where each cell is 6×6 pixels. Around **65 particles** are placed in the grid, each with a position, velocity, and a golden color gradient.
+
+The IMU is read via I2C (D4/D5) using the Seeed Arduino LSM6DS3 library at address `0x6A`. Raw acceleration values are low-pass filtered and used to derive a gravity vector. When you tilt the board:
+
+1. **Gravity vector updates** — accelerometer data is smoothed with an exponential moving average to avoid jitter.
+2. **Particle velocity** — each particle accelerates in the direction of the gravity vector, with damping and a per-particle mobility factor based on its depth in the flow.
+3. **Cell occupancy** — particles deeper in the flow (closer to the "bottom" relative to gravity) have reduced mobility, creating a realistic packing effect.
+4. **Differential rendering** — only cells where particles moved into or out of are redrawn, minimizing SPI traffic and keeping the animation smooth on the small panel.
+
+Particles near the surface flow freely (higher mobility); particles buried deeper pack tightly (lower mobility) — mimicking how real sand behaves.
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_096_electronic_quicksand.ino` in Arduino IDE.
+
+**Step 2.** Select the board and port, then click **Upload**.
+
+**Step 3.** Once uploaded, the screen fills with golden particles at the bottom. Tilt the board in different directions — the sand flows as if pulled by gravity.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud) to confirm initialization:
+
+```
+LCD w=80 h=160
+=== Electronic Quicksand 0.96 ===
+imu.begin=0
+```
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_function_quicksand.gif" style={{width:500, height:'auto'}}/></div>
+
+The golden sand particles flow smoothly as you tilt the board. When held flat, the sand settles at the bottom of the screen. Rotate the board 90 degrees and the sand flows to the new "bottom" within a second.
+
+---
+
+### Demo 2: Raise to Wake
+
+This demo implements a **screen sleep/wake system** driven by the IMU's built-in motion interrupt on **D14**. The screen automatically turns off (backlight off + nRF52 system ON sleep) after a configurable idle period, and wakes instantly when you pick up or move the device.
+
+**Code location:** `code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_wakeup/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_wakeup" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The demo uses the LSM6DS3's **embedded wake-up event detector** — a hardware feature that monitors accelerometer data internally and asserts the INT1 pin (routed to D14 on this board) when motion exceeds a configurable threshold. This means the MCU does not need to poll the accelerometer continuously.
+
+**IMU configuration (LSM6DS3):**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Register</th><th>Value</th><th>Purpose</th></tr>
+    <tr><td><code>CTRL3_C</code></td><td><code>0x44</code></td><td>Block data update (BDU) + auto-increment</td></tr>
+    <tr><td><code>CTRL1_XL</code></td><td><code>0x40</code></td><td>Accelerometer @ 104 Hz, ±2g</td></tr>
+    <tr><td><code>TAP_CFG</code></td><td><code>0x80</code></td><td>Enable embedded interrupts</td></tr>
+    <tr><td><code>WAKE_UP_THS</code></td><td><code>0x05</code></td><td>Wake-up threshold (medium-low sensitivity)</td></tr>
+    <tr><td><code>WAKE_UP_DUR</code></td><td><code>0x00</code></td><td>No duration filter (responsive wake)</td></tr>
+    <tr><td><code>MD1_CFG</code></td><td><code>0x20</code></td><td>Route wake-up to INT1</td></tr>
+  </table>
+</div>
+
+**Sleep/wake flow:**
+
+1. **Active state** — screen is on, backlight at full brightness, UI refreshes every 250 ms with real-time IMU data.
+2. **Auto-sleep** — after 8 seconds of inactivity, the sketch turns off the backlight, displays a "Sleep — Move to wake" message, and enters nRF52 System ON sleep (low-power mode with RAM retention). The IMU wake interrupt on D14 was already configured at startup, so motion detection remains active during sleep.
+3. **Wake-up** — when the user picks up the board, the IMU detects motion and asserts D14 HIGH. The nRF52840 exits System ON sleep, turns the backlight back on, and redraws the UI — the LCD and IMU keep their state because System ON sleep retains RAM.
+
+**Manual test buttons:**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Pin</th><th>Action</th></tr>
+    <tr><td>USR1</td><td>D6</td><td>Force sleep</td></tr>
+    <tr><td>USR2</td><td>D7</td><td>Force wake</td></tr>
+  </table>
+</div>
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_096_wakeup.ino` in Arduino IDE, select the board and port, and click **Upload**.
+
+**Step 2.** The screen shows a compact dashboard with power state, motion data, and a countdown. Let the board sit still — it will automatically enter sleep after 8 seconds.
+
+**Step 3.** Pick up the board or shake it gently — the screen wakes immediately.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud) to observe the boot and sleep/wake transitions:
+
+```
+=== XIAO nRF52840 Plus 0.96 IMU Wake Demo ===
+[LCD] OK 0.96 ST7789 80x160
+[IMU] LSM6DS3 begin=0
+[IMU] CTRL1_XL    = 0x40
+[IMU] TAP_CFG     = 0x80
+[IMU] MD1_CFG     = 0x20
+[IMU] WAKE_UP_THS = 0x05
+[IMU] D14 wake interrupt OK
+[IMU] D14 pin state = 0
+[BOOT] done. Screen should be on.
+[SLEEP] screen off, entering System ON sleep
+[SLEEP] loops=1 D14=0 awake=N
+[SLEEP] loops=1025 D14=0 awake=N
+[WAKE] D14 pin HIGH (polled)
+[WAKE] src=0xA
+[WAKE] reason=IMU_D14 wakeCount=8 sleptMs=4142 sleepLoops=1936 wakeSrc=0xA
+[WAKE] src=0x0
+```
+
+The `sleptMs`, `sleepLoops`, and `wakeSrc` fields vary depending on how long the board slept and what gesture triggered the wake.
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_function_wakeup.gif" style={{width:500, height:'auto'}}/></div>
+
+The screen displays real-time motion data while awake. After 8 seconds of stillness, the screen goes dark and the nRF52840 enters low-power sleep. Pick up the device and the screen restores instantly, with the wake counter incremented.
+
+---
+
+## Microphone & Speaker — Flash Recorder
+
+This demo turns the 0.96'' IPS Display into a tiny voice recorder. Press USR1 to capture a short clip from the onboard PDM microphone into the nRF52840's internal flash filesystem, then press USR2 to play it back through an external I2S amplifier.
+
+The 0.96'' IPS Display's PDM microphone connects to the same pins as the other XIAO display boards:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Pin</th><th>Signal</th><th>Function</th></tr>
+    <tr><td>D0</td><td>PDM_CLK</td><td>PDM clock output to microphone</td></tr>
+    <tr><td>D1</td><td>PDM_DATA</td><td>PDM data input from microphone</td></tr>
+  </table>
+</div>
+
+**Code location:** `code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_flash_record/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_flash_record" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### Hardware Setup
+
+The playback side needs an external I2S amplifier. The demo is written for the **MAX98357A** breakout, wired to the 0.96'' IPS Display's I2S test pads:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>XIAO Pin</th><th>I2S Signal</th><th>MAX98357A</th></tr>
+    <tr><td>3V3</td><td>Power</td><td>VIN</td></tr>
+    <tr><td>GND</td><td>Ground</td><td>GND</td></tr>
+    <tr><td>D11</td><td>I2S_SD (data out)</td><td>DIN</td></tr>
+    <tr><td>D12</td><td>I2S_SCK (bit clock)</td><td>BCLK</td></tr>
+    <tr><td>D13</td><td>I2S_WS (word select)</td><td>LRC</td></tr>
+  </table>
+</div>
+
+:::caution
+Disconnect the USB power before wiring the amplifier and speaker. Connect the speaker to the **SPK+** and **SPK-** terminals of the MAX98357A — do **not** connect either speaker wire to GND.
+:::
+
+:::note
+The 0.96'' IPS Display does **not** have an SD card slot, so this demo records into the nRF52840's **internal flash filesystem** (InternalFS). InternalFS is about **28 KB** — the tutorial records 11,200 mono samples at 16 kHz, producing about 22 KB of PCM audio and a recording duration of approximately 0.7 seconds.
+:::
+
+### How It Works
+
+**Display:**
+
+The screen is driven by **Seeed_GFX2** with `Board_XIAO_0inch96_LCD<38, 37>` and `Config_Seeed_0inch96_LCD_ST7789` (80×160, BGR, rotation 2) over 10 MHz hardware SPI.
+
+**Recording (USR1):**
+
+1. The sketch starts the PDM peripheral at **16 kHz, single channel** and captures raw samples into a 11200-sample buffer (≈ 0.7 s, ≈ 22 KB of PCM) through an ISR (`onPdmData`).
+2. A progress screen shows the recording percentage and elapsed time in real time.
+3. When the buffer is full, the sketch prepends a 44-byte WAV header and writes the file `/REC_RAW.WAV` to InternalFS.
+
+**Playback (USR2):**
+
+1. The WAV is loaded back from InternalFS.
+2. The sketch drives the nRF52840's I2S peripheral in **master mode** with a 32× ratio (≈ 16 kHz LRCK), sending 16-bit stereo frames to the MAX98357A at **0.75× gain** (each mono sample is duplicated to both channels).
+3. A double-buffer (ping-pong) scheme keeps the audio stream uninterrupted until the clip ends.
+
+**Buttons:**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Pin</th><th>Action</th></tr>
+    <tr><td>USR1</td><td>D6</td><td>Record a new clip (overwrites the previous one)</td></tr>
+    <tr><td>USR2</td><td>D7</td><td>Play back the saved clip</td></tr>
+  </table>
+</div>
+
+:::note
+The **PDM**, **Adafruit TinyUSB**, **Adafruit LittleFS**, and **InternalFileSystem** libraries are bundled with **Seeed nRF52 Boards 1.1.13** — do not install separate versions from the Library Manager. This tutorial does not use SdFat.
+:::
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_096_flash_record.ino` in Arduino IDE.
+
+**Step 2.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**.
+
+**Step 3.** Click **Upload**.
+
+**Step 4.** The screen shows the "Recorder" idle screen. Press **USR1** — a red "REC" progress bar fills as it records. When done, it saves the WAV and returns to the idle screen.
+
+**Step 5.** Press **USR2** — the clip plays through the connected MAX98357A speaker, with the screen showing "Playing...".
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_function_flash_record.gif" style={{width:500, height:'auto'}}/></div>
+
+After pressing USR1, the red progress bar fills to 100% and the clip is saved. Pressing USR2 plays the recording back through the MAX98357A. The WAV file is stored in InternalFS and remains available after a reset or power cycle. Recording again with USR1 overwrites the previous file.
+
+:::note
+This tutorial has been compiled, uploaded, and hardware-tested with the XIAO nRF52840 Plus, the 0.96'' IPS Display, a MAX98357A amplifier, and an external speaker.
+:::
+
+---
+
+## User Buttons
+
+The 0.96'' IPS Display has **two physical push buttons** connected to the XIAO nRF52840 Plus:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Pin</th><th>Logic</th><th>Silkscreen Label</th></tr>
+    <tr><td><strong>USR1</strong></td><td>D6</td><td>Active-low (pressed = LOW)</td><td>USR1</td></tr>
+    <tr><td><strong>USR2</strong></td><td>D7</td><td>Active-low (pressed = LOW)</td><td>USR2</td></tr>
+  </table>
+</div>
+
+:::note
+Unlike the 1.14'' IPS Display, the 0.96'' IPS Display has **no third button** (no USR3 on D19). It also has no dedicated button breakout pads.
+:::
+
+### Reading Buttons
+
+The onboard demos configure the buttons with the internal pull-up:
+
+```cpp
+const int USR1 = D6;
+const int USR2 = D7;
+
+void setup() {
+  pinMode(USR1, INPUT_PULLUP);
+  pinMode(USR2, INPUT_PULLUP);
+  Serial.begin(115200);
+}
+
+void loop() {
+  if (digitalRead(USR1) == LOW) {
+    Serial.println("USR1 (D6) pressed");
+    delay(200); // simple debounce
+  }
+  if (digitalRead(USR2) == LOW) {
+    Serial.println("USR2 (D7) pressed");
+    delay(200);
+  }
+}
+```
+
+### Debounce with Interrupts
+
+For responsive, debounced button handling without blocking the main loop, you can use pin-change interrupts:
+
+```cpp
+volatile bool btn1Flag = false;
+volatile bool btn2Flag = false;
+
+void btn1Isr() { btn1Flag = true; }
+void btn2Isr() { btn2Flag = true; }
+
+void setup() {
+  pinMode(D6, INPUT_PULLUP);
+  pinMode(D7, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(D6), btn1Isr, FALLING);
+  attachInterrupt(digitalPinToInterrupt(D7), btn2Isr, FALLING);
+}
+
+void loop() {
+  if (btn1Flag) {
+    btn1Flag = false;
+    delay(30); // debounce settling time
+    if (digitalRead(D6) == LOW) {
+      // handle USR1 press
+    }
+  }
+  if (btn2Flag) {
+    btn2Flag = false;
+    delay(30);
+    if (digitalRead(D7) == LOW) {
+      // handle USR2 press
+    }
+  }
+}
+```
+
+### Default Behavior in the Factory Dashboard
+
+In the preloaded factory firmware, the buttons are mapped as follows (you can override these in your own code):
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Pin</th><th>Action</th></tr>
+    <tr><td><strong>USR1</strong></td><td>D6</td><td>Cycle screen brightness (100% → 75% → 50% → 25% → 100%)</td></tr>
+    <tr><td><strong>USR2</strong></td><td>D7</td><td>Toggle screen backlight ON/OFF</td></tr>
+  </table>
+</div>
+
+When the screen is off (toggled via USR2), pressing USR2 again restores it to the previous non-zero level.
+
+---
+
+## Battery Status
+
+This demo shows the battery status — a battery icon with charge level and charging state — on the 0.96'' IPS Display. It detects whether a LiPo battery is physically connected and shows one of three states: **USB PWR** (no battery), **percentage** (battery only), or **charging** (USB + battery).
+
+The 0.96'' IPS Display has **no dedicated battery ADC pin** (D16 is NC) — battery voltage is measured through the XIAO nRF52840 Plus module's internal divider.
+
+**Code location:** `code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_battery_status/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/096_nRF52840/xiao_nrf52840_096_battery_status" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+**Display:**
+
+The screen is driven by **Seeed_GFX2** with `Board_XIAO_0inch96_LCD<38, 37>` and `Config_Seeed_0inch96_LCD_ST7789` (80×160, BGR, rotation 2) over 10 MHz hardware SPI.
+
+**Battery circuit:**
+
+The nRF52840 Plus uses **three GPIO pins** to form a complete battery monitoring system:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Signal</th><th>nRF52840 Pin</th><th>Function</th></tr>
+    <tr><td><code>READ_BAT</code></td><td><strong>P0.14</strong></td><td>Battery voltage divider enable. Active-low — set LOW to enable the divider, then release to HIGH (high-impedance) to save power.</td></tr>
+    <tr><td><code>VBAT_ADC</code></td><td><strong>PIN_VBAT</strong> (AIN7 / P0.31)</td><td>Analog input reading the divided battery voltage.</td></tr>
+    <tr><td><code>CHG</code></td><td><strong>P0.17</strong></td><td>Charging status indicator. Active-low — reads LOW when a charger is connected and the battery is charging.</td></tr>
+  </table>
+</div>
+
+**Detection:**
+
+Under USB-C, a static VBAT voltage cannot tell whether a battery is present — the charger's BAT node can look like a real Li-ion cell even with no battery attached. So the demo first learns a **USB-only baseline**, then confirms battery insertion only after a sustained downward VBAT shift, and confirms removal after a noisy/jumped reading combined with `~CHG` going HIGH. This mirrors the factory Dashboard's detection logic.
+
+**Icon states:**
+
+- **No battery** — grey outline battery with a red cross, labelled **USB PWR**.
+- **Battery present** — white outline battery with a coloured fill (green / yellow / red by percentage), labelled with the **percentage** and **voltage**.
+- **Charging** — cyan fill with a lightning-bolt icon, labelled with the percentage and voltage.
+
+:::note
+The `~CHG` pin is read through the nRF52840's **raw GPIO registers** (`nrf_gpio_cfg_input()` and `NRF_P0->IN`) instead of `digitalRead()`. In the Arduino API, pin numbers follow the board package's mapping, where `digitalRead(17)` actually reads **P0.07** (the 6D IMU's I2C data line) rather than P0.17. The constants `14` and `17` here are **raw Nordic P0.x pin numbers** (P0.14 and P0.17), which is exactly what the register calls expect.
+:::
+
+:::note
+The demo uses the factory-calibrated **499 kΩ** low-side resistor (divider ratio ≈ 3.004), not the 510 kΩ nominal value. The divider is built into the XIAO nRF52840 Plus module itself, not the display board. The P0.14 enable pin is **active-low**: drive it LOW to enable the divider, then release it to high-impedance (INPUT) to minimize quiescent current drain when the battery is not being measured.
+:::
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_096_battery_status.ino` in Arduino IDE.
+
+**Step 2.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**.
+
+**Step 3.** Click **Upload**.
+
+**Step 4.** Observe the screen — it shows the battery icon with the current state. Plug or unplug a LiPo battery (or the USB-C cable) to watch the icon switch between the three states.
+
+### Expected Result
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_function_battery_status_state1.jpg" style={{width:300, height:'auto'}}/><br/><strong>USB PWR</strong> (no battery)</div></td>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_function_battery_status_state2.jpg" style={{width:300, height:'auto'}}/><br/><strong>Percentage</strong> (battery only)</div></td>
+    </tr>
+    <tr>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_function_battery_status_state3.jpg" style={{width:300, height:'auto'}}/><br/><strong>Charging</strong> (USB + battery)</div></td>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_function_battery_status_back.jpg" style={{width:300, height:'auto'}}/><br/><strong>Battery connector</strong> (back)</div></td>
+    </tr>
+  </table>
+</div>
+
+Without a battery, the screen shows a grey battery with a red cross and the label **USB PWR**. Insert a LiPo battery and the icon switches to a coloured fill with the percentage and voltage. Plug in USB-C while a battery is present and the fill turns cyan with a lightning bolt, indicating charging.
+
+The demo also prints a diagnostic line to the Serial Monitor every 500 ms, for example:
+
+```
+VBAT 3.87V  charging  85  spread=5  usb=ON  base=4.140  baseValid=Y  state=PRESENT  filter=STABLE  removeCount=0
+```
+---
+
+## Resources
+
+- **🗃️[PCB Design Files]** [XIAO 0.96'' IPS Display (nRF52840) KiCad Project](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/kicad/XIAO%200.96%27%27%20IPS%20Display%20%28nRF52840%29%20KiCad%20Project.zip)
+- **📄[Schematic]** [XIAO 0.96'' IPS Display (nRF52840) Schematic](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/schematic/XIAO%200.96%27%27%20IPS%20Display%20%28nRF52840%29%20Schematic.pdf)
+- **📦[3D Model]** [XIAO 0.96'' IPS Display (STEP)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/3d-model/XIAO%200.96%27%27%20IPS%20Display.step)
+- **📄[Datasheet]** [0.96 Inch Display Datasheet](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/datasheet/0.96%20Inch%20Display%20Datasheet.pdf)
+- **💾[Factory Firmware]** [XIAO 0.96'' IPS Display (nRF52840) Factory Firmware](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/firmware/XIAO%200.96%27%27%20IPS%20Display%20%28nRF52840%29%20Factory%20Firmware.uf2)
+- **[Demo]** [XIAO Display Board Demo Code](https://github.com/Seeed-Projects/Display-Gadgets) — all Function demos are in the `code_GFX2/Function/096_nRF52840/` directory
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="table-center">
+  <div class="button_tech_support_container">
+  <a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+  <a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+  </div>
+
+  <div class="button_tech_support_container">
+  <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+  <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+  </div>
+</div>

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_0.96_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_0.96_inch_display_nrf52840.md
@@ -14,7 +14,6 @@ keywords:
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /function_0.96_inch_display_nrf52840
 sku: 100063377
-sidebar_label: Function
 sidebar_position: 2
 last_update:
   date: 08/25/2026

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_0.96_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_0.96_inch_display_nrf52840.md
@@ -1,6 +1,7 @@
 ---
 description: Standalone function-level demos for each onboard peripheral of the XIAO 0.96'' IPS Display (nRF52840). Covers screen, IMU, PDM microphone, internal Flash recording and I2S audio playback, buttons, and battery.
 title: Onboard Peripheral Usage
+sidebar_label: Function
 keywords:
   - XIAO
   - nRF52840

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
@@ -1,0 +1,232 @@
+---
+description: Getting Started with XIAO 0.96'' IPS Display (nRF52840).
+title: Getting Started with XIAO 0.96'' IPS Display (nRF52840)
+keywords:
+  - XIAO
+  - nRF52840
+  - Display
+  - LCD
+  - 0.96
+image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+slug: /getting_started_0.96_inch_display_nrf52840
+sku: 100063377
+sidebar_label: Getting Started
+sidebar_position: 1
+type: gettingstarted
+last_update:
+  date: 09/07/2026
+  author: FaiyuetCik
+createdAt: '2026-08-11'
+updatedAt: '2026-09-07'
+url: https://wiki.seeedstudio.com/getting_started_0.96_inch_display_nrf52840/
+---
+
+# Getting Started with XIAO 0.96'' IPS Display (nRF52840)
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>XIAO 0.96'' IPS Display (nRF52840)</th></tr>
+    <tr><td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/NEW096_nRF52840Plus_display_hardware_hero.jpg" style={{width:600, height:'auto'}}/></div></td></tr>
+    <tr><td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+        <a class="get_one_now_item" href="https://www.seeedstudio.com/0-96-Inch-Display-Powered-by-XIAO-nRF52840-Plus-p-6992.html" target="_blank">
+            <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+        </a>
+    </div></td></tr>
+  </table>
+</div>
+
+## Introduction
+
+The 0.96'' IPS Display is an expansion board designed for the XIAO series, powered by the XIAO nRF52840 Plus. It features a compact 80×160 IPS color LCD, onboard PDM microphone, 6-axis IMU (LSM6DS3), two user buttons, and battery power management with percentage display — all packed into a form factor even smaller than the 1.14'' IPS Display.
+
+This combination makes it an ideal platform for ultra-compact wearables, keychain gadgets, portable sensor nodes, and IoT prototyping where every millimetre of space counts.
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Specification</th><th>Detail</th></tr>
+    <tr><td>Product Positioning</td><td>Ultra-Compact</td></tr>
+    <tr><td>Core Controller</td><td>Seeed Studio XIAO nRF52840 Plus</td></tr>
+    <tr><td>Processor</td><td>Nordic nRF52840, ARM® Cortex®-M4 32-bit processor with FPU, 64 MHz</td></tr>
+    <tr><td>Memory</td><td>256 KB RAM + 1 MB internal Flash + 2 MB onboard Flash</td></tr>
+    <tr><td>Wireless Connectivity</td><td>BLE 5.4</td></tr>
+    <tr><td>Display Type</td><td>0.96" IPS TFT LCD</td></tr>
+    <tr><td>Resolution</td><td>80 × 160</td></tr>
+    <tr><td>Display Driver</td><td>ST7789</td></tr>
+    <tr><td>Display Interface</td><td>SPI</td></tr>
+    <tr><td>Touch Input</td><td>No</td></tr>
+    <tr><td>6-Axis IMU</td><td>Yes</td></tr>
+    <tr><td>PDM Digital Microphone</td><td>Yes</td></tr>
+    <tr><td>MicroSD Card Slot</td><td>No</td></tr>
+    <tr><td>Grove I2C Connector</td><td>No</td></tr>
+    <tr><td>User Buttons</td><td>2</td></tr>
+    <tr><td>Battery Connector</td><td>2-pin JST 2.0 Connector for 3.7 V LiPo</td></tr>
+    <tr><td>Battery Monitoring</td><td>Battery status detection supported; battery voltage can also be monitored for battery-level estimation.</td></tr>
+    <tr><td>Expansion Interfaces</td><td>1x I2C pads, 1x I2S pads</td></tr>
+    <tr><td>Board Size</td><td>18.8 × 43.6 × 10.6 mm</td></tr>
+    <tr><td>Best For</td><td>Smart badges, tiny wearables, BLE status displays</td></tr>
+  </table>
+</div>
+
+:::note
+This display board is designed for the **XIAO nRF52840 Plus**. If you are using the XIAO ESP32-S3 Plus version, please refer to the [XIAO 0.96'' IPS Display (ESP32-S3)](/getting_started_0.96_inch_display_esp32s3) guide instead.
+:::
+
+## Hardware Overview
+
+Before we start, refer to the following image to understand the physical layout of the 0.96'' IPS Display.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_display_hardware_overview.png" style={{width:1000, height:'auto'}}/></div>
+
+### Pin Map
+
+The 0.96'' IPS Display breaks out all XIAO nRF52840 Plus pins. The table below lists every pin, its net name on the display board, its function, and how it is connected to onboard peripherals.
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>XIAO Pin</th><th>Net Name</th><th>Function Description</th><th>Hardware Connection Notes</th></tr>
+    <tr><td>D0</td><td>PDM_CLK</td><td>PDM digital microphone clock</td><td>Internally connected to PDM Mic</td></tr>
+    <tr><td>D1</td><td>PDM_DATA</td><td>PDM digital microphone data</td><td>Internally connected to PDM Mic</td></tr>
+    <tr><td>D2</td><td>LCD_CS</td><td>Screen chip select signal</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D3</td><td>LCD_DC</td><td>Screen data/command switch</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D4</td><td>SDA</td><td>I2C data bus</td><td>Bus sharing: internally connected to IMU; externally exposed to the back-side 4-pin test pad</td></tr>
+    <tr><td>D5</td><td>SCL</td><td>I2C clock bus</td><td>Bus sharing: internally connected to IMU; externally exposed to the back-side 4-pin test pad</td></tr>
+    <tr><td>D6</td><td>BTN_USR1</td><td>User button 1 (KEY1)</td><td>Internally connected to microswitch 1; cycles backlight brightness</td></tr>
+    <tr><td>D7</td><td>BTN_USR2</td><td>User button 2 (KEY2)</td><td>Internally connected to microswitch 2; toggles backlight ON/OFF</td></tr>
+    <tr><td>D8</td><td>LCD_SCK</td><td>Hardware SPI clock</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D9</td><td>NC</td><td>Floating (reserved)</td><td>No physical connection</td></tr>
+    <tr><td>D10</td><td>LCD_MOSI</td><td>Hardware SPI data output</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D11</td><td>I2S_SD</td><td>Audio data output</td><td>Externally exposed to the bottom audio expansion pad</td></tr>
+    <tr><td>D12</td><td>I2S_SCK</td><td>Audio bit clock</td><td>Externally exposed to the bottom audio expansion pad</td></tr>
+    <tr><td>D13</td><td>I2S_WS</td><td>Audio word select</td><td>Externally exposed to the bottom audio expansion pad</td></tr>
+    <tr><td>D14</td><td>IMU_INT</td><td>IMU motion hardware interrupt</td><td>Internally connected to 6-axis IMU (supports motion wake-up)</td></tr>
+    <tr><td>D15</td><td>NC</td><td>Floating (reserved)</td><td>No physical connection</td></tr>
+    <tr><td>D16</td><td>NC</td><td>Floating (reserved)</td><td>No physical connection — battery voltage is measured through the module's internal PIN_VBAT, not through D16</td></tr>
+    <tr><td>D17</td><td>LCD_RST</td><td>Screen soft reset</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D18</td><td>LCD_BL</td><td>Screen backlight control</td><td>Internally connected to backlight driver circuit</td></tr>
+    <tr><td>D19</td><td>NC</td><td>Floating (reserved)</td><td>No physical connection</td></tr>
+  </table>
+</div>
+
+
+## Getting Started
+
+This guide uploads a minimal **"Hello, XIAO"** sketch to the display board: the screen turns on its backlight, fills black, and prints **"Hello,"** and **"XIAO"** as two centered lines of large green text. It is the fastest way to confirm the screen and your development environment are working before diving into the individual peripheral demos.
+
+### Software Preparation
+
+You will need the following tools and libraries:
+
+- **Arduino IDE** (version 1.8 or later)
+
+<div class="download_arduino_container" style={{textAlign: 'center'}}>
+    <a class="download_arduino_item" href="https://www.arduino.cc/en/software"><strong><span><font color={'FFFFFF'} size={"4"}>Download Arduino IDE</font></span></strong></a>
+</div><br />
+
+- **Seeed nRF52 Boards (1.1.13)** — add the following URL to **File > Preferences > Additional Boards Manager URLs**:
+
+```
+https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
+```
+
+Then go to **Tools > Board > Boards Manager**, search for **Seeed nRF52** and install version **1.1.13**.
+
+- **Seeed_GFX2 (Manual Installation)** — this library is not available in the Library Manager and must be installed manually:
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Studio/Seeed_GFX2/archive/refs/tags/v1.0.0.zip" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> Download Seeed_GFX2</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+**Step 1.** Click the button above to download `Seeed_GFX2` v1.0.0 as a ZIP file (pinned to a release tag so the tutorial stays reproducible). Alternatively, clone the repository from [Seeed-Studio/Seeed_GFX2](https://github.com/Seeed-Studio/Seeed_GFX2).
+
+**Step 2.** In the Arduino IDE, go to **Sketch > Include Library > Add .ZIP Library...** and select the downloaded ZIP. The IDE reads `library.properties` and installs it into the correct `Seeed_GFX2` folder automatically — you do not need to rename the extracted folder. (To install manually instead, unzip the archive and rename the extracted folder to `Seeed_GFX2` before placing it in `Documents/Arduino/libraries/`.)
+
+**Step 3.** Restart the Arduino IDE so the new library is detected.
+
+:::tip
+- **Seeed_GFX2** is Seeed Studio's graphics library built on a layered `Board` + `Panel Config` architecture. Each demo initializes the display with a single `display.begin<Board_..., Config_...>()` call — the **Board** template owns the pin map (CS/DC/SCK/MOSI/RST/BL), and the **Panel Config** bakes in the 80×160 resolution, color order (BGR), and orientation. No `driver.h` or manual pin setup is needed.
+- On this board the sketch uses `Board_XIAO_0inch96_LCD<38, 37>` (RST=38, BL=37) with `Config_Seeed_0inch96_LCD_ST7789`.
+- The **Adafruit TinyUSB** library used by the sketch is bundled with the **Seeed nRF52 Boards** package, so it needs no separate installation.
+:::
+
+### Download the Code
+
+The example sketch is available on GitHub:
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/getting_started_code/xiao_nrf52840_096_hello" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> Download the Code</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+Navigate to `code_GFX2/getting_started_code/xiao_nrf52840_096_hello/` and open `xiao_nrf52840_096_hello.ino` in the Arduino IDE. **Download the complete folder** rather than copying the `.ino` source from the GitHub web view.
+
+### Upload the Sketch
+
+**Step 1.** Connect the XIAO nRF52840 Plus to your computer via the USB-C port.
+
+**Step 2.** In Arduino IDE, select the board: **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus**.
+
+**Step 3.** Select the correct **Port** under **Tools > Port**.
+
+**Step 4.** Click the **Upload** button (→). The sketch will compile and upload to the board.
+
+:::note
+If you encounter upload issues, double-click the reset button to enter bootloader mode. The USR LED will breathe in red and a **NRF52BOOT** drive will appear on your computer, indicating the board is in bootloader mode.
+:::
+
+### Expected Output
+
+After uploading, the screen lights up with a black background and shows two centered lines of large green text — **"Hello,"** on the first line and **"XIAO"** on the second. The greeting stays on screen without redrawing.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/096_nRF52840Plus_display_hello.gif" style={{width:500, height:'auto'}}/></div>
+
+If the display fails to initialize, the sketch prints the library error message to the serial monitor at **115200** baud. Open **Tools > Serial Monitor** and set the baud rate to 115200 to read it.
+
+## What's Next
+
+The display board packs several onboard peripherals. The [Function](/function_0.96_inch_display_nrf52840) page provides a standalone demo for each one:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Peripheral</th><th>Demo</th></tr>
+    <tr><td>Screen</td><td>[GraphicTest](/function_0.96_inch_display_nrf52840#screen-display--graphictest) — ten graphics primitives with timing benchmarks</td></tr>
+    <tr><td>IMU</td><td>[Electronic Quicksand + Raise to Wake](/function_0.96_inch_display_nrf52840#imu) — 6-axis motion effects and wake-on-motion</td></tr>
+    <tr><td>Microphone & Speaker</td><td>[Flash Recorder](/function_0.96_inch_display_nrf52840#microphone--speaker--flash-recorder) — record and play back audio</td></tr>
+    <tr><td>Buttons</td><td>[User Buttons](/function_0.96_inch_display_nrf52840#user-buttons) — read presses and debounce with interrupts</td></tr>
+    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_0.96_inch_display_nrf52840#battery-voltage-detection) — measure voltage and convert to a percentage</td></tr>
+  </table>
+</div>
+
+## FAQ
+
+### What if the upload fails or the board is not detected?
+
+Double-click the reset button on the XIAO nRF52840 Plus. The USR LED will breathe in red and a drive named **NRF52BOOT** will appear on your computer. Drag the compiled `.uf2` file onto the **NRF52BOOT** drive. The board will program itself and reset automatically.
+
+## Resources
+
+- **🗃️[PCB Design Files]** [XIAO 0.96'' IPS Display (nRF52840) KiCad Project](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/kicad/XIAO%200.96%27%27%20IPS%20Display%20%28nRF52840%29%20KiCad%20Project.zip)
+- **📄[Schematic]** [XIAO 0.96'' IPS Display (nRF52840) Schematic](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/schematic/XIAO%200.96%27%27%20IPS%20Display%20%28nRF52840%29%20Schematic.pdf)
+- **📦[3D Model]** [XIAO 0.96'' IPS Display (STEP)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/3d-model/XIAO%200.96%27%27%20IPS%20Display.step)
+- **📄[Datasheet]** [0.96 Inch Display Datasheet](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/datasheet/0.96%20Inch%20Display%20Datasheet.pdf)
+- **💾[Factory Firmware]** [XIAO 0.96'' IPS Display (nRF52840) Factory Firmware](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/firmware/XIAO%200.96%27%27%20IPS%20Display%20%28nRF52840%29%20Factory%20Firmware.uf2)
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="table-center">
+  <div class="button_tech_support_container">
+  <a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+  <a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+  </div>
+
+  <div class="button_tech_support_container">
+  <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+  <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+  </div>
+</div>

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
@@ -11,7 +11,6 @@ keywords:
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /getting_started_0.96_inch_display_nrf52840
 sku: 100063377
-sidebar_label: Getting Started
 sidebar_position: 1
 type: gettingstarted
 last_update:
@@ -198,7 +197,7 @@ The display board packs several onboard peripherals. The [Function](/function_0.
     <tr><td>IMU</td><td>[Electronic Quicksand + Raise to Wake](/function_0.96_inch_display_nrf52840#imu) — 6-axis motion effects and wake-on-motion</td></tr>
     <tr><td>Microphone & Speaker</td><td>[Flash Recorder](/function_0.96_inch_display_nrf52840#microphone--speaker--flash-recorder) — record and play back audio</td></tr>
     <tr><td>Buttons</td><td>[User Buttons](/function_0.96_inch_display_nrf52840#user-buttons) — read presses and debounce with interrupts</td></tr>
-    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_0.96_inch_display_nrf52840#battery-voltage-detection) — measure voltage and convert to a percentage</td></tr>
+    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_0.96_inch_display_nrf52840#battery-status) — measure voltage and convert to a percentage</td></tr>
   </table>
 </div>
 

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
@@ -1,6 +1,7 @@
 ---
 description: Getting Started with XIAO 0.96'' IPS Display (nRF52840).
 title: Getting Started with XIAO 0.96'' IPS Display (nRF52840)
+sidebar_label: Getting Started
 keywords:
   - XIAO
   - nRF52840

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
@@ -197,7 +197,7 @@ The display board packs several onboard peripherals. The [Function](/function_0.
     <tr><td>IMU</td><td>[Electronic Quicksand + Raise to Wake](/function_0.96_inch_display_nrf52840#imu) — 6-axis motion effects and wake-on-motion</td></tr>
     <tr><td>Microphone & Speaker</td><td>[Flash Recorder](/function_0.96_inch_display_nrf52840#microphone--speaker--flash-recorder) — record and play back audio</td></tr>
     <tr><td>Buttons</td><td>[User Buttons](/function_0.96_inch_display_nrf52840#user-buttons) — read presses and debounce with interrupts</td></tr>
-    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_0.96_inch_display_nrf52840#battery-status) — measure voltage and convert to a percentage</td></tr>
+    <tr><td>Battery</td><td>[Battery Status](/function_0.96_inch_display_nrf52840#battery-status) — measure voltage and convert to a percentage</td></tr>
   </table>
 </div>
 

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/0.96_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_0.96_inch_display_nrf52840.md
@@ -68,7 +68,7 @@ This combination makes it an ideal platform for ultra-compact wearables, keychai
 </div>
 
 :::note
-This display board is designed for the **XIAO nRF52840 Plus**. If you are using the XIAO ESP32-S3 Plus version, please refer to the [XIAO 0.96'' IPS Display (ESP32-S3)](/getting_started_0.96_inch_display_esp32s3) guide instead.
+This display board is designed for the **XIAO nRF52840 Plus**. If you are using the XIAO ESP32-S3 Plus version, please refer to the XIAO 0.96'' IPS Display (ESP32-S3) guide instead.
 :::
 
 ## Hardware Overview

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/_category_.yml
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/_category_.yml
@@ -1,0 +1,4 @@
+position: 2
+label: "XIAO 1.14'' IPS Display (nRF52840)"
+collapsible: true
+collapsed: true

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.14_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.14_inch_display_nrf52840.md
@@ -1,0 +1,741 @@
+---
+description: Standalone function-level demos for each onboard peripheral of the XIAO 1.14'' IPS Display (nRF52840). Covers screen, IMU, PDM microphone, internal Flash recording and I2S audio playback, buttons, battery, and Grove I2C.
+title: Onboard Peripheral Usage
+keywords:
+  - XIAO
+  - nRF52840
+  - Display
+  - LCD
+  - Function
+  - 1.14
+  - I2S
+  - Audio
+image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+slug: /function_1.14_inch_display_nrf52840
+sku: 100069374
+sidebar_label: Function
+sidebar_position: 2
+last_update:
+  date: 08/12/2026
+  author: FaiyuetCik
+createdAt: '2026-08-13'
+updatedAt: '2026-08-24'
+url: https://wiki.seeedstudio.com/function_1.14_inch_display_nrf52840/
+---
+
+# Onboard Peripheral Usage
+
+This page collects standalone function-level demos for each onboard peripheral of the 1.14'' IPS Display. Each section is self-contained — you can pick the one that matches your use case without reading through the others.
+
+:::tip
+The demo GIFs on this page are sped up to keep them short.
+:::
+
+:::note
+All demos in this page require **Seeed nRF52 Boards (1.1.13)** as described in [Getting Started](/getting_started_1.14_inch_display_nrf52840), plus the **Seeed_GFX2** library installed manually as described below.
+:::
+
+- **Library Manager** — go to **Sketch > Include Library > Manage Libraries...**, search for and install:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Library</th><th>Search Keyword</th><th>Author</th><th>Required by</th></tr>
+    <tr><td><strong>Seeed Arduino LSM6DS3</strong></td><td><code>Seeed Arduino LSM6DS3</code></td><td>Seeed Studio</td><td>IMU demos</td></tr>
+  </table>
+</div>
+
+- **Seeed_GFX2 (Manual Installation)** — this library is not available in Library Manager and must be installed manually:
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Studio/Seeed_GFX2/archive/refs/tags/v1.0.0.zip" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> Download Seeed_GFX2</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+**Step 1.** Click the button above to download `Seeed_GFX2` v1.0.0 as a ZIP file (pinned to a release tag so the tutorial stays reproducible). Alternatively, clone the repository from [Seeed-Studio/Seeed_GFX2](https://github.com/Seeed-Studio/Seeed_GFX2).
+
+**Step 2.** In the Arduino IDE, go to **Sketch > Include Library > Add .ZIP Library...** and select the downloaded ZIP. The IDE reads `library.properties` and installs it into the correct `Seeed_GFX2` folder automatically — you do not need to rename the extracted folder. (To install manually instead, unzip the archive and rename the extracted folder to `Seeed_GFX2` before placing it in `Documents/Arduino/libraries/`.)
+
+**Step 3.** Restart the Arduino IDE so the new library is detected.
+
+:::tip
+- **Seeed_GFX2** is Seeed Studio's graphics library built on a layered `Board` + `Panel Config` architecture. Each demo initializes the display with a single `display.begin<Board_..., Config_...>()` call — the **Board** template owns the pin map (CS/DC/SCK/MOSI/RST/BL), and the **Panel Config** bakes in the 135×240 resolution, color order, and inversion. No `driver.h` or manual pin setup is needed.
+- On this board the demos use `Board_XIAO_1inch14_LCD<38, 37>` (RST=38, BL=37) with `Config_Seeed_1inch14_LCD_ST7789` (135×240). A few demos define a sketch-local `Config_XIAO_1inch14_LCD_ST7789_BGR` override for the BGR color order.
+- The **IMU** demos use the **Seeed Arduino LSM6DS3** library (installed above).
+- The 1.14'' IPS Display has **no touch controller, no SD card slot**, so no touch or SD libraries are needed.
+:::
+
+:::note
+The **PDM**, **Adafruit TinyUSB**, **Adafruit LittleFS**, and **InternalFileSystem** libraries used by the **Flash Recorder** tutorial are bundled with **Seeed nRF52 Boards 1.1.13** — do not install separate versions from the Library Manager.
+
+The recording is stored in the nRF52840's **internal Flash filesystem**. This display has no SD card slot, and the tutorial does not use SdFat.
+:::
+
+## Getting the Demo Code
+
+Every demo on this page lives in the [Display-Gadgets](https://github.com/Seeed-Projects/Display-Gadgets) repository, under the `code_GFX2/Function/` directory. Each demo is a folder containing a single `.ino` sketch. **Always download the complete folder** rather than copying the `.ino` source from the GitHub web view.
+
+**Option A — Download the repository as a ZIP (recommended):**
+
+1. Open [github.com/Seeed-Projects/Display-Gadgets](https://github.com/Seeed-Projects/Display-Gadgets) and click **Code > Download ZIP**, then extract the archive anywhere convenient.
+2. Navigate into `code_GFX2/Function/` and open the folder shown in each demo's **Code location** line. For example, the GraphicTest demo for this board lives in `code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_graphictest/`.
+3. **Double-click the `.ino` file** to open it in the Arduino IDE.
+
+**Option B — git clone:**
+
+```sh
+git clone https://github.com/Seeed-Projects/Display-Gadgets.git
+```
+
+Then open the demo's `.ino` file from the cloned `code_GFX2/Function/...` folder.
+
+## Screen Display — GraphicTest
+
+This demo runs a full graphics benchmark on the 1.14-inch ST7789 IPS panel (135×240), covering color bars, lines, rectangles, circles, triangles, rounded rectangles, text, and a pixel gradient. Use it to verify that the screen is wired correctly and that all draw calls work as expected.
+
+**Code location:** `code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_graphictest/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_graphictest" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The sketch initializes the ST7789 IPS panel via **Seeed_GFX2**, then runs through ten graphics primitives in sequence, measuring the execution time of each one via `micros()` and printing the result to the serial monitor.
+
+The display is initialized with a single template call:
+
+```cpp
+display.begin<Board_XIAO_1inch14_LCD<38, 37>,
+              Config_Seeed_1inch14_LCD_ST7789>();
+```
+
+The **Board** template owns the pin map — CS=D2, DC=D3, SCK=D8, MOSI=D10 — and its `<RST, BL>` template parameters take bare GPIO numbers, so `<38, 37>` sets RST=GPIO38 and BL=GPIO37. The **Panel Config** bakes in the 135×240 resolution, color order, and inversion (`invert = true`), so no `driver.h` or manual `invertDisplay()` call is needed.
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_114_graphictest.ino` in Arduino IDE.
+
+**Step 2.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**.
+
+**Step 3.** Click **Upload**.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud). You should see timing output for each test:
+
+```
+LCD width: 135
+LCD height: 240
+Color bars: 34.18 ms
+Lines: 2599.61 ms
+Fast lines: 57.62 ms
+Rectangles: 44.92 ms
+Filled rectangles: 125.98 ms
+Circles: 291.02 ms
+Triangles: 289.06 ms
+Round rectangles: 95.70 ms
+Text: 1416.02 ms
+Pixel gradient: 4774.42 ms
+Graphic test finished.
+```
+
+On the screen, you will see each test pattern displayed for about one second before the next one starts. When all tests complete, a "Finished" screen appears.
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_graphictest.gif" style={{width:500, height:'auto'}}/></div>
+
+After the sketch runs through all patterns, the screen shows a "Finished" message. Reset the board to run the test again.
+
+---
+
+## IMU
+
+The 1.14'' IPS Display features an onboard 6-axis IMU (LSM6DS3) connected via I2C on D4/D5. The motion interrupt line on **D14** supports hardware wake-up and gesture detection.
+
+Both demos below use the LSM6DS3 at I2C address **0x6A**.
+
+<a id="imu-quicksand"></a>
+
+### Demo 1: Electronic Quicksand
+
+This demo turns the screen into an interactive fluid simulation — golden sand particles that flow and settle according to gravity, as measured by the onboard 6-axis IMU. Tilt the board and the sand shifts direction in real time.
+
+**Code location:** `code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_electronic_quicksand/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_electronic_quicksand" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The simulation uses a **22×40 occupancy grid** overlaid on the 135×240 screen, where each cell is 6×6 pixels. Around **150 particles** are placed in the grid, each with a position, velocity, and a golden color gradient.
+
+The IMU is read via I2C (D4/D5) using the Seeed Arduino LSM6DS3 library at address `0x6A`. Raw acceleration values are low-pass filtered and used to derive a gravity vector. When you tilt the board:
+
+1. **Gravity vector updates** — accelerometer data is smoothed with an exponential moving average to avoid jitter.
+2. **Particle velocity** — each particle accelerates in the direction of the gravity vector, with damping and a per-particle mobility factor based on its depth in the flow.
+3. **Cell occupancy** — particles deeper in the flow (closer to the "bottom" relative to gravity) have reduced mobility, creating a realistic packing effect.
+4. **Differential rendering** — only cells where particles moved into or out of are redrawn, minimizing SPI traffic and keeping the animation smooth.
+
+Particles near the surface flow freely (higher mobility); particles buried deeper pack tightly (lower mobility) — mimicking how real sand behaves.
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_114_electronic_quicksand.ino` in Arduino IDE.
+
+**Step 2.** Select the board and port, then click **Upload**.
+
+**Step 3.** Once uploaded, the screen fills with golden particles at the bottom. Tilt the board in different directions — the sand flows as if pulled by gravity.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud) to confirm initialization:
+
+```
+=== Electronic Quicksand 1.14 ===
+imu.begin=0
+```
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_quicksand.gif" style={{width:500, height:'auto'}}/></div>
+
+The golden sand particles flow smoothly as you tilt the board. When held flat, the sand settles at the bottom of the screen. Rotate the board 90 degrees and the sand flows to the new "bottom" within a second.
+
+---
+
+### Demo 2: Raise to Wake
+
+This demo implements a **screen sleep/wake system** driven by the IMU's built-in motion interrupt on **D14**. The screen automatically turns off (backlight off + nRF52 system ON sleep) after a configurable idle period, and wakes instantly when you pick up or move the device.
+
+**Code location:** `code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_wakeup/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_wakeup" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The demo uses the LSM6DS3's **embedded wake-up event detector** — a hardware feature that monitors accelerometer data internally and asserts the INT1 pin (routed to D14 on this board) when motion exceeds a configurable threshold. This means the MCU does not need to poll the accelerometer continuously.
+
+**IMU configuration (LSM6DS3):**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Register</th><th>Value</th><th>Purpose</th></tr>
+    <tr><td><code>CTRL1_XL</code></td><td><code>0x40</code></td><td>Accelerometer @ 104 Hz, ±2g</td></tr>
+    <tr><td><code>TAP_CFG</code></td><td><code>0x80</code></td><td>Enable embedded interrupts</td></tr>
+    <tr><td><code>WAKE_UP_THS</code></td><td><code>0x05</code></td><td>Wake-up threshold (medium-low sensitivity)</td></tr>
+    <tr><td><code>WAKE_UP_DUR</code></td><td><code>0x00</code></td><td>No duration filter (responsive wake)</td></tr>
+    <tr><td><code>MD1_CFG</code></td><td><code>0x20</code></td><td>Route wake-up to INT1</td></tr>
+  </table>
+</div>
+
+**Sleep/wake flow:**
+
+1. **Active state** — screen is on, backlight at full brightness, UI refreshes every 250 ms with real-time IMU data. A countdown timer shows seconds remaining until auto-sleep.
+2. **Auto-sleep** — after the idle timeout, the sketch turns off the backlight, displays a "Sleeping... Pick up device to wake" message, and enters nRF52 System ON sleep (low-power mode with RAM retention). The IMU wake interrupt on D14 was already configured at startup, so motion detection remains active during sleep.
+3. **Wake-up** — when the user picks up the board, the IMU detects motion and asserts D14 HIGH. The nRF52840 exits System ON sleep, restores the backlight, and redraws the UI. The LCD and IMU are **not** re-initialized — System ON sleep retains RAM and peripheral configuration, so both keep the settings applied at startup.
+
+**Manual test buttons:**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Pin</th><th>Action</th></tr>
+    <tr><td>USR1</td><td>D6</td><td>Force sleep</td></tr>
+    <tr><td>USR2</td><td>D7</td><td>Force wake</td></tr>
+  </table>
+</div>
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_114_wakeup.ino` in Arduino IDE, select the board and port, and click **Upload**.
+
+**Step 2.** The screen shows a dashboard with power state, motion data, and a countdown timer. Let the board sit still — it will automatically enter sleep after the idle period.
+
+**Step 3.** Pick up the board or shake it gently — the screen wakes immediately.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud) to observe the sleep/wake transitions:
+
+```
+LCD: 135x240
+[IMU] Seeed LSM6DS3 begin=0
+[IMU] D14 wake interrupt OK
+[BOOT] done. Screen should be on.
+[WAKE] reason=IMU_D14 wakeCount=1 sleptMs=3568 sleepLoops=0
+[SLEEP] screen off, entering System ON sleep
+[SLEEP] loops=1 D14=0 awake=N
+[WAKE] reason=IMU_D14 wakeCount=2 sleptMs=1378 sleepLoops=439
+```
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_wakeup.gif" style={{width:500, height:'auto'}}/></div>
+
+The screen displays real-time motion data while awake. After the idle period of stillness, the screen goes dark and the nRF52840 enters low-power sleep. Pick up the device and the screen restores instantly, with the wake counter incremented.
+
+---
+
+## Microphone & Speaker
+
+The 1.14'' IPS Display features the same PDM digital microphone as the 1.47" version, connected to the same pins:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Pin</th><th>Signal</th><th>Function</th></tr>
+    <tr><td>D0</td><td>PDM_CLK</td><td>PDM clock output to microphone</td></tr>
+    <tr><td>D1</td><td>MIC_DATA</td><td>PDM data input from microphone</td></tr>
+  </table>
+</div>
+
+### Demo 1: Voice Bar
+
+This demo visualizes the PDM microphone's real-time audio input as a dynamic equalizer-style waveform and a segmented volume bar. Speak, clap, or blow into the onboard microphone and watch the bars react instantly.
+
+**Code location:** `code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_voice_bar/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_voice_bar" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+#### How It Works
+
+The sketch uses the nRF52840's PDM peripheral via the `PDM` library (bundled with Seeed nRF52 Boards) at 16 kHz, single channel. The ISR (`onPDMdata`) captures raw PDM samples into a 256-sample ring buffer and computes the peak amplitude.
+
+The screen is divided into three zones:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Zone</th><th>Position</th><th>Description</th></tr>
+    <tr><td><strong>Waveform</strong></td><td>Top (y=30–95)</td><td>27-bar equalizer visualizer. Raw samples are down-sampled and drawn as symmetric bars around a center baseline. Waveform color is driven by the same smoothed volume as the volume bar and percentage label — green (&lt;50%), yellow (50–90%), red (&gt;90%).</td></tr>
+    <tr><td><strong>Percentage</strong></td><td>Middle</td><td>Large numeric volume percentage (0–100%), color-coded green (&lt;50%), yellow (50–90%), red (&gt;90%).</td></tr>
+    <tr><td><strong>Volume Bar</strong></td><td>Bottom (y=130–225)</td><td>10-segment bar (green/yellow/red gradient). Updates with smoothed volume from the PDM peak.</td></tr>
+  </table>
+</div>
+
+**Signal processing:**
+
+1. **PDM ISR** — `onPDMdata()` fires at ~62 Hz (16000 / 256). It reads raw samples, computes the peak magnitude, and down-samples into 27 bins for the waveform visualizer.
+2. **Normalization** — peak values below 10 are treated as silence. Values above 1500 saturate to 100%. In between, linear mapping produces a 0.0–1.0 volume level.
+3. **Exponential smoothing** — the displayed volume is smoothed with a 20% mix factor (`SMOOTH = 0.20`) to avoid jitter. During silence, the volume decays at 6% per frame.
+4. **Differential rendering** — the volume bar and percentage label are only redrawn when the value changes, minimizing SPI traffic.
+
+#### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_114_voice_bar.ino` in Arduino IDE.
+
+**Step 2.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**.
+
+**Step 3.** Click **Upload**.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud). You should see:
+
+```
+[MIC] ready
+```
+
+**Step 5.** Speak, clap, or blow into the microphone. The waveform and volume bar respond in real time. The percentage label changes color as the volume increases.
+
+#### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_voice_bar.gif" style={{width:500, height:'auto'}}/></div>
+
+When silent, the waveform is flat and the volume bar is empty (0%). Speak into the microphone and the equalizer bars animate while the volume bar fills up from green through yellow to red. The percentage label updates in real time.
+
+### Demo 2: Flash Recorder with I2S Playback
+
+This demo records a short audio clip from the onboard PDM microphone into the nRF52840's **internal Flash filesystem**, then plays it back through an external I2S amplifier and speaker:
+
+- **USR1** records from the onboard PDM microphone.
+- The recording is **16 kHz, 16-bit, mono**.
+- Each clip is about **0.7 seconds** — 11,200 samples (22,400 bytes of PCM).
+- The clip is saved as **`/REC_RAW.WAV`** in the internal Flash filesystem.
+- **USR2** plays the recording back through an external **MAX98357A** and speaker.
+- This demo has been compiled, flashed, and hardware-verified on the XIAO nRF52840 Plus with **Seeed nRF52 Boards 1.1.13**.
+
+**Code location:** `code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_flash_record/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_flash_record" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+#### Hardware Setup
+
+Playback requires an external **I2S audio amplifier and speaker**. The demo is written for a **MAX98357A** breakout connected to the board's I2S output pads:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Display Board</th><th>MAX98357A</th></tr>
+    <tr><td>3V3</td><td>VIN</td></tr>
+    <tr><td>GND</td><td>GND</td></tr>
+    <tr><td>D11 / I2S_SD</td><td>DIN</td></tr>
+    <tr><td>D12 / I2S_SCK</td><td>BCLK</td></tr>
+    <tr><td>D13 / I2S_WS</td><td>LRC / WS</td></tr>
+  </table>
+</div>
+
+Connect the speaker to the **SPK+** and **SPK-** terminals of the MAX98357A. Do **not** connect one speaker wire to GND — the MAX98357A is a bridge-tied-load (BTL) amplifier, so both speaker terminals must go to the SPK outputs.
+
+:::caution
+Disconnect the USB power before wiring the amplifier and speaker.
+:::
+
+#### How It Works
+
+- The PDM microphone uses **D0 (CLK)** and **D1 (DATA)**.
+- The `PDM` library captures the microphone at **16 kHz mono**.
+- The WAV file consists of a **44-byte header** plus **22,400 bytes of PCM** data.
+- The internal Flash filesystem (InternalFS) is only about **28 KB**, which limits each recording to roughly **0.7 seconds**.
+- Playback uses the nRF52840's **I2S hardware peripheral** in Philips I2S format, **16-bit, stereo** output.
+- The mono samples are duplicated to both the left and right channels.
+- The I2S pins are **D11**, **D12**, and **D13**.
+
+#### Running the Tutorial
+
+**Step 1.** Disconnect the USB power and wire the MAX98357A and speaker as shown above.
+
+**Step 2.** Open `xiao_nrf52840_114_flash_record.ino` in the Arduino IDE.
+
+**Step 3.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**.
+
+**Step 4.** Compile and upload the sketch.
+
+**Step 5.** Press **USR1** and immediately speak into the onboard microphone for about **0.7 seconds**.
+
+:::tip
+Recording starts the moment you press **USR1** — do not wait for the red progress bar to appear. The 0.7-second window is counted from the moment **USR1** is pressed, so speak immediately or you will miss the beginning of your clip.
+:::
+
+**Step 6.** Wait for the screen to show **Saved WAV**.
+
+**Step 7.** Press **USR2** and the speaker plays back your recording.
+
+#### Expected Result
+
+- On startup the screen shows **Flash Recorder**.
+- When no recording exists, the screen shows **No recording**.
+- While recording, the screen shows a progress readout.
+- When saving completes, the screen shows **Saved WAV**.
+- Press **USR2** and you hear the recording through the speaker.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_flash_record_i2s.gif" style={{width:500, height:'auto'}}/></div>
+
+---
+
+## Grove I2C
+
+The 1.14'' IPS Display features a dedicated **Grove I2C connector** that exposes D4 (SDA) and D5 (SCL) on a standard 4-pin Grove socket (GND / 3V3 / SDA / SCL). Unlike the 1.47" version where D4/D5 are additionally shared with the touch controller, the 1.14" display shares D4/D5 only with the onboard IMU (it has no touch controller).
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Grove Pin</th><th>XIAO Pin</th><th>Notes</th></tr>
+    <tr><td>GND</td><td>GND</td><td>Common ground</td></tr>
+    <tr><td>3V3</td><td>3V3</td><td>3.3V power output</td></tr>
+    <tr><td>SDA</td><td>D4</td><td>I2C data — shared with onboard IMU</td></tr>
+    <tr><td>SCL</td><td>D5</td><td>I2C clock — shared with onboard IMU</td></tr>
+  </table>
+</div>
+
+:::note
+D4/D5 are shared between the Grove connector and the onboard IMU. The IMU is at address `0x6A`. When connecting an external I2C device, make sure it does not conflict with this address.
+:::
+
+### Demo: SHT31 Temperature & Humidity
+
+This demo reads temperature and humidity from a **Grove SHT31** sensor plugged into the Grove I2C connector and displays the readings on the screen. The sketch talks to the sensor directly over I2C with `Wire.h` — no SHT31 library is needed — and validates each reading with the sensor's CRC.
+
+**Code location:** `code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_sht31_temperature_humidity/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_sht31_temperature_humidity" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+#### Hardware Setup
+
+Plug a **Grove SHT31** temperature & humidity sensor into the Grove I2C connector. The sensor is powered at 3.3V and communicates at I2C address `0x44`:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Grove Pin</th><th>XIAO Pin</th><th>SHT31</th></tr>
+    <tr><td>GND</td><td>GND</td><td>GND</td></tr>
+    <tr><td>3V3</td><td>3V3</td><td>VCC</td></tr>
+    <tr><td>SDA</td><td>D4</td><td>SDA</td></tr>
+    <tr><td>SCL</td><td>D5</td><td>SCL</td></tr>
+  </table>
+</div>
+
+#### How It Works
+
+The sketch reads the SHT31 directly over I2C (`Wire`) at address `0x44`:
+
+1. **I2C scan** — on startup it scans the I2C bus and reports every device found.
+2. **Single-shot measurement** — it sends a high-repeatability single-shot command (`0x24 0x00`, no clock stretching), waits 20 ms, then reads 6 bytes: temperature high/low + CRC, humidity high/low + CRC.
+3. **CRC check** — each 16-bit value is verified against its CRC byte; a mismatch is reported as an error (wiring or a damaged/noisy module).
+4. **Conversion** — raw values are converted to temperature (`-45 + 175 × raw / 65535` °C) and relative humidity (`100 × raw / 65535` %).
+
+The display is initialized with `Board_XIAO_1inch14_LCD<38, 37>` and a sketch-local `Config_XIAO_1inch14_LCD_ST7789_BGR` (135×240, BGR color order, inverted) so colors render correctly. The screen shows "SHT31 OK" with the live temperature and humidity, or "SHT31 ERROR" plus an error code if a read fails.
+
+#### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_114_sht31_temperature_humidity.ino` in Arduino IDE.
+
+**Step 2.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**, then click **Upload**.
+
+**Step 3.** Open **Tools > Serial Monitor** (115200 baud). You should see:
+
+```
+=== XIAO nRF52840 1.14 SHT31 Temperature/Humidity ===
+[PIN] SDA=D4 SCL=D5 address=0x44
+[I2C] scan start
+[I2C] found 0x44
+[I2C] scan done
+[SHT31] OK T=26.81 C H=48.32 %
+```
+
+The screen shows "SHT31 OK" with the temperature and humidity, updating once per second. If the sensor is disconnected or the CRC check fails, the screen shows "SHT31 ERROR" with an error code.
+
+#### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_sht31.gif" style={{width:500, height:'auto'}}/></div>
+
+The temperature and humidity update once per second on the screen. Breathe on the sensor and the humidity reading rises.
+
+---
+
+## User Buttons
+
+The 1.14'' IPS Display has **three physical push buttons** connected to the XIAO nRF52840 Plus. All three buttons have external **1 KΩ pull-up resistors** on the board, so you can configure the corresponding pins as `INPUT` (no internal pull-up needed):
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Pin</th><th>Logic</th><th>Silkscreen Label</th><th>Breakout Pad</th></tr>
+    <tr><td><strong>USR1</strong></td><td>D6</td><td>Active-low (pressed = LOW)</td><td>USR1</td><td>U1</td></tr>
+    <tr><td><strong>USR2</strong></td><td>D7</td><td>Active-low (pressed = LOW)</td><td>USR2</td><td>U2</td></tr>
+    <tr><td><strong>USR3</strong></td><td>D19</td><td>Active-low (pressed = LOW)</td><td>USR3</td><td>U3</td></tr>
+  </table>
+</div>
+
+### Reading Buttons
+
+With the external 1 KΩ pull-up already on the board, you can read the buttons with a simple direct read:
+
+```cpp
+const int USR1 = D6;
+const int USR2 = D7;
+const int USR3 = D19;
+
+void setup() {
+  // External 1K pull-up on the board — no internal pull-up needed.
+  pinMode(USR1, INPUT);
+  pinMode(USR2, INPUT);
+  pinMode(USR3, INPUT);
+  Serial.begin(115200);
+}
+
+void loop() {
+  if (digitalRead(USR1) == LOW) {
+    Serial.println("USR1 (D6) pressed");
+    delay(200); // simple debounce
+  }
+  if (digitalRead(USR2) == LOW) {
+    Serial.println("USR2 (D7) pressed");
+    delay(200);
+  }
+  if (digitalRead(USR3) == LOW) {
+    Serial.println("USR3 (D19) pressed");
+    delay(200);
+  }
+}
+```
+
+### Debounce with Interrupts
+
+For responsive, debounced button handling without blocking the main loop, you can use pin-change interrupts:
+
+```cpp
+volatile bool btn1Flag = false;
+volatile bool btn2Flag = false;
+volatile bool btn3Flag = false;
+
+void btn1Isr() { btn1Flag = true; }
+void btn2Isr() { btn2Flag = true; }
+void btn3Isr() { btn3Flag = true; }
+
+void setup() {
+  pinMode(D6, INPUT);
+  pinMode(D7, INPUT);
+  pinMode(D19, INPUT);
+  attachInterrupt(digitalPinToInterrupt(D6), btn1Isr, FALLING);
+  attachInterrupt(digitalPinToInterrupt(D7), btn2Isr, FALLING);
+  attachInterrupt(digitalPinToInterrupt(D19), btn3Isr, FALLING);
+}
+
+void loop() {
+  if (btn1Flag) {
+    btn1Flag = false;
+    delay(30); // debounce settling time
+    if (digitalRead(D6) == LOW) {
+      // handle USR1 press
+    }
+  }
+  if (btn2Flag) {
+    btn2Flag = false;
+    delay(30);
+    if (digitalRead(D7) == LOW) {
+      // handle USR2 press
+    }
+  }
+  if (btn3Flag) {
+    btn3Flag = false;
+    delay(30);
+    if (digitalRead(D19) == LOW) {
+      // handle USR3 press
+    }
+  }
+}
+```
+
+### Default Behavior in the Factory Dashboard
+
+In the preloaded factory firmware, the buttons are mapped as follows (you can override these in your own code):
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Pin</th><th>Action</th></tr>
+    <tr><td><strong>USR1</strong></td><td>D6</td><td>Cycle screen brightness (100% → 75% → 50% → 25% → 100%)</td></tr>
+    <tr><td><strong>USR2</strong></td><td>D7</td><td>Toggle screen off / restore to last brightness</td></tr>
+    <tr><td><strong>USR3</strong></td><td>D19</td><td>Toggle header title between "Hello,XIAO!" and "Seeed"</td></tr>
+  </table>
+</div>
+
+The button breakout pads (labeled U1, U2, and U3 on the board) mirror D6, D7, and D19 respectively, allowing you to connect external buttons if desired.
+
+---
+
+## Battery Status
+
+This demo shows the battery status — a battery icon with charge level and charging state — on the 1.14'' IPS Display. It detects whether a LiPo battery is physically connected and shows one of three states: **USB PWR** (no battery), **percentage** (battery only), or **charging** (USB + battery).
+
+The 1.14'' IPS Display includes an onboard battery voltage measurement circuit connected to the XIAO nRF52840 Plus.
+
+**Code location:** `code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_battery_status/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/114_nRF52840/xiao_nrf52840_114_battery_status" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+**Display:**
+
+The screen is driven by **Seeed_GFX2** with `Board_XIAO_1inch14_LCD<38, 37>` and a BGR override of `Config_Seeed_1inch14_LCD_ST7789` (135×240, BGR, rotation 2) over 10 MHz hardware SPI.
+
+**Battery circuit:**
+
+The nRF52840 Plus uses **three GPIO pins** to form a complete battery monitoring system:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Signal</th><th>nRF52840 Pin</th><th>Function</th></tr>
+    <tr><td><code>READ_BAT</code></td><td><strong>P0.14</strong></td><td>Battery voltage divider enable. Active-low — set LOW to enable the divider, then release to HIGH (high-impedance) to save power.</td></tr>
+    <tr><td><code>VBAT_ADC</code></td><td><strong>PIN_VBAT</strong> (AIN7 / P0.31)</td><td>Analog input reading the divided battery voltage.</td></tr>
+    <tr><td><code>CHG</code></td><td><strong>P0.17</strong></td><td>Charging status indicator. Active-low — reads LOW when a charger is connected and the battery is charging.</td></tr>
+  </table>
+</div>
+
+**Detection:**
+
+Under USB-C, a static VBAT voltage cannot tell whether a battery is present — the charger's BAT node can look like a real Li-ion cell even with no battery attached. So the demo first learns a **USB-only baseline**, then confirms battery insertion only after a sustained downward VBAT shift, and confirms removal after a noisy/jumped reading combined with `~CHG` going HIGH. This mirrors the factory Dashboard's detection logic.
+
+**Icon states:**
+
+- **No battery** — grey outline battery with a red cross, labelled **USB PWR**.
+- **Battery present** — white outline battery with a coloured fill (green / yellow / red by percentage), labelled with the **percentage** and **voltage**.
+- **Charging** — cyan fill with a lightning-bolt icon, labelled with the percentage and voltage.
+
+:::note
+The `~CHG` pin is read through the nRF52840's **raw GPIO registers** (`nrf_gpio_cfg_input()` and `NRF_P0->IN`) instead of `digitalRead()`. In the Arduino API, pin numbers follow the board package's mapping, where `digitalRead(17)` actually reads **P0.07** (the 6D IMU's I2C data line) rather than P0.17. The constants `14` and `17` here are **raw Nordic P0.x pin numbers** (P0.14 and P0.17), which is exactly what the register calls expect.
+:::
+
+:::note
+The demo uses the factory-calibrated **499 kΩ** low-side resistor (divider ratio ≈ 3.004), not the 510 kΩ nominal value. The divider is built into the XIAO nRF52840 Plus module itself, not the display board. The P0.14 enable pin is **active-low**: drive it LOW to enable the divider, then release it to high-impedance (INPUT) to minimize quiescent current drain when the battery is not being measured.
+:::
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_114_battery_status.ino` in Arduino IDE.
+
+**Step 2.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**.
+
+**Step 3.** Click **Upload**.
+
+**Step 4.** Observe the screen — it shows the battery icon with the current state. Plug or unplug a LiPo battery (or the USB-C cable) to watch the icon switch between the three states.
+
+### Expected Result
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_battery_status_state1.jpg" style={{width:300, height:'auto'}}/><br/><strong>USB PWR</strong> (no battery)</div></td>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_battery_status_state2.jpg" style={{width:300, height:'auto'}}/><br/><strong>Percentage</strong> (battery only)</div></td>
+    </tr>
+    <tr>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_battery_status_state3.jpg" style={{width:300, height:'auto'}}/><br/><strong>Charging</strong> (USB + battery)</div></td>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_function_battery_status_back.jpg" style={{width:300, height:'auto'}}/><br/><strong>Battery connector</strong> (back)</div></td>
+    </tr>
+  </table>
+</div>
+
+Without a battery, the screen shows a grey battery with a red cross and the label **USB PWR**. Insert a LiPo battery and the icon switches to a coloured fill with the percentage and voltage. Plug in USB-C while a battery is present and the fill turns cyan with a lightning bolt, indicating charging.
+
+The demo also prints a diagnostic line to the Serial Monitor every 500 ms, for example:
+
+```
+VBAT 3.87V  charging  85  spread=5  usb=ON  base=4.140  baseValid=Y  state=PRESENT  filter=STABLE  removeCount=0
+```
+---
+
+## Resources
+
+- **🗃️[PCB Design Files]** [XIAO 1.14'' IPS Display (nRF52840) KiCad Project](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/kicad/XIAO%201.14%27%27%20IPS%20Display%20%28nRF52840%29%20KiCad%20Project.zip)
+- **📄[Schematic]** [XIAO 1.14'' IPS Display (nRF52840) Schematic](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/schematic/XIAO%201.14%27%27%20IPS%20Display%20%28nRF52840%29%20Schematic.pdf)
+- **📦[3D Model]** [XIAO 1.14'' IPS Display (STEP)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/3d-model/XIAO%201.14%27%27%20IPS%20Display.step)
+- **📄[Datasheet]** [1.14 Inch Display Datasheet](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/datasheet/1.14%20Inch%20Display%20Datasheet.pdf)
+- **💾[Factory Firmware]** [XIAO 1.14'' IPS Display (nRF52840) Factory Firmware](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/firmware/XIAO%201.14%27%27%20IPS%20Display%20%28nRF52840%29%20Factory%20Firmware.uf2)
+- **[Demo]** [XIAO Display Board Demo Code](https://github.com/Seeed-Projects/Display-Gadgets) — all Function demos are in the `code_GFX2/Function/114_nRF52840/` directory
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="table-center">
+  <div class="button_tech_support_container">
+  <a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+  <a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+  </div>
+
+  <div class="button_tech_support_container">
+  <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+  <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+  </div>
+</div>

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.14_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.14_inch_display_nrf52840.md
@@ -1,6 +1,7 @@
 ---
 description: Standalone function-level demos for each onboard peripheral of the XIAO 1.14'' IPS Display (nRF52840). Covers screen, IMU, PDM microphone, internal Flash recording and I2S audio playback, buttons, battery, and Grove I2C.
 title: Onboard Peripheral Usage
+sidebar_label: Function
 keywords:
   - XIAO
   - nRF52840

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.14_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.14_inch_display_nrf52840.md
@@ -14,7 +14,6 @@ keywords:
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /function_1.14_inch_display_nrf52840
 sku: 100069374
-sidebar_label: Function
 sidebar_position: 2
 last_update:
   date: 08/12/2026

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
@@ -68,7 +68,7 @@ This combination makes it an ideal platform for wearable devices, compact sensor
 </div>
 
 :::note
-This display board is designed for the **XIAO nRF52840 Plus**. If you are using the XIAO ESP32-S3 Plus version, please refer to the [XIAO 1.14'' IPS Display (ESP32-S3)](/getting_started_1.14_inch_display_esp32s3) guide instead.
+This display board is designed for the **XIAO nRF52840 Plus**. If you are using the XIAO ESP32-S3 Plus version, please refer to the XIAO 1.14'' IPS Display (ESP32-S3) guide instead.
 :::
 
 ## Hardware Overview

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
@@ -11,7 +11,6 @@ keywords:
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /getting_started_1.14_inch_display_nrf52840
 sku: 100069374
-sidebar_label: Getting Started
 sidebar_position: 1
 type: gettingstarted
 last_update:
@@ -199,7 +198,7 @@ The display board packs several onboard peripherals. The [Function](/function_1.
     <tr><td>Microphone & Speaker</td><td>[Voice Bar + Flash Recorder](/function_1.14_inch_display_nrf52840#microphone--speaker) — live PDM level meter and recording with I2S playback</td></tr>
     <tr><td>Grove I2C</td><td>[SHT31 Temperature & Humidity](/function_1.14_inch_display_nrf52840#grove-i2c) — read a Grove SHT31 sensor</td></tr>
     <tr><td>Buttons</td><td>[User Buttons](/function_1.14_inch_display_nrf52840#user-buttons) — read presses and debounce with interrupts</td></tr>
-    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_1.14_inch_display_nrf52840#battery-voltage-detection) — measure voltage and convert to a percentage</td></tr>
+    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_1.14_inch_display_nrf52840#battery-status) — measure voltage and convert to a percentage</td></tr>
   </table>
 </div>
 

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
@@ -1,6 +1,7 @@
 ---
 description: Getting Started with XIAO 1.14'' IPS Display (nRF52840).
 title: Getting Started with XIAO 1.14'' IPS Display (nRF52840)
+sidebar_label: Getting Started
 keywords:
   - XIAO
   - nRF52840

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
@@ -198,7 +198,7 @@ The display board packs several onboard peripherals. The [Function](/function_1.
     <tr><td>Microphone & Speaker</td><td>[Voice Bar + Flash Recorder](/function_1.14_inch_display_nrf52840#microphone--speaker) — live PDM level meter and recording with I2S playback</td></tr>
     <tr><td>Grove I2C</td><td>[SHT31 Temperature & Humidity](/function_1.14_inch_display_nrf52840#grove-i2c) — read a Grove SHT31 sensor</td></tr>
     <tr><td>Buttons</td><td>[User Buttons](/function_1.14_inch_display_nrf52840#user-buttons) — read presses and debounce with interrupts</td></tr>
-    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_1.14_inch_display_nrf52840#battery-status) — measure voltage and convert to a percentage</td></tr>
+    <tr><td>Battery</td><td>[Battery Status](/function_1.14_inch_display_nrf52840#battery-status) — measure voltage and convert to a percentage</td></tr>
   </table>
 </div>
 

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.14_Inch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.14_inch_display_nrf52840.md
@@ -1,0 +1,239 @@
+---
+description: Getting Started with XIAO 1.14'' IPS Display (nRF52840).
+title: Getting Started with XIAO 1.14'' IPS Display (nRF52840)
+keywords:
+  - XIAO
+  - nRF52840
+  - Display
+  - LCD
+  - 1.14
+image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+slug: /getting_started_1.14_inch_display_nrf52840
+sku: 100069374
+sidebar_label: Getting Started
+sidebar_position: 1
+type: gettingstarted
+last_update:
+  date: 09/07/2026
+  author: FaiyuetCik
+createdAt: '2026-08-11'
+updatedAt: '2026-09-07'
+url: https://wiki.seeedstudio.com/getting_started_1.14_inch_display_nrf52840/
+---
+
+# Getting Started with XIAO 1.14'' IPS Display (nRF52840)
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>XIAO 1.14'' IPS Display (nRF52840)</th></tr>
+    <tr><td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/NEW114_nRF52840Plus_display_hardware_hero.jpg" style={{width:600, height:'auto'}}/></div></td></tr>
+    <tr><td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+        <a class="get_one_now_item" href="https://www.seeedstudio.com/1-14-Inch-Display-Powered-by-XIAO-nRF52840-Plus-p-6994.html" target="_blank">
+            <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+        </a>
+    </div></td></tr>
+  </table>
+</div>
+
+## Introduction
+
+The 1.14'' IPS Display is an expansion board designed for the XIAO series, powered by the XIAO nRF52840 Plus. It features a 135×240 IPS color LCD, onboard PDM microphone, 6-axis IMU (LSM6DS3-compatible), Grove I2C connector, three user buttons, and battery power management with percentage display — all integrated into a compact form factor.
+
+This combination makes it an ideal platform for wearable devices, compact sensor nodes, portable instruments, and IoT prototyping where space is at a premium.
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Specification</th><th>Detail</th></tr>
+    <tr><td>Product Positioning</td><td>Sensing & Expansion</td></tr>
+    <tr><td>Core Controller</td><td>Seeed Studio XIAO nRF52840 Plus</td></tr>
+    <tr><td>Processor</td><td>Nordic nRF52840, ARM® Cortex®-M4 32-bit processor with FPU, 64 MHz</td></tr>
+    <tr><td>Memory</td><td>256 KB RAM + 1 MB internal Flash + 2 MB onboard Flash</td></tr>
+    <tr><td>Wireless Connectivity</td><td>BLE 5.4</td></tr>
+    <tr><td>Display Type</td><td>1.14" IPS TFT LCD</td></tr>
+    <tr><td>Resolution</td><td>135 × 240</td></tr>
+    <tr><td>Display Driver</td><td>ST7789</td></tr>
+    <tr><td>Display Interface</td><td>SPI</td></tr>
+    <tr><td>Touch Input</td><td>No</td></tr>
+    <tr><td>6-Axis IMU</td><td>Yes</td></tr>
+    <tr><td>PDM Digital Microphone</td><td>Yes</td></tr>
+    <tr><td>MicroSD Card Slot</td><td>No</td></tr>
+    <tr><td>Grove I2C Connector</td><td>Yes</td></tr>
+    <tr><td>User Buttons</td><td>3</td></tr>
+    <tr><td>Battery Connector</td><td>2-pin JST 2.0 Connector for 3.7 V LiPo</td></tr>
+    <tr><td>Battery Monitoring</td><td>Battery status detection supported; battery voltage can also be monitored for battery-level estimation.</td></tr>
+    <tr><td>Expansion Interfaces</td><td>1x Grove I2C Connector, 1x I2C pads, 1x I2S pads, 1x SWD pads, 3x user-button pads</td></tr>
+    <tr><td>Board Size</td><td>26 × 48 × 10.6 mm</td></tr>
+    <tr><td>Best For</td><td>Portable sensor displays, Grove devices, physical controllers</td></tr>
+  </table>
+</div>
+
+:::note
+This display board is designed for the **XIAO nRF52840 Plus**. If you are using the XIAO ESP32-S3 Plus version, please refer to the [XIAO 1.14'' IPS Display (ESP32-S3)](/getting_started_1.14_inch_display_esp32s3) guide instead.
+:::
+
+## Hardware Overview
+
+Before we start, refer to the following image to understand the physical layout of the 1.14'' IPS Display.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_display_hardware_overview.png" style={{width:1000, height:'auto'}}/></div>
+
+### Pin Map
+
+The 1.14'' IPS Display breaks out all XIAO nRF52840 Plus pins. The table below lists every pin, its net name on the display board, its function, and how it is connected to onboard peripherals.
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>XIAO Pin</th><th>Net Name</th><th>Function Description</th><th>Hardware Connection Notes</th></tr>
+    <tr><td>D0</td><td>PDM_CLK</td><td>PDM digital microphone clock</td><td>Internally connected to PDM Mic</td></tr>
+    <tr><td>D1</td><td>MIC_DATA</td><td>PDM digital microphone data</td><td>Internally connected to PDM Mic</td></tr>
+    <tr><td>D2</td><td>LCD_CS</td><td>Screen chip select signal</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D3</td><td>LCD_DC</td><td>Screen data/command switch</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D4</td><td>SDA</td><td>I2C data bus</td><td>Bus sharing: internally connected to IMU; externally exposed to Grove I2C connector</td></tr>
+    <tr><td>D5</td><td>SCL</td><td>I2C clock bus</td><td>Bus sharing: internally connected to IMU; externally exposed to Grove I2C connector</td></tr>
+    <tr><td>D6</td><td>BTN_A</td><td>Physical button A (left)</td><td>Internally connected to front-left microswitch with external 1 KΩ pull-up. Externally exposed as U1 test pad</td></tr>
+    <tr><td>D7</td><td>BTN_B</td><td>Physical button B (right)</td><td>Internally connected to front-right microswitch with external 1 KΩ pull-up. Externally exposed as U2 test pad</td></tr>
+    <tr><td>D8</td><td>SCK</td><td>Hardware SPI clock</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D9</td><td>NC</td><td>Floating (reserved)</td><td>No physical connection</td></tr>
+    <tr><td>D10</td><td>MOSI</td><td>Hardware SPI data output</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D11</td><td>I2S_SD</td><td>Audio data output</td><td>Externally exposed to bottom expansion pad</td></tr>
+    <tr><td>D12</td><td>I2S_SCK</td><td>Audio bit clock</td><td>Externally exposed to bottom expansion pad</td></tr>
+    <tr><td>D13</td><td>I2S_WS</td><td>Audio word select</td><td>Externally exposed to bottom expansion pad</td></tr>
+    <tr><td>D14</td><td>IMU_INT</td><td>IMU motion hardware interrupt</td><td>Internally connected to 6-axis IMU for asynchronous wake-up</td></tr>
+    <tr><td>D15</td><td>NC</td><td>Reserved test point</td><td>Bare copper test pad reserved on PCB</td></tr>
+    <tr><td>D16</td><td>NC</td><td>Floating (reserved)</td><td>No physical connection</td></tr>
+    <tr><td>D17</td><td>LCD_RST</td><td>Screen soft reset</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D18</td><td>LCD_BL</td><td>Screen backlight control</td><td>Internally connected to backlight driver circuit</td></tr>
+    <tr><td>D19</td><td>BTN_C</td><td>Physical button C (side)</td><td>Internally connected to side microswitch with external 1 KΩ pull-up. Externally exposed as U3 test pad</td></tr>
+  </table>
+</div>
+
+
+## Getting Started
+
+This guide uploads a minimal **"Hello, XIAO"** sketch to the display board: the screen turns on its backlight, fills black, and prints **"Hello,"** and **"XIAO"** as two centered lines of large green text. It is the fastest way to confirm the screen and your development environment are working before diving into the individual peripheral demos.
+
+### Software Preparation
+
+You will need the following tools and libraries:
+
+- **Arduino IDE** (version 1.8 or later)
+
+<div class="download_arduino_container" style={{textAlign: 'center'}}>
+    <a class="download_arduino_item" href="https://www.arduino.cc/en/software"><strong><span><font color={'FFFFFF'} size={"4"}>Download Arduino IDE</font></span></strong></a>
+</div><br />
+
+- **Seeed nRF52 Boards (1.1.13)** — add the following URL to **File > Preferences > Additional Boards Manager URLs**:
+
+```
+https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
+```
+
+Then go to **Tools > Board > Boards Manager**, search for **Seeed nRF52** and install version **1.1.13**.
+
+- **Seeed_GFX2 (Manual Installation)** — this library is not available in the Library Manager and must be installed manually:
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Studio/Seeed_GFX2/archive/refs/tags/v1.0.0.zip" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> Download Seeed_GFX2</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+**Step 1.** Click the button above to download `Seeed_GFX2` v1.0.0 as a ZIP file (pinned to a release tag so the tutorial stays reproducible). Alternatively, clone the repository from [Seeed-Studio/Seeed_GFX2](https://github.com/Seeed-Studio/Seeed_GFX2).
+
+**Step 2.** In the Arduino IDE, go to **Sketch > Include Library > Add .ZIP Library...** and select the downloaded ZIP. The IDE reads `library.properties` and installs it into the correct `Seeed_GFX2` folder automatically — you do not need to rename the extracted folder. (To install manually instead, unzip the archive and rename the extracted folder to `Seeed_GFX2` before placing it in `Documents/Arduino/libraries/`.)
+
+**Step 3.** Restart the Arduino IDE so the new library is detected.
+
+:::tip
+- **Seeed_GFX2** is Seeed Studio's graphics library built on a layered `Board` + `Panel Config` architecture. Each demo initializes the display with a single `display.begin<Board_..., Config_...>()` call — the **Board** template owns the pin map (CS/DC/SCK/MOSI/RST/BL), and the **Panel Config** bakes in the 135×240 resolution, color order (BGR), and orientation. No `driver.h` or manual pin setup is needed.
+- On this board the sketch uses `Board_XIAO_1inch14_LCD<38, 37>` (RST=38, BL=37) with `Config_Seeed_1inch14_LCD_ST7789`.
+- The **Adafruit TinyUSB** library used by the sketch is bundled with the **Seeed nRF52 Boards** package, so it needs no separate installation.
+:::
+
+### Download the Code
+
+The example sketch is available on GitHub:
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/getting_started_code/xiao_nrf52840_114_hello" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> Download the Code</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+Navigate to `code_GFX2/getting_started_code/xiao_nrf52840_114_hello/` and open `xiao_nrf52840_114_hello.ino` in the Arduino IDE. **Download the complete folder** rather than copying the `.ino` source from the GitHub web view.
+
+### Upload the Sketch
+
+**Step 1.** Connect the XIAO nRF52840 Plus to your computer via the USB-C port.
+
+**Step 2.** In Arduino IDE, select the board: **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus**.
+
+**Step 3.** Select the correct **Port** under **Tools > Port**.
+
+**Step 4.** Click the **Upload** button (→). The sketch will compile and upload to the board.
+
+:::note
+If you encounter upload issues, double-click the reset button to enter bootloader mode. The USR LED will breathe in red and a **NRF52BOOT** drive will appear on your computer, indicating the board is in bootloader mode.
+:::
+
+### Expected Output
+
+After uploading, the screen lights up with a black background and shows two centered lines of large green text — **"Hello,"** on the first line and **"XIAO"** on the second. The greeting stays on screen without redrawing.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/114_nRF52840Plus_display_hello.gif" style={{width:500, height:'auto'}}/></div>
+
+If the display fails to initialize, the sketch prints the library error message to the serial monitor at **115200** baud. Open **Tools > Serial Monitor** and set the baud rate to 115200 to read it.
+
+## What's Next
+
+The display board packs several onboard peripherals. The [Function](/function_1.14_inch_display_nrf52840) page provides a standalone demo for each one:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Peripheral</th><th>Demo</th></tr>
+    <tr><td>Screen</td><td>[GraphicTest](/function_1.14_inch_display_nrf52840#screen-display--graphictest) — ten graphics primitives with timing benchmarks</td></tr>
+    <tr><td>IMU</td><td>[Electronic Quicksand + Raise to Wake](/function_1.14_inch_display_nrf52840#imu) — 6-axis motion effects and wake-on-motion</td></tr>
+    <tr><td>Microphone & Speaker</td><td>[Voice Bar + Flash Recorder](/function_1.14_inch_display_nrf52840#microphone--speaker) — live PDM level meter and recording with I2S playback</td></tr>
+    <tr><td>Grove I2C</td><td>[SHT31 Temperature & Humidity](/function_1.14_inch_display_nrf52840#grove-i2c) — read a Grove SHT31 sensor</td></tr>
+    <tr><td>Buttons</td><td>[User Buttons](/function_1.14_inch_display_nrf52840#user-buttons) — read presses and debounce with interrupts</td></tr>
+    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_1.14_inch_display_nrf52840#battery-voltage-detection) — measure voltage and convert to a percentage</td></tr>
+  </table>
+</div>
+
+## FAQ
+
+### What if the upload fails or the board is not detected?
+
+Double-click the reset button on the XIAO nRF52840 Plus. The USR LED will breathe in red and a drive named **NRF52BOOT** will appear on your computer. Drag the compiled `.uf2` file onto the **NRF52BOOT** drive. The board will program itself and reset automatically.
+
+### [About Factory Firmware-DashBoard]
+
+#### Can I hot-plug I2C devices while the dashboard is running?
+
+No — we strongly recommend **against hot-plugging** devices on the I2C interface while the dashboard is running. Always power off the board before connecting or disconnecting anything on the Grove I2C connector or the SDA/SCL breakout pads. Hot-plugging can hang the I2C bus.
+
+## Resources
+
+- **🗃️[PCB Design Files]** [XIAO 1.14'' IPS Display (nRF52840) KiCad Project](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/kicad/XIAO%201.14%27%27%20IPS%20Display%20%28nRF52840%29%20KiCad%20Project.zip)
+- **📄[Schematic]** [XIAO 1.14'' IPS Display (nRF52840) Schematic](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/schematic/XIAO%201.14%27%27%20IPS%20Display%20%28nRF52840%29%20Schematic.pdf)
+- **📦[3D Model]** [XIAO 1.14'' IPS Display (STEP)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/3d-model/XIAO%201.14%27%27%20IPS%20Display.step)
+- **📄[Datasheet]** [1.14 Inch Display Datasheet](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/datasheet/1.14%20Inch%20Display%20Datasheet.pdf)
+- **💾[Factory Firmware]** [XIAO 1.14'' IPS Display (nRF52840) Factory Firmware](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/firmware/XIAO%201.14%27%27%20IPS%20Display%20%28nRF52840%29%20Factory%20Firmware.uf2)
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="table-center">
+  <div class="button_tech_support_container">
+  <a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+  <a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+  </div>
+
+  <div class="button_tech_support_container">
+  <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+  <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+  </div>
+</div>

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/Application/_category_.yml
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/Application/_category_.yml
@@ -1,0 +1,4 @@
+position: 3
+label: 'Application'
+collapsible: true
+collapsed: true

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/_category_.yml
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/_category_.yml
@@ -1,0 +1,4 @@
+position: 1
+label: "XIAO 1.47'' IPS Display (nRF52840)"
+collapsible: true
+collapsed: true

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.47_inch_touch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.47_inch_touch_display_nrf52840.md
@@ -785,7 +785,6 @@ VBAT 3.87V  charging  85  spread=5  usb=ON  base=4.140  baseValid=Y  state=PRESE
 - **📄[Schematic]** [XIAO 1.47'' IPS Display (nRF52840) Schematic](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/schematic/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20Schematic.pdf)
 - **📦[3D Model]** [XIAO 1.47'' IPS Display (STEP)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/3d-model/XIAO%201.47%27%27%20IPS%20Display.step)
 - **📄[Datasheet]** [1.47 Inch Display Datasheet](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/datasheet/1.47%20Inch%20Display%20Datasheet.pdf)
-- **🏠[3D Enclosure]** [XIAO 1.47'' IPS Display Enclosure (Design by gokul)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/enclosure/XIAO%201.47%27%27%20IPS%20Display%20Enclosure.zip)
 - **💾[Factory Firmware]** [XIAO 1.47'' IPS Display (nRF52840) Factory Firmware](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/firmware/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20Factory%20Firmware.uf2)
 - **[Demo]** [XIAO Display Board Demo Code](https://github.com/Seeed-Projects/Display-Gadgets) — all Function demos are in the `code_GFX2/Function/147_nRF52840/` directory
 

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.47_inch_touch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.47_inch_touch_display_nrf52840.md
@@ -1,0 +1,806 @@
+---
+description: Standalone function-level demos for each onboard peripheral of the XIAO 1.47'' IPS Display (nRF52840). Covers screen, touch, SD card, microphone, IMU, buttons, and battery voltage detection.
+title: Onboard Peripheral Usage
+keywords:
+  - XIAO
+  - nRF52840
+  - IPS Display
+  - LCD
+  - Function
+image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+slug: /function_1.47_inch_touch_display_nrf52840
+sku: 100004242
+sidebar_label: Function
+sidebar_position: 2
+last_update:
+  date: 08/20/2026
+  author: FaiyuetCik
+createdAt: '2026-08-11'
+updatedAt: '2026-08-24'
+url: https://wiki.seeedstudio.com/function_1.47_inch_touch_display_nrf52840/
+---
+
+# Onboard Peripheral Usage
+
+This page collects standalone function-level demos for each onboard peripheral of the 1.47'' IPS Display. Each section is self-contained — you can pick the one that matches your use case without reading through the others.
+
+:::tip
+The demo GIFs on this page are sped up to keep them short.
+:::
+
+:::note
+All demos in this page require **Seeed nRF52 Boards (1.1.13)** as described in [Getting Started](/getting_started_1.47_inch_touch_display_nrf52840), plus the **Seeed_GFX2** library installed manually as described below.
+:::
+
+- **Library Manager** — go to **Sketch > Include Library > Manage Libraries...**, search for and install:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Library</th><th>Search Keyword</th><th>Author</th><th>Required by</th></tr>
+    <tr><td><strong>Seeed Arduino LSM6DS3</strong></td><td><code>Seeed Arduino LSM6DS3</code></td><td>Seeed Studio</td><td>IMU demos</td></tr>
+  </table>
+</div>
+
+:::note
+**SdFat** is bundled with the **Seeed nRF52 Boards (1.1.13)** board package, so the **SD Image Reader** and **Record to SD** demos need no separate SdFat install. Do not install SdFat from the Library Manager, as it may override the bundled version and cause library or API conflicts.
+:::
+
+- **Seeed_GFX2 (Manual Installation)** — this library is not available in Library Manager and must be installed manually:
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Studio/Seeed_GFX2/archive/refs/tags/v1.0.0.zip" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> Download Seeed_GFX2</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+**Step 1.** Click the button above to download `Seeed_GFX2` v1.0.0 as a ZIP file (pinned to a release tag so the tutorial stays reproducible). Alternatively, clone the repository from [Seeed-Studio/Seeed_GFX2](https://github.com/Seeed-Studio/Seeed_GFX2).
+
+**Step 2.** In the Arduino IDE, go to **Sketch > Include Library > Add .ZIP Library...** and select the downloaded ZIP. The IDE reads `library.properties` and installs it into the correct `Seeed_GFX2` folder automatically — you do not need to rename the extracted folder. (To install manually instead, unzip the archive and rename the extracted folder to `Seeed_GFX2` before placing it in `Documents/Arduino/libraries/`.)
+
+**Step 3.** Restart the Arduino IDE so the new library is detected.
+
+:::tip
+- **Seeed_GFX2** is Seeed Studio's graphics library built on a layered `Board` + `Panel Config` architecture. Each demo initializes the display with a single `display.begin<Board_..., Config_...>()` call — the **Board** template owns the pin map (CS/DC/SCK/MOSI/RST/BL), and the **Panel Config** bakes in the 172×320 resolution, color order (BGR), and orientation. No `driver.h` or manual pin setup is needed.
+- On this board the demos use `Board_XIAO_1inch47_Touch_Display<38, 37>` (RST=38, BL=37) with `Config_Seeed_1inch47_Touch_JD9853A` (172×320, BGR, no inversion).
+- The **touch controller** (AXS5106L) is handled by the `Seeed_GFX2` Touch layer (`Touch_AXS5106L`) — no extra library is needed. The **IMU** demos use the **Seeed Arduino LSM6DS3** library (installed above).
+:::
+
+## Getting the Demo Code
+
+Every demo on this page lives in the [Display-Gadgets](https://github.com/Seeed-Projects/Display-Gadgets) repository, under the `code_GFX2/Function/` directory. Each demo is a folder containing a single `.ino` sketch. **Always download the complete folder** rather than copying the `.ino` source from the GitHub web view.
+
+**Option A — Download the repository as a ZIP (recommended):**
+
+1. Open [github.com/Seeed-Projects/Display-Gadgets](https://github.com/Seeed-Projects/Display-Gadgets) and click **Code > Download ZIP**, then extract the archive anywhere convenient.
+2. Navigate into `code_GFX2/Function/` and open the folder shown in each demo's **Code location** line. For example, the GraphicTest demo for this board lives in `code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_graphictest/`.
+3. **Double-click the `.ino` file** to open it in the Arduino IDE.
+
+**Option B — git clone:**
+
+```sh
+git clone https://github.com/Seeed-Projects/Display-Gadgets.git
+```
+
+Then open the demo's `.ino` file from the cloned `code_GFX2/Function/...` folder.
+
+## Screen Display — GraphicTest
+
+This demo runs a full graphics benchmark on the 1.47-inch JD9853A panel, covering color bars, lines, rectangles, circles, triangles, rounded rectangles, text, and a pixel gradient. Use it to verify that the screen is wired correctly and that all draw calls work as expected.
+
+**Code location:** `code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_graphictest/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The sketch initializes the JD9853A panel via **Seeed_GFX2**, then runs through ten graphics primitives in sequence, measuring the execution time of each one via `micros()` and printing the result to the serial monitor.
+
+The display is initialized with a single template call:
+
+```cpp
+display.begin<Board_XIAO_1inch47_Touch_Display<38, 37>,
+              Config_Seeed_1inch47_Touch_JD9853A>();
+```
+
+The **Board** template owns the pin map — CS=D2, DC=D3, SCK=D8, MOSI=D10 — and its `<RST, BL>` template parameters take bare GPIO numbers, so `<38, 37>` sets RST=GPIO38 and BL=GPIO37. The **Panel Config** bakes in the 172×320 resolution, BGR color order, and no inversion — no `driver.h` or manual MADCTL write is needed.
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_147_graphictest.ino` in Arduino IDE.
+
+**Step 2.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**.
+
+**Step 3.** Click **Upload**.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud). You should see timing output for each test:
+
+```
+LCD width: 172
+LCD height: 320
+Color bars: 57.62 ms
+Lines: 4859.38 ms
+Fast lines: 95.70 ms
+Rectangles: 74.22 ms
+Filled rectangles: 236.33 ms
+Circles: 588.87 ms
+Triangles: 413.09 ms
+Round rectangles: 125.98 ms
+Text: 1961.91 ms
+Pixel gradient: 8716.80 ms
+Graphic test finished.
+```
+
+On the screen, you will see each test pattern displayed for about one second before the next one starts. When all tests complete, a "Finished" screen appears with a blue rounded-rectangle border.
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_graphictest.gif" style={{width:500, height:'auto'}}/></div>
+
+After the sketch runs through all patterns, the screen shows a "Graphic Test / Finished" message. Reset the board to run the test again.
+
+---
+
+## Touch — Touch Circle
+
+This demo turns the 1.47-inch touch screen into an interactive drawing pad. Tap anywhere on the screen and a white circle appears at your fingertip. Circles stay on screen, building up as you tap. Tap the **CLEAR** bar at the bottom of the screen to erase all circles and start over.
+
+**Code location:** `code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_touch_circle/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The demo uses the **AXS5106L** capacitive touch controller (I2C address `0x63`) connected via I2C on D4/D5. The touch interrupt line on **D7** fires on the falling edge whenever a finger touches or releases the screen. Touch is handled by the Seeed_GFX2 **Touch layer** (`Touch_AXS5106L`):
+
+```cpp
+Touch_AXS5106L touch(-1, D7, Wire, 172, 320);
+display.attachTouch(touch, display.panel().driver().bus());
+// ...
+display.getTouch(&x, &y);
+```
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Pin</th><th>Function</th></tr>
+    <tr><td>D4 (SDA)</td><td>I2C data bus — shared with IMU</td></tr>
+    <tr><td>D5 (SCL)</td><td>I2C clock bus — shared with IMU</td></tr>
+    <tr><td>D7</td><td>Touch interrupt (active-low, falling edge)</td></tr>
+    <tr><td>RST</td><td>Shared with the LCD reset (GPIO38)</td></tr>
+  </table>
+</div>
+
+**Edge-triggered drawing.** The sketch uses an edge-detection approach: it only adds a circle on the falling edge of a touch (finger-down), not while the finger is held. This gives crisp, intentional tap-to-draw behavior rather than continuously painting a trail as you drag.
+
+**X-axis mirroring.** The touch panel is physically mounted in a different orientation than the LCD, so the raw X coordinate must be mirrored. `display.getTouch()` already applies this mirroring internally and returns screen coordinates, so no manual `screenX = 172 - 1 - rawX` transform is needed.
+
+**Circle buffer.** Up to 120 circles are stored in a circular buffer. When the buffer is full, the oldest circle is removed and the screen is redrawn to keep the display clean.
+
+**CLEAR zone.** The bottom 36 pixels of the screen are reserved as a CLEAR bar. Tapping this area erases all circles and resets the counter instead of drawing a new circle.
+
+**Safe drawing area.** A dim gray border outlines the area where circles are fully visible.
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_147_touch_circle.ino` in Arduino IDE.
+
+**Step 2.** Select the board and port, then click **Upload**.
+
+**Step 3.** Open **Tools > Serial Monitor** (115200 baud). You should see:
+
+```
+LCD: 172x320
+Touch: AXS5106L ready
+Tap screen to draw white circles.
+Tap CLEAR bar at bottom to erase.
+```
+
+**Step 4.** Tap the screen — each tap prints the mapped screen coordinates:
+
+```
+Touch: screen=(144,124)
+Touch: screen=(166,210)
+Touch: screen=(121,250)
+Touch: screen=(37,231)
+Touch: screen=(122,44)
+```
+
+Tap the CLEAR bar at the bottom to erase all circles.
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_touch_circle.gif" style={{width:500, height:'auto'}}/></div>
+
+Each tap leaves a white circle at your fingertip. The screen title bar shows the running count. Tap the CLEAR bar and the screen resets to blank with the border and title bar redrawn.
+
+---
+
+## SD Card — Image Reader
+
+This demo reads `.bmp` image files from a MicroSD card and displays them on the screen. It supports 24-bit uncompressed BMP images and center-crops them to fit the 172×320 display.
+
+**Code location:** `code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_sd_image_reader/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The LCD and SD card share the same hardware SPI bus (SCK = D8, MOSI = D10, MISO = D9). To avoid bus contention, the sketch de-asserts the SD card chip-select (D6) before any LCD operation and re-asserts it before SD access. The SD card is driven by SdFat in `SHARED_SPI` mode on the default `SPI` instance, while the LCD runs on Seeed_GFX2's SPI host — both share the same physical D8/D9/D10 pins.
+
+The sketch scans the SD card root directory for `.bmp` files (up to 24), then displays them in a loop with a 2-second interval between images.
+
+**Supported BMP formats:**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Format</th><th>Bit Depth</th><th>Notes</th></tr>
+    <tr><td>Uncompressed BMP</td><td>24-bit</td><td>BGR888 converted to RGB565 for display</td></tr>
+  </table>
+</div>
+
+Images larger than 172×320 are center-cropped.
+
+### Running the Demo
+
+**Step 1.** Format a MicroSD card as **FAT32**.
+
+**Step 2.** Copy one or more `.bmp` images to the root of the SD card.
+
+**Step 3.** Insert the SD card into the MicroSD slot on the display board.
+
+**Step 4.** Open `xiao_nrf52840_147_sd_image_reader.ino` in Arduino IDE, select the board and port, and click **Upload**.
+
+**Step 5.** Open **Tools > Serial Monitor** (115200 baud). You should see:
+
+```
+[IMAGE] /Atest.bmp
+[IMAGE] /Another test.bmp
+[IMAGE] /test.bmp
+[SD] mounted @ 8000000
+```
+
+:::note
+The filenames listed reflect the `.bmp` files you placed on the SD card. Your output will vary depending on the files you copy to the card.
+:::
+
+The screen displays each image for 2 seconds, then advances to the next one in a continuous loop.
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_sd_reader.gif" style={{width:500, height:'auto'}}/></div>
+
+If no BMP files are found, the screen shows "No BMP found". If an image fails to decode, the screen briefly shows the file path with "BMP decode failed" and moves to the next file.
+
+---
+
+## Microphone & Speaker
+
+The 1.47'' IPS Display has an onboard **PDM (Pulse Density Modulation) digital microphone** for audio input, plus I2S output pads for driving an external speaker/amplifier. This section shows two demos: a real-time **Volume Bar** visualization of the microphone input (no extra hardware), and a **Record to SD** demo that records 5 seconds of audio to a MicroSD card and plays it back through an external I2S amplifier.
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Pin</th><th>Signal</th><th>Function</th></tr>
+    <tr><td>D0</td><td>PDM_CLK</td><td>PDM clock output to microphone</td></tr>
+    <tr><td>D1</td><td>MIC_DATA</td><td>PDM data input from microphone</td></tr>
+  </table>
+</div>
+
+### Demo 1: Volume Bar
+
+This demo turns the onboard PDM microphone into a large, responsive volume meter. A 10-segment bar fills the center of the screen — green at low levels, yellow at mid-range, red when loud. The percentage is displayed above the bar and changes color to match the level.
+
+**Code location:** `code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_mic_canvas/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+#### How It Works
+
+The onboard **PDM (Pulse Density Modulation) digital microphone** is connected to the nRF52840's PDM peripheral via **D0 (PDM_CLK)** and **D1 (MIC_DATA)** as shown in the pin table above.
+
+The Arduino **PDM library** handles the low-level PDM-to-PCM conversion in hardware. The sketch configures the PDM peripheral at **16 kHz mono** with a gain of **30**, then registers an interrupt-driven callback (`onPDMdata`) that fires whenever a 256-sample buffer is ready.
+
+**Signal processing:**
+
+1. **Peak extraction** — each callback scans the 256-sample buffer for the largest absolute value (peak amplitude).
+2. **Normalization** — the raw peak is mapped from a floor of 40 to a ceiling of 16,000, producing a 0.0–1.0 volume value. Values below the floor are treated as silence.
+3. **Exponential smoothing** — the displayed volume is an exponential moving average of the raw peak (α = 0.20) to prevent jitter. When silence is detected, the displayed value decays by ×0.94 per frame.
+
+**Bar drawing:**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Segment</th><th>Color</th><th>Volume Range</th></tr>
+    <tr><td>0–4 (bottom 5)</td><td>Green</td><td>0% – 50%</td></tr>
+    <tr><td>5–8 (middle 4)</td><td>Yellow</td><td>50% – 90%</td></tr>
+    <tr><td>9 (top)</td><td>Red</td><td>90% – 100%</td></tr>
+  </table>
+</div>
+
+The bar uses **differential rendering**: only segments whose state changed since the last frame are redrawn. Unchanged segments are left as-is, minimizing SPI traffic and preventing flicker.
+
+#### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_147_mic_canvas.ino` in Arduino IDE.
+
+**Step 2.** Select the board and port, then click **Upload**.
+
+**Step 3.** Open **Tools > Serial Monitor** (115200 baud). You should see:
+
+```
+[MIC] ready
+```
+
+**Step 4.** Speak into the PDM microphone (located near the bottom-left corner of the display board) or blow on it. The bar fills from green to yellow to red, and the percentage updates above it.
+
+#### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_mic_bar.gif" style={{width:500, height:'auto'}}/></div>
+
+The bar responds in real time. In a quiet room the bar stays empty. Speaking at a normal volume from ~20 cm away lights up the green segments. Blowing directly into the mic pushes into the yellow or red range.
+
+---
+
+### Demo 2: Record to SD
+
+This demo records **5 seconds** of audio from the onboard PDM microphone into RAM, saves it to a MicroSD card as a WAV file, then plays it back through an external I2S amplifier. Press one button to record, another to play.
+
+**Code location:** `code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_sd_unline_record/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+#### Hardware Setup
+
+Playback requires an external **I2S audio amplifier and speaker**. The demo is written for a **MAX98357A** breakout connected to the board's I2S output pads:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>I2S Pad</th><th>XIAO Pin</th><th>MAX98357A</th></tr>
+    <tr><td>3V3</td><td>3V3</td><td>VIN</td></tr>
+    <tr><td>GND</td><td>GND</td><td>GND</td></tr>
+    <tr><td>I2S_SD</td><td>D11</td><td>DIN</td></tr>
+    <tr><td>I2S_SCK</td><td>D12</td><td>BCLK</td></tr>
+    <tr><td>I2S_WS</td><td>D13</td><td>LRC</td></tr>
+  </table>
+</div>
+
+The I2S pads (3V3, GND, D11, D12, D13) are exposed on the bottom expansion pad group of the display board.
+
+#### How It Works
+
+**Recording.** The onboard PDM microphone is captured at **16 kHz mono, 16-bit** through the nRF52840's PDM peripheral, using the same **D0 (PDM_CLK)** / **D1 (MIC_DATA)** pins as Demo 1. When you press **USR1**, the sketch samples 5 seconds of audio directly into a static RAM buffer, then writes it to the SD card as a WAV file (`/REC_001_RAW.WAV`) using the SdFat library bundled with Seeed nRF52 Boards 1.1.13.
+
+The recording is buffered in RAM because the nRF52840 has only **256 KB of RAM**. At 16 kHz × 16-bit mono, 5 seconds needs 160,000 bytes — which fits. 10 seconds would need 320,000 bytes and would not fit, so the demo is fixed at 5 seconds.
+
+**Playback.** Pressing **USR2** reads the WAV back from the SD card (skipping the 44-byte WAV header) and streams it out through the nRF52840's I2S peripheral in Philips stereo mode on **D11/D12/D13**. The mono samples are duplicated to both channels with a `0.75×` gain applied to avoid clipping. The amplifier drives a small speaker so you can hear the recording.
+
+**State machine.** The recorder runs through a deterministic sequence of states, printing each transition to the serial monitor:
+
+```
+IDLE → PREPARE_SYSTEM → QUIET_RADIO → PREPARE_PERIPHERALS → START_HFCLK → START_PDM
+     → DISCARD_WARMUP → CAPTURE_RAM → STOP_PDM → SAVE_RAW → DONE
+```
+
+- **QUIET_RADIO** disables the RADIO peripheral (this sketch never initializes BLE) to keep the timing-sensitive capture section stable.
+- **START_HFCLK** switches the high-frequency clock to the external 32 MHz crystal, which the PDM peripheral needs for accurate sampling.
+- **DISCARD_WARMUP** drops the first 300 ms of PDM output while the microphone settles.
+- **CAPTURE_RAM** fills the buffer until 80,000 samples (5 s) are collected, drawing a live progress bar on screen.
+
+**On-screen states:**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>State</th><th>Description</th></tr>
+    <tr><td><strong>Ready</strong></td><td>"RAM Recorder" title with "USR1: record" and "USR2: play last"</td></tr>
+    <tr><td><strong>Recording</strong></td><td>"Recording" label, an elapsed timer ("2.3s / 5s"), and a red progress bar</td></tr>
+    <tr><td><strong>Done</strong></td><td>"Done" title with the saved filename and "Saved raw WAV", plus "USR1: record" / "USR2: play raw"</td></tr>
+    <tr><td><strong>Playback</strong></td><td>"Playback" title showing "Loading RAW audio..." then "Playing RAW audio", ending on "Finished"</td></tr>
+  </table>
+</div>
+
+#### Running the Demo
+
+**Step 1.** Format a MicroSD card as **FAT32** and insert it into the MicroSD slot on the display board.
+
+**Step 2.** Connect a MAX98357A amplifier and speaker to the I2S pads as described above.
+
+**Step 3.** Open `xiao_nrf52840_147_sd_unline_record.ino` in Arduino IDE, select the board and port, and click **Upload**.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud). On boot you should see:
+
+```
+=== XIAO nRF52840 Plus RAM PDM recorder ===
+[RAM] record buffer bytes=160000
+[RADIO] BLE is not initialized by this sketch
+[PDM] library uses EasyDMA double buffering
+[STATE] IDLE
+```
+
+**Step 5.** Press **USR1 (D19)** to record 5 seconds of audio from the onboard microphone. The progress bar fills as it records, and the state machine prints each transition:
+
+```
+[STATE] PREPARE_SYSTEM
+[STATE] QUIET_RADIO
+[STATE] PREPARE_PERIPHERALS
+[STATE] START_HFCLK
+[STATE] START_PDM
+[STATE] DISCARD_WARMUP
+[STATE] CAPTURE_RAM
+[STATE] STOP_PDM
+[STATE] SAVE_RAW
+[STATE] DONE
+[SAVE] /REC_001_RAW.WAV
+```
+
+**Step 6.** Press **USR2 (D15)** to play the recording back through the speaker:
+
+```
+[PLAY] latest RAW audio
+[PLAY] finished
+```
+
+:::note
+Each new recording is saved as a numbered WAV file (`REC_001_RAW.WAV`, `REC_002_RAW.WAV`, …), so previous recordings are kept. The "Done" screen shows the filename of the most recent recording.
+:::
+
+#### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_record.gif" style={{width:500, height:'auto'}}/></div>
+
+Press USR1 and the screen shows a recording progress bar. After 5 seconds it confirms the WAV was saved to the SD card. Press USR2 and the audio plays through the connected speaker while the screen shows the playback status.
+
+---
+
+## IMU
+
+### Demo 1: Electronic Quicksand
+
+This demo turns the screen into an interactive fluid simulation — golden sand particles that flow and settle according to gravity, as measured by the onboard LSM6DS3 6-axis IMU. Tilt the board and the sand shifts direction in real time.
+
+**Code location:** `code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_electronic_quicksand/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The simulation uses a **24×45 occupancy grid** overlaid on the 172×320 screen, where each cell is 7×7 pixels. Around **180 particles** are placed in the grid, each with a position, velocity, and a golden color gradient.
+
+The LSM6DS3 accelerometer is read via I2C (D4/D5) every **8 ms**. The raw acceleration values are low-pass filtered and used to derive a gravity vector. When you tilt the board:
+
+1. **Gravity vector updates** — accelerometer data is smoothed with an exponential moving average to avoid jitter.
+2. **Particle velocity** — each particle accelerates in the direction of the gravity vector, with damping and a per-particle mobility factor based on its depth in the flow.
+3. **Cell occupancy** — particles deeper in the flow (closer to the "bottom" relative to gravity) have reduced mobility, creating a realistic packing effect.
+4. **Differential rendering** — only cells where particles moved into or out of are redrawn, minimizing SPI traffic and keeping the animation smooth.
+
+Particles near the surface flow freely (higher mobility); particles buried deeper pack tightly (lower mobility) — mimicking how real sand behaves.
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_147_electronic_quicksand.ino` in Arduino IDE.
+
+**Step 2.** Select the board and port, then click **Upload**.
+
+**Step 3.** Once uploaded, the screen fills with golden particles at the bottom. Tilt the board in different directions — the sand flows as if pulled by gravity.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud) to confirm initialization:
+
+```
+=== Electronic Quicksand ===
+imu.begin=0
+```
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_quicksand.gif" style={{width:500, height:'auto'}}/></div>
+
+The golden sand particles flow smoothly as you tilt the board. When held flat, the sand settles at the bottom of the screen. Rotate the board 90 degrees and the sand flows to the new "bottom" within a second.
+
+---
+
+### Demo 2: Raise to Wake
+
+This demo implements a **screen sleep/wake system** driven by the LSM6DS3 IMU's built-in wake-up interrupt on **D14**. The screen automatically turns off (backlight off + CPU enters System ON sleep) after 8 seconds of inactivity, and wakes instantly when you pick up or move the device.
+
+**Code location:** `code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_wakeup/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+The demo uses the LSM6DS3's **embedded wake-up event detector** — a hardware feature that monitors accelerometer data internally and asserts the INT1 pin (routed to D14 on this board) when motion exceeds a configurable threshold. This means the MCU does not need to poll the accelerometer continuously.
+
+**IMU configuration:**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Register</th><th>Value</th><th>Purpose</th></tr>
+    <tr><td><code>CTRL1_XL</code></td><td><code>0x40</code></td><td>Accelerometer @ 104 Hz, ±2g</td></tr>
+    <tr><td><code>CTRL3_C</code></td><td><code>0x44</code></td><td>Block data update + auto-increment</td></tr>
+    <tr><td><code>TAP_CFG</code></td><td><code>0x80</code></td><td>Enable embedded interrupts</td></tr>
+    <tr><td><code>WAKE_UP_THS</code></td><td><code>0x05</code></td><td>Wake-up threshold (medium-low sensitivity)</td></tr>
+    <tr><td><code>WAKE_UP_DUR</code></td><td><code>0x00</code></td><td>No duration filter (responsive wake)</td></tr>
+    <tr><td><code>MD1_CFG</code></td><td><code>0x20</code></td><td>Route wake-up to INT1</td></tr>
+  </table>
+</div>
+
+**Sleep/wake flow:**
+
+1. **Active state** — screen is on, backlight at PWM 120. IMU data and battery status refresh every 250 ms / 1000 ms respectively. A countdown timer shows seconds remaining until auto-sleep.
+2. **Auto-sleep** — after 8 seconds of no activity, the sketch turns off the backlight, draws a "Sleeping... Pick up device to wake" message, and enters nRF52840 **System ON sleep** via WFE (Wait For Event).
+3. **Wake-up** — when the user picks up the board, the LSM6DS3 detects motion and asserts D14 HIGH. The GPIO interrupt fires, the CPU wakes from WFE, the backlight turns on, and the UI is fully redrawn.
+
+In System ON sleep, all RAM and peripheral states are preserved — wake-up is nearly instant (under 1 ms from interrupt to backlight on).
+
+**Manual test buttons:**
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Pin</th><th>Action</th></tr>
+    <tr><td>USR1</td><td>D19</td><td>Force sleep</td></tr>
+    <tr><td>USR2</td><td>D15</td><td>Force wake</td></tr>
+  </table>
+</div>
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_147_wakeup.ino` in Arduino IDE, select the board and port, and click **Upload**.
+
+**Step 2.** The screen shows a dashboard with power state, motion data, and a countdown timer. Let the board sit still for 8 seconds — it will automatically sleep.
+
+**Step 3.** Pick up the board or shake it gently — the screen wakes immediately.
+
+**Step 4.** Open **Tools > Serial Monitor** (115200 baud) to observe the sleep/wake transitions:
+
+```
+[SLEEP] screen backlight off, waiting for IMU D14 wake
+[SYS_ON_SLEEP] waiting, sleepLoops=26625 D14=0 awake=N
+[SYS_ON_SLEEP] waiting, sleepLoops=27649 D14=0 awake=N
+[SYS_ON_SLEEP] waiting, sleepLoops=28673 D14=0 awake=N
+[SYS_ON_SLEEP] waiting, sleepLoops=29697 D14=0 awake=N
+[WAKE] reason=IMU_D14 wakeCount=1 sleptMs=58776 sleepLoops=29705
+[WAKE] reason=IMU_D14 wakeCount=2 sleptMs=60110 sleepLoops=29705
+```
+
+### Expected Result
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_wakeup.gif" style={{width:500, height:'auto'}}/></div>
+
+The screen displays real-time accelerometer and gyroscope data while awake. After 8 seconds of stillness, the screen goes dark and the nRF52840 enters low-power sleep. Pick up the device and the screen restores within a fraction of a second, with the wake counter incremented.
+
+---
+
+## User Button
+
+The 1.47'' IPS Display has **two physical push buttons** connected to the XIAO nRF52840 Plus:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Pin</th><th>Logic</th><th>Silkscreen Label</th></tr>
+    <tr><td><strong>BTN_A</strong></td><td>D19</td><td>Active-low (pressed = LOW)</td><td>USR1</td></tr>
+    <tr><td><strong>BTN_B</strong></td><td>D15</td><td>Active-low (pressed = LOW)</td><td>USR2</td></tr>
+  </table>
+</div>
+
+### Reading a Button
+
+Both buttons use the XIAO's internal pull-up resistors. A simple non-blocking read looks like this:
+
+```cpp
+const int BTN_A = D19;
+const int BTN_B = D15;
+
+void setup() {
+  pinMode(BTN_A, INPUT_PULLUP);
+  pinMode(BTN_B, INPUT_PULLUP);
+  Serial.begin(115200);
+}
+
+void loop() {
+  if (digitalRead(BTN_A) == LOW) {
+    Serial.println("BTN_A pressed");
+    delay(200); // simple debounce
+  }
+  if (digitalRead(BTN_B) == LOW) {
+    Serial.println("BTN_B pressed");
+    delay(200);
+  }
+}
+```
+
+### Debounce with Interrupts
+
+For responsive, debounced button handling without blocking the main loop, you can use pin-change interrupts:
+
+```cpp
+volatile bool btnAFlag = false;
+volatile bool btnBFlag = false;
+
+void btnAIsr() { btnAFlag = true; }
+void btnBIsr() { btnBFlag = true; }
+
+void setup() {
+  pinMode(D19, INPUT_PULLUP);
+  pinMode(D15, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(D19), btnAIsr, FALLING);
+  attachInterrupt(digitalPinToInterrupt(D15), btnBIsr, FALLING);
+}
+
+void loop() {
+  if (btnAFlag) {
+    btnAFlag = false;
+    delay(30); // debounce settling time
+    if (digitalRead(D19) == LOW) {
+      // handle BTN_A press
+    }
+  }
+  if (btnBFlag) {
+    btnBFlag = false;
+    delay(30);
+    if (digitalRead(D15) == LOW) {
+      // handle BTN_B press
+    }
+  }
+}
+```
+
+### Default Behavior in the Factory Dashboard
+
+In the preloaded factory firmware, the buttons are mapped as follows (you can override these in your own code):
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Button</th><th>Action</th></tr>
+    <tr><td><strong>BTN_A (D19)</strong></td><td>Short press: cycle screen brightness <strong>100% → 75% → 50% → 25% → 0% → 100%</strong></td></tr>
+    <tr><td><strong>BTN_B (D15)</strong></td><td>Short press: <strong>toggle screen off / restore to last brightness</strong></td></tr>
+  </table>
+</div>
+
+The button breakout pads (labeled U1 and U2 on the board) mirror D19 and D15 respectively, allowing you to connect external buttons if desired.
+
+---
+
+## Battery Status
+
+This demo shows the battery status — a battery icon with charge level and charging state — on the 1.47'' IPS Display. It detects whether a LiPo battery is physically connected and shows one of three states: **USB PWR** (no battery), **percentage** (battery only), or **charging** (USB + battery).
+
+The 1.47'' IPS Display includes an onboard battery voltage measurement circuit. The nRF52840 Plus reads the LiPo battery voltage through a voltage divider and can display the remaining capacity as a percentage.
+
+**Code location:** `code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_battery_status/`
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/Function/147_nRF52840/xiao_nrf52840_147_battery_status" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> View on GitHub</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+### How It Works
+
+**Display:**
+
+The screen is driven by **Seeed_GFX2** with `Board_XIAO_1inch47_Touch_Display<38, 37>` and `Config_Seeed_1inch47_Touch_JD9853A` (172×320, BGR, rotation 2) over 10 MHz hardware SPI.
+
+**Battery circuit:**
+
+The nRF52840 Plus uses **three GPIO pins** to form a complete battery monitoring system:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Signal</th><th>nRF52840 Pin</th><th>Function</th></tr>
+    <tr><td><code>READ_BAT</code></td><td><strong>P0.14</strong></td><td>Battery voltage divider enable. Active-low — set LOW to enable the divider, then release to HIGH (high-impedance) to save power.</td></tr>
+    <tr><td><code>VBAT_ADC</code></td><td><strong>PIN_VBAT</strong> (AIN7 / P0.31)</td><td>Analog input reading the divided battery voltage.</td></tr>
+    <tr><td><code>CHG</code></td><td><strong>P0.17</strong></td><td>Charging status indicator. Active-low — reads LOW when a charger is connected and the battery is charging.</td></tr>
+  </table>
+</div>
+
+**Detection:**
+
+Under USB-C, a static VBAT voltage cannot tell whether a battery is present — the charger's BAT node can look like a real Li-ion cell even with no battery attached. So the demo first learns a **USB-only baseline**, then confirms battery insertion only after a sustained downward VBAT shift, and confirms removal after a noisy/jumped reading combined with `~CHG` going HIGH. This mirrors the factory Dashboard's detection logic.
+
+**Icon states:**
+
+- **No battery** — grey outline battery with a red cross, labelled **USB PWR**.
+- **Battery present** — white outline battery with a coloured fill (green / yellow / red by percentage), labelled with the **percentage** and **voltage**.
+- **Charging** — cyan fill with a lightning-bolt icon, labelled with the percentage and voltage.
+
+:::note
+The `~CHG` pin is read through the nRF52840's **raw GPIO registers** (`nrf_gpio_cfg_input()` and `NRF_P0->IN`) instead of `digitalRead()`. In the Arduino API, pin numbers follow the board package's mapping, where `digitalRead(17)` actually reads **P0.07** (the 6D IMU's I2C data line) rather than P0.17. The constants `14` and `17` here are **raw Nordic P0.x pin numbers** (P0.14 and P0.17), which is exactly what the register calls expect.
+:::
+
+:::note
+The demo uses the factory-calibrated **499 kΩ** low-side resistor (divider ratio ≈ 3.004), not the 510 kΩ nominal value. The divider is built into the XIAO nRF52840 Plus module itself, not the display board. The P0.14 enable pin is **active-low**: drive it LOW to enable the divider, then release it to high-impedance (INPUT) to minimize quiescent current drain when the battery is not being measured.
+:::
+
+### Running the Demo
+
+**Step 1.** Open `xiao_nrf52840_147_battery_status.ino` in Arduino IDE.
+
+**Step 2.** Select **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus** and the correct **Port**.
+
+**Step 3.** Click **Upload**.
+
+**Step 4.** Observe the screen — it shows the battery icon with the current state. Plug or unplug a LiPo battery (or the USB-C cable) to watch the icon switch between the three states.
+
+### Expected Result
+
+<div class="table-center">
+  <table align="center">
+    <tr>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_battery_status_state1.jpg" style={{width:300, height:'auto'}}/><br/><strong>USB PWR</strong> (no battery)</div></td>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_battery_status_state2.jpg" style={{width:300, height:'auto'}}/><br/><strong>Percentage</strong> (battery only)</div></td>
+    </tr>
+    <tr>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_battery_status_state3.jpg" style={{width:300, height:'auto'}}/><br/><strong>Charging</strong> (USB + battery)</div></td>
+      <td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_function_battery_status_back.jpg" style={{width:300, height:'auto'}}/><br/><strong>Battery connector</strong> (back)</div></td>
+    </tr>
+  </table>
+</div>
+
+Without a battery, the screen shows a grey battery with a red cross and the label **USB PWR**. Insert a LiPo battery and the icon switches to a coloured fill with the percentage and voltage. Plug in USB-C while a battery is present and the fill turns cyan with a lightning bolt, indicating charging.
+
+The demo also prints a diagnostic line to the Serial Monitor every 500 ms, for example:
+
+```
+VBAT 3.87V  charging  85  spread=5  usb=ON  base=4.140  baseValid=Y  state=PRESENT  filter=STABLE  removeCount=0
+```
+---
+
+## Resources
+
+- **🗃️[PCB Design Files]** [XIAO 1.47'' IPS Display (nRF52840) KiCad Project](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/kicad/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20KiCad%20Project.zip)
+- **📄[Schematic]** [XIAO 1.47'' IPS Display (nRF52840) Schematic](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/schematic/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20Schematic.pdf)
+- **📦[3D Model]** [XIAO 1.47'' IPS Display (STEP)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/3d-model/XIAO%201.47%27%27%20IPS%20Display.step)
+- **📄[Datasheet]** [1.47 Inch Display Datasheet](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/datasheet/1.47%20Inch%20Display%20Datasheet.pdf)
+- **🏠[3D Enclosure]** [XIAO 1.47'' IPS Display Enclosure (Design by gokul)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/enclosure/XIAO%201.47%27%27%20IPS%20Display%20Enclosure.zip)
+- **💾[Factory Firmware]** [XIAO 1.47'' IPS Display (nRF52840) Factory Firmware](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/firmware/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20Factory%20Firmware.uf2)
+- **[Demo]** [XIAO Display Board Demo Code](https://github.com/Seeed-Projects/Display-Gadgets) — all Function demos are in the `code_GFX2/Function/147_nRF52840/` directory
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="table-center">
+  <div class="button_tech_support_container">
+  <a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+  <a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+  </div>
+
+  <div class="button_tech_support_container">
+  <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+  <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+  </div>
+</div>

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.47_inch_touch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.47_inch_touch_display_nrf52840.md
@@ -11,7 +11,6 @@ keywords:
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /function_1.47_inch_touch_display_nrf52840
 sku: 100004242
-sidebar_label: Function
 sidebar_position: 2
 last_update:
   date: 08/20/2026

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.47_inch_touch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/function_1.47_inch_touch_display_nrf52840.md
@@ -1,6 +1,7 @@
 ---
 description: Standalone function-level demos for each onboard peripheral of the XIAO 1.47'' IPS Display (nRF52840). Covers screen, touch, SD card, microphone, IMU, buttons, and battery voltage detection.
 title: Onboard Peripheral Usage
+sidebar_label: Function
 keywords:
   - XIAO
   - nRF52840

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
@@ -210,7 +210,6 @@ Double-click the reset button on the XIAO nRF52840 Plus. The USR LED will breath
 - **📄[Schematic]** [XIAO 1.47'' IPS Display (nRF52840) Schematic](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/schematic/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20Schematic.pdf)
 - **📦[3D Model]** [XIAO 1.47'' IPS Display (STEP)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/3d-model/XIAO%201.47%27%27%20IPS%20Display.step)
 - **📄[Datasheet]** [1.47 Inch Display Datasheet](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/datasheet/1.47%20Inch%20Display%20Datasheet.pdf)
-- **🏠[3D Enclosure]** [XIAO 1.47'' IPS Display Enclosure (Design by gokul)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/enclosure/XIAO%201.47%27%27%20IPS%20Display%20Enclosure.zip)
 - **💾[Factory Firmware]** [XIAO 1.47'' IPS Display (nRF52840) Factory Firmware](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/firmware/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20Factory%20Firmware.uf2)
 
 ## Tech Support & Product Discussion

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
@@ -1,0 +1,230 @@
+---
+description: Getting Started with XIAO 1.47'' IPS Display (nRF52840).
+title: Getting Started with XIAO 1.47'' IPS Display (nRF52840)
+keywords:
+  - XIAO
+  - nRF52840
+  - IPS Display
+  - LCD
+image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
+slug: /getting_started_1.47_inch_touch_display_nrf52840
+sku: 100004242
+sidebar_label: Getting Started
+sidebar_position: 1
+type: gettingstarted
+last_update:
+  date: 09/07/2026
+  author: FaiyuetCik
+createdAt: '2026-08-11'
+updatedAt: '2026-09-07'
+url: https://wiki.seeedstudio.com/getting_started_1.47_inch_touch_display_nrf52840/
+---
+
+# Getting Started with XIAO 1.47'' IPS Display (nRF52840)
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>XIAO 1.47'' IPS Display (nRF52840)</th></tr>
+    <tr><td><div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/NEW147_nRF52840Plus_display_hardware_hero.jpg" style={{width:600, height:'auto'}}/></div></td></tr>
+    <tr><td><div class="get_one_now_container" style={{textAlign: 'center'}}>
+        <a class="get_one_now_item" href="https://www.seeedstudio.com/1-47-Inch-Touch-Display-Powered-by-XIAO-nRF52840-Plus-p-6995.html" target="_blank">
+            <strong><span><font color={'FFFFFF'} size={"4"}> Get One Now 🖱️</font></span></strong>
+        </a>
+    </div></td></tr>
+  </table>
+</div>
+
+## Introduction
+
+The 1.47'' IPS Display is an expansion board designed for the XIAO series, powered by the XIAO nRF52840 Plus. It features a 172×320 color LCD with capacitive touch, onboard PDM microphone, 6-axis IMU (LSM6DS3), MicroSD card slot, and battery power management — all integrated into a compact form factor.
+
+This combination makes it an ideal platform for portable HMI applications, IoT dashboards, wearable devices, and interactive prototyping.
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Specification</th><th>Detail</th></tr>
+    <tr><td>Product Positioning</td><td>Touch & Full Interaction</td></tr>
+    <tr><td>Core Controller</td><td>Seeed Studio XIAO nRF52840 Plus</td></tr>
+    <tr><td>Processor</td><td>Nordic nRF52840, ARM® Cortex®-M4 32-bit processor with FPU, 64 MHz</td></tr>
+    <tr><td>Memory</td><td>256 KB RAM + 1 MB internal Flash + 2 MB onboard Flash</td></tr>
+    <tr><td>Wireless Connectivity</td><td>BLE 5.4</td></tr>
+    <tr><td>Display Type</td><td>1.47" IPS TFT LCD</td></tr>
+    <tr><td>Resolution</td><td>172 × 320</td></tr>
+    <tr><td>Display Driver</td><td>JD9853A</td></tr>
+    <tr><td>Display Interface</td><td>SPI</td></tr>
+    <tr><td>Touch Input</td><td>Capacitive Touch</td></tr>
+    <tr><td>6-Axis IMU</td><td>Yes</td></tr>
+    <tr><td>PDM Digital Microphone</td><td>Yes</td></tr>
+    <tr><td>MicroSD Card Slot</td><td>Yes</td></tr>
+    <tr><td>Grove I2C Connector</td><td>No</td></tr>
+    <tr><td>User Buttons</td><td>2</td></tr>
+    <tr><td>Battery Connector</td><td>2-pin JST 2.0 Connector for 3.7 V LiPo</td></tr>
+    <tr><td>Battery Monitoring</td><td>Battery status detection supported; battery voltage can also be monitored for battery-level estimation.</td></tr>
+    <tr><td>Expansion Interfaces</td><td>1x I2C pads, 1x I2S pads, 1x SWD pads, 2x user-button pads</td></tr>
+    <tr><td>Board Size</td><td>26.4 × 51.4 × 12.6 mm</td></tr>
+    <tr><td>Best For</td><td>Touch UI, portable HMI, local media and data logging</td></tr>
+  </table>
+</div>
+
+## Hardware Overview
+
+Before we start, refer to the following image to understand the physical layout of the 1.47'' IPS Display.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_display_hardware_overview.png" style={{width:1000, height:'auto'}}/></div>
+
+### Pin Map
+
+The 1.47'' IPS Display breaks out all XIAO nRF52840 Plus pins. The table below lists every pin, its net name on the display board, its function, and how it is connected to onboard peripherals.
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>XIAO Pin</th><th>Net Name</th><th>Function Description</th><th>Hardware Connection Notes</th></tr>
+    <tr><td>D0</td><td>PDM_CLK</td><td>MIC_CLK</td><td>PDM digital microphone clock</td></tr>
+    <tr><td>D1</td><td>MIC_DATA</td><td>PDM digital microphone data</td><td>Internally connected to PDM Mic</td></tr>
+    <tr><td>D2</td><td>LCD_CS</td><td>Screen chip select signal</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D3</td><td>LCD_DC</td><td>Screen data/command switch</td><td>Internally connected to LCD driver IC</td></tr>
+    <tr><td>D4</td><td>SDA</td><td>I2C data bus</td><td>Bus sharing: internally connected to IMU and touch IC; externally exposed as I2C expansion pads</td></tr>
+    <tr><td>D5</td><td>SCL</td><td>I2C clock bus</td><td>Bus sharing: internally connected to IMU and touch IC; externally exposed as I2C expansion pads</td></tr>
+    <tr><td>D6</td><td>SD_CS</td><td>SD card chip select signal</td><td>Internally connected to MicroSD card slot</td></tr>
+    <tr><td>D7</td><td>TOUCH_INT</td><td>Touch interrupt signal</td><td>Internally connected to touch IC for asynchronous wake-up</td></tr>
+    <tr><td>D8</td><td>SCK</td><td>Hardware SPI clock</td><td>Internally connected to LCD and SD card slot</td></tr>
+    <tr><td>D9</td><td>MISO</td><td>Hardware SPI data input</td><td>Internally connected to SD card slot</td></tr>
+    <tr><td>D10</td><td>MOSI</td><td>Hardware SPI data output</td><td>Internally connected to LCD and SD card slot</td></tr>
+    <tr><td>D11</td><td>I2S_SD</td><td>Audio data line</td><td>Corresponds to I2S_SD default mapping, exposed to bottom pad group</td></tr>
+    <tr><td>D12</td><td>I2S_SCK</td><td>Audio bit clock</td><td>Corresponds to I2S_SCK default mapping, exposed to bottom pad group</td></tr>
+    <tr><td>D13</td><td>I2S_WS</td><td>Audio word select</td><td>Corresponds to I2S_WS default mapping, exposed to bottom pad group</td></tr>
+    <tr><td>D14</td><td>IMU_INT</td><td>IMU motion interrupt</td><td>Function reassignment: used for motion wake-up</td></tr>
+    <tr><td>D15</td><td>BTN_B</td><td>Physical button 2 (USR2)</td><td>Function reassignment: user button 2. Externally exposed as button expansion pad</td></tr>
+    <tr><td>D16</td><td>NC</td><td>Floating (reserved)</td><td>No physical connection</td></tr>
+    <tr><td>D17</td><td>LCD_RST</td><td>Screen reset signal</td><td>Independent GPIO control for reliable startup</td></tr>
+    <tr><td>D18</td><td>LCD_BL</td><td>Screen backlight control</td><td>Supports hardware PWM brightness adjustment</td></tr>
+    <tr><td>D19</td><td>BTN_A</td><td>Physical button 1 (USR1)</td><td>User button 1. Externally exposed as button expansion pad</td></tr>
+  </table>
+</div>
+
+
+## Getting Started
+
+This guide uploads a minimal **"Hello, XIAO"** sketch to the display board: the screen turns on its backlight, fills black, and prints **"Hello,"** and **"XIAO"** as two centered lines of large green text. It is the fastest way to confirm the screen and your development environment are working before diving into the individual peripheral demos.
+
+### Software Preparation
+
+You will need the following tools and libraries:
+
+- **Arduino IDE** (version 1.8 or later)
+
+<div class="download_arduino_container" style={{textAlign: 'center'}}>
+    <a class="download_arduino_item" href="https://www.arduino.cc/en/software"><strong><span><font color={'FFFFFF'} size={"4"}>Download Arduino IDE</font></span></strong></a>
+</div><br />
+
+- **Seeed nRF52 Boards (1.1.13)** — add the following URL to **File > Preferences > Additional Boards Manager URLs**:
+
+```
+https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
+```
+
+Then go to **Tools > Board > Boards Manager**, search for **Seeed nRF52** and install version **1.1.13**.
+
+- **Seeed_GFX2 (Manual Installation)** — this library is not available in the Library Manager and must be installed manually:
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Studio/Seeed_GFX2/archive/refs/tags/v1.0.0.zip" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> Download Seeed_GFX2</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+**Step 1.** Click the button above to download `Seeed_GFX2` v1.0.0 as a ZIP file (pinned to a release tag so the tutorial stays reproducible). Alternatively, clone the repository from [Seeed-Studio/Seeed_GFX2](https://github.com/Seeed-Studio/Seeed_GFX2).
+
+**Step 2.** In the Arduino IDE, go to **Sketch > Include Library > Add .ZIP Library...** and select the downloaded ZIP. The IDE reads `library.properties` and installs it into the correct `Seeed_GFX2` folder automatically — you do not need to rename the extracted folder. (To install manually instead, unzip the archive and rename the extracted folder to `Seeed_GFX2` before placing it in `Documents/Arduino/libraries/`.)
+
+**Step 3.** Restart the Arduino IDE so the new library is detected.
+
+:::tip
+- **Seeed_GFX2** is Seeed Studio's graphics library built on a layered `Board` + `Panel Config` architecture. Each demo initializes the display with a single `display.begin<Board_..., Config_...>()` call — the **Board** template owns the pin map (CS/DC/SCK/MOSI/RST/BL), and the **Panel Config** bakes in the 172×320 resolution, color order (BGR), and orientation. No `driver.h` or manual pin setup is needed.
+- On this board the sketch uses `Board_XIAO_1inch47_Touch_Display<38, 37>` (RST=38, BL=37) with `Config_Seeed_1inch47_Touch_JD9853A`.
+- The **Adafruit TinyUSB** library used by the sketch is bundled with the **Seeed nRF52 Boards** package, so it needs no separate installation.
+:::
+
+### Download the Code
+
+The example sketch is available on GitHub:
+
+<div class="github_container" style={{textAlign: 'center'}}>
+    <a class="github_item" href="https://github.com/Seeed-Projects/Display-Gadgets/tree/main/code_GFX2/getting_started_code/xiao_nrf52840_147_hello" target="_blank" rel="noopener noreferrer">
+    <strong><span><font color={'FFFFFF'} size={"4"}> Download the Code</font></span></strong>
+    <svg aria-hidden="true" focusable="false" role="img" className="mr-2" viewBox="-3 10 9 1" width={16} height={16} fill="currentColor" style={{textAlign: 'center', display: 'inline-block', userSelect: 'none', verticalAlign: 'text-bottom', overflow: 'visible'}}><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" /></svg>
+    </a>
+</div><br />
+
+Navigate to `code_GFX2/getting_started_code/xiao_nrf52840_147_hello/` and open `xiao_nrf52840_147_hello.ino` in the Arduino IDE. **Download the complete folder** rather than copying the `.ino` source from the GitHub web view.
+
+### Upload the Sketch
+
+**Step 1.** Connect the XIAO nRF52840 Plus to your computer via the USB-C port.
+
+**Step 2.** In Arduino IDE, select the board: **Tools > Board > Seeed nRF52 Boards > Seeed XIAO nRF52840 Plus**.
+
+**Step 3.** Select the correct **Port** under **Tools > Port**.
+
+**Step 4.** Click the **Upload** button (→). The sketch will compile and upload to the board.
+
+:::note
+If you encounter upload issues, double-click the reset button to enter bootloader mode. The USR LED will breathe in red and a **NRF52BOOT** drive will appear on your computer, indicating the board is in bootloader mode.
+:::
+
+### Expected Output
+
+After uploading, the screen lights up with a black background and shows two centered lines of large green text — **"Hello,"** on the first line and **"XIAO"** on the second. The greeting stays on screen without redrawing.
+
+<div style={{textAlign:'center'}}><img src="https://files.seeedstudio.com/wiki/Display_Gadgets/imgs/147_nRF52840Plus_display_hello.gif" style={{width:500, height:'auto'}}/></div>
+
+If the display fails to initialize, the sketch prints the library error message to the serial monitor at **115200** baud. Open **Tools > Serial Monitor** and set the baud rate to 115200 to read it.
+
+## What's Next
+
+The display board packs several onboard peripherals. The [Function](/function_1.47_inch_touch_display_nrf52840) page provides a standalone demo for each one:
+
+<div class="table-center">
+  <table align="center">
+    <tr><th>Peripheral</th><th>Demo</th></tr>
+    <tr><td>Screen</td><td>[GraphicTest](/function_1.47_inch_touch_display_nrf52840#screen-display--graphictest) — ten graphics primitives with timing benchmarks</td></tr>
+    <tr><td>Touch</td><td>[Touch Circle](/function_1.47_inch_touch_display_nrf52840#touch--touch-circle) — a circle that follows your finger</td></tr>
+    <tr><td>SD Card</td><td>[Image Reader](/function_1.47_inch_touch_display_nrf52840#sd-card--image-reader) — display a BMP from the MicroSD card</td></tr>
+    <tr><td>Microphone & Speaker</td><td>[Volume Bar + Record to SD](/function_1.47_inch_touch_display_nrf52840#microphone--speaker) — live PDM level meter and recording to SD</td></tr>
+    <tr><td>IMU</td><td>[Electronic Quicksand + Raise to Wake](/function_1.47_inch_touch_display_nrf52840#imu) — 6-axis motion effects and wake-on-motion</td></tr>
+    <tr><td>Buttons</td><td>[User Button](/function_1.47_inch_touch_display_nrf52840#user-button) — read presses and debounce with interrupts</td></tr>
+    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_1.47_inch_touch_display_nrf52840#battery-voltage-detection) — measure voltage and convert to a percentage</td></tr>
+  </table>
+</div>
+
+## FAQ
+
+### What if the upload fails or the board is not detected?
+
+Double-click the reset button on the XIAO nRF52840 Plus. The USR LED will breathe in red and a drive named **NRF52BOOT** will appear on your computer. Drag the compiled `.uf2` file onto the **NRF52BOOT** drive. The board will program itself and reset automatically.
+
+## Resources
+
+- **🗃️[PCB Design Files]** [XIAO 1.47'' IPS Display (nRF52840) KiCad Project](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/kicad/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20KiCad%20Project.zip)
+- **📄[Schematic]** [XIAO 1.47'' IPS Display (nRF52840) Schematic](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/schematic/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20Schematic.pdf)
+- **📦[3D Model]** [XIAO 1.47'' IPS Display (STEP)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/3d-model/XIAO%201.47%27%27%20IPS%20Display.step)
+- **📄[Datasheet]** [1.47 Inch Display Datasheet](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/datasheet/1.47%20Inch%20Display%20Datasheet.pdf)
+- **🏠[3D Enclosure]** [XIAO 1.47'' IPS Display Enclosure (Design by gokul)](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/enclosure/XIAO%201.47%27%27%20IPS%20Display%20Enclosure.zip)
+- **💾[Factory Firmware]** [XIAO 1.47'' IPS Display (nRF52840) Factory Firmware](https://files.seeedstudio.com/wiki/Display_Gadgets/resources/firmware/XIAO%201.47%27%27%20IPS%20Display%20%28nRF52840%29%20Factory%20Firmware.uf2)
+
+## Tech Support & Product Discussion
+
+Thank you for choosing our products! We are here to provide you with different support to ensure that your experience with our products is as smooth as possible. We offer several communication channels to cater to different preferences and needs.
+
+<div class="table-center">
+  <div class="button_tech_support_container">
+  <a href="https://forum.seeedstudio.com/" class="button_forum"></a>
+  <a href="https://www.seeedstudio.com/contacts" class="button_email"></a>
+  </div>
+
+  <div class="button_tech_support_container">
+  <a href="https://discord.gg/eWkprNDMU7" class="button_discord"></a>
+  <a href="https://github.com/Seeed-Studio/wiki-documents/discussions/69" class="button_discussion"></a>
+  </div>
+</div>

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
@@ -194,7 +194,7 @@ The display board packs several onboard peripherals. The [Function](/function_1.
     <tr><td>Microphone & Speaker</td><td>[Volume Bar + Record to SD](/function_1.47_inch_touch_display_nrf52840#microphone--speaker) — live PDM level meter and recording to SD</td></tr>
     <tr><td>IMU</td><td>[Electronic Quicksand + Raise to Wake](/function_1.47_inch_touch_display_nrf52840#imu) — 6-axis motion effects and wake-on-motion</td></tr>
     <tr><td>Buttons</td><td>[User Button](/function_1.47_inch_touch_display_nrf52840#user-button) — read presses and debounce with interrupts</td></tr>
-    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_1.47_inch_touch_display_nrf52840#battery-status) — measure voltage and convert to a percentage</td></tr>
+    <tr><td>Battery</td><td>[Battery Status](/function_1.47_inch_touch_display_nrf52840#battery-status) — measure voltage and convert to a percentage</td></tr>
   </table>
 </div>
 

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
@@ -10,7 +10,6 @@ keywords:
 image: https://files.seeedstudio.com/wiki/seeed_logo/logo_2023.png
 slug: /getting_started_1.47_inch_touch_display_nrf52840
 sku: 100004242
-sidebar_label: Getting Started
 sidebar_position: 1
 type: gettingstarted
 last_update:
@@ -195,7 +194,7 @@ The display board packs several onboard peripherals. The [Function](/function_1.
     <tr><td>Microphone & Speaker</td><td>[Volume Bar + Record to SD](/function_1.47_inch_touch_display_nrf52840#microphone--speaker) — live PDM level meter and recording to SD</td></tr>
     <tr><td>IMU</td><td>[Electronic Quicksand + Raise to Wake](/function_1.47_inch_touch_display_nrf52840#imu) — 6-axis motion effects and wake-on-motion</td></tr>
     <tr><td>Buttons</td><td>[User Button](/function_1.47_inch_touch_display_nrf52840#user-button) — read presses and debounce with interrupts</td></tr>
-    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_1.47_inch_touch_display_nrf52840#battery-voltage-detection) — measure voltage and convert to a percentage</td></tr>
+    <tr><td>Battery</td><td>[Battery Voltage Detection](/function_1.47_inch_touch_display_nrf52840#battery-status) — measure voltage and convert to a percentage</td></tr>
   </table>
 </div>
 

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/1.47_Inch_Touch_Display_Powered_by_XIAO_nRF52840_Plus/getting_started_1.47_inch_touch_display_nrf52840.md
@@ -1,6 +1,7 @@
 ---
 description: Getting Started with XIAO 1.47'' IPS Display (nRF52840).
 title: Getting Started with XIAO 1.47'' IPS Display (nRF52840)
+sidebar_label: Getting Started
 keywords:
   - XIAO
   - nRF52840

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/_category_.yml
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/XIAO_nRF52840_Series/_category_.yml
@@ -1,0 +1,4 @@
+position: 2
+label: 'XIAO nRF52840 Series'
+collapsible: true
+collapsed: true

--- a/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/_category_.yml
+++ b/sites/en/docs/Sensor/LCD_Displays/Display_Gadgets/_category_.yml
@@ -1,0 +1,4 @@
+position: 4
+label: 'XIAO Display Gadgets'
+collapsible: true
+collapsed: true


### PR DESCRIPTION
## Summary
Add Getting Started and Function documentation for the XIAO nRF52840 Series displays (3 models).

## Models
- XIAO 0.96'' IPS Display (nRF52840)
- XIAO 1.14'' IPS Display (nRF52840)
- XIAO 1.47'' IPS Display (nRF52840)

## What's included
- Getting Started × 3 (Introduction, Hardware Overview, Hello demo, FAQ, Resources)
- Function × 3 (GraphicTest, Electronic Quicksand, Raise to Wake, Flash Recorder, Voice Bar, SHT31, Battery Status, Touch Circle, SD, Mic, etc.)
- Sidebar category entries

## Note
- ESP32-S3 models and the series overview page will follow in a separate PR.
- The top-level category link to the overview page is omitted for now (the overview references ESP32-S3 models not yet added).