### PR TITLE
Fix: recamera_pro_debian13.md - replace Google Drive image download link with GitHub release link

### DIFF
--- a/sites/en/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/recamera_pro_debian13.md
+++ b/sites/en/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/recamera_pro_debian13.md
@@ -10,7 +10,7 @@ slug: /recamera_pro_debian
 sku: 10003420
 sidebar_position: 2
 last_update:
-  date: 09/07/2026
+  date: 09/08/2026
   author: yylin
 createdAt: '2026-08-04'
 updatedAt: '2026-09-07'
@@ -31,7 +31,7 @@ This firmware is currently experimental. Seeed does not maintain it at this time
 
 ### Download the Image
 
-[Download the Debian 13 image from Google Drive](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link).
+[Download the Debian 13 image](https://github.com/yyling0101-a11y/reCamere_pro_debian_img/releases/download/v1.0.0/recamera_pro_debian13_v1.0.0.tar.gz).
 
 ### Download the Flashing Tool and Driver
 

--- a/sites/es/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/es_recamera_pro_debian13.md
+++ b/sites/es/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/es_recamera_pro_debian13.md
@@ -31,7 +31,7 @@ Este firmware es actualmente experimental. Seeed no lo mantiene por el momento; 
 
 ### Descargar la imagen
 
-[Descarga la imagen de Debian 13 desde Google Drive](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link).
+[Descargar la imagen de Debian 13](https://github.com/yyling0101-a11y/reCamere_pro_debian_img/releases/download/v1.0.0/recamera_pro_debian13_v1.0.0.tar.gz).
 
 ### Descargar la herramienta de flasheo y el controlador
 

--- a/sites/ja/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/ja_recamera_pro_debian13.md
+++ b/sites/ja/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/ja_recamera_pro_debian13.md
@@ -31,7 +31,7 @@ Debian 13 イメージを書き込んだ後は、CMake を使って独自アプ�
 
 ### イメージをダウンロード
 
-[Google Drive から Debian 13 イメージをダウンロードします](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link)。
+[Debian 13 イメージをダウンロード](https://github.com/yyling0101-a11y/reCamere_pro_debian_img/releases/download/v1.0.0/recamera_pro_debian13_v1.0.0.tar.gz)。
 
 ### 書き込みツールとドライバをダウンロード
 

--- a/sites/pt-BR/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/pt_recamera_pro_debian13.md
+++ b/sites/pt-BR/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/pt_recamera_pro_debian13.md
@@ -31,7 +31,7 @@ Este firmware é atualmente experimental. A Seeed não o mantém neste momento; 
 
 ### Baixar a imagem
 
-[Baixe a imagem Debian 13 do Google Drive](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link).
+[Baixar a imagem do Debian 13](https://github.com/yyling0101-a11y/reCamere_pro_debian_img/releases/download/v1.0.0/recamera_pro_debian13_v1.0.0.tar.gz).
 
 ### Baixar a ferramenta de gravação e o driver
 

--- a/sites/zh-CN/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/cn_recamera_pro_debian13.md
+++ b/sites/zh-CN/docs/Edge/reCamera/reCamera_Pro/Secondary_Development/cn_recamera_pro_debian13.md
@@ -31,7 +31,7 @@ reCamera Pro 由 RV1126B 芯片驱动，提供 2 GB 或 4 GB 内存版本。其�
 
 ### 下载镜像
 
-[从 Google Drive 下载 Debian 13 镜像](https://drive.google.com/file/d/1qLlbsgUB88qC2xBn4-_Decl8XBZgr7EI/view?usp=drive_link)。
+[下载 Debian 13 镜像](https://github.com/yyling0101-a11y/reCamere_pro_debian_img/releases/download/v1.0.0/recamera_pro_debian13_v1.0.0.tar.gz)。
 
 ### 下载烧录工具和驱动
 


### PR DESCRIPTION
Replace the experimental Debian 13 image download link from Google Drive to GitHub release (https://github.com/yyling0101-a11y/reCamere_pro_debian_img/releases/download/v1.0.0/recamera_pro_debian13_v1.0.0.tar.gz), and update the link text from 'Download the Debian 13 image from Google Drive' to 'Download the Debian 13 image'. Also bump last_update.date to 09/08/2026.