### PR TITLE
docs: refine the B601 RS getting started guide

### DIFF
--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
@@ -73,25 +73,38 @@ The content of this guide is racing towards you at the speed of light — stay t
 
 If your household voltage is 220V, set the voltage selector switch on the side of the power supply to 230V. If your household voltage is 110V, switch it to 115V.
 
-| **220V** | **110V** |
-|:---:|:---:|
-| <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/230V.jpg" width="300" /> | <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/115V.jpg" width="300" /> |
+<div className="rebot-power-gallery">
+  <figure className="rebot-power-gallery-item">
+    <figcaption>220V</figcaption>
+    <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/230V.jpg" alt="Power supply voltage selector set to 230V" />
+  </figure>
+  <figure className="rebot-power-gallery-item">
+    <figcaption>110V</figcaption>
+    <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/115V.jpg" alt="Power supply voltage selector set to 115V" />
+  </figure>
+  <figure className="rebot-power-gallery-item rebot-power-gallery-item--wide">
+    <img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/1/0/100054289-gallery-6.jpg" alt="MeanWell power adapter for reBot Arm B601-RS" />
+  </figure>
+</div>
 
+### Assemble the Power Supply
 
-   <div align="center">
-     <img width={800}
-     src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/1/0/100054289-gallery-6.jpg" />
-   </div>
+Alternatively, you can choose our open-source 24V 14.6A MeanWell power supply enclosure for self-assembly. The text instructions and BOM are open-sourced in the [GitHub repository](https://github.com/LAN-GER/reBot-DevArm/tree/main/hardware/reBot_B601_RS) (recommended only for developers with relevant power supply assembly experience).
 
-2. Alternatively, you can choose our open-source 24V 14.6A MeanWell power supply enclosure for self-assembly. The text instructions and BOM are open-sourced in the [GitHub repository](https://github.com/LAN-GER/reBot-DevArm/tree/main/hardware/reBot_B601_RS) (recommended only for developers with relevant power supply assembly experience).
-
-   Assembly reference video:
+Assembly reference video:
 
    <div class="video-container">
      <iframe width="900" height="600" src="https://www.youtube.com/embed/5GitUWT9gx0?si=I_dnd2bSNHbB95BW" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
    </div>
 
-## Step 1: Assembly Guide
+## Assembly Guide
+
+<div className="rebot-step-flow">
+<section className="rebot-step-item">
+    <span className="rebot-step-number">1</span>
+<div className="rebot-step-content">
+      <h4>Assemble the reBot Arm</h4>
+      <p className="rebot-step-label">Step 1</p>
 
 - Before assembly, please read the following instructions carefully. To ensure a smooth assembly process and a complete hands-on experience, please be patient, stay focused, and always follow these key points:
   1. This kit includes numerous screws and structural parts, some of which look similar. Please carefully verify the screw specifications and part models, and confirm the installation orientation before fastening.
@@ -99,31 +112,9 @@ If your household voltage is 220V, set the voltage selector switch on the side o
   3. For ease of screw installation and removal, the open-source BOM specifies standard screws. However, the screws shipped with the kit have thread-lock applied. You may also use your own preferred tools or an electric screwdriver (highly recommended to have one ready). If using an electric tool, be sure to set the torque to a low-to-medium level (3–6 kgf·cm) to avoid excessive torque that could strip the screws, causing irreversible damage where parts cannot be removed. If there is any sign of stripping, immediately replace the screw or realign and retry. Stripped thread-lock screws cannot be removed with a screw extractor and will scrap the entire part. Therefore, please proceed with caution.
   4. Please prioritize safety during assembly to avoid pinched fingers or crush injuries. Children should complete this project with the accompaniment of a parent or guardian.
 
-
-
-
-## Step 2: Calibrate the Robotic Arm and Get Started
-
-1. Explore our **MotorBridge** platform. This platform is a one-stop comprehensive solution that supports continuous expansion of motor types, covering [Damiao motors](https://www.seeedstudio.com/DIP-Servo-Motor-24V-120RPM-Brushless-98-9mm-4P-L56-W56-H46mm-p-6660.html), [Robstride motors](https://www.seeedstudio.com/Robostride-00-Actuator-p-6664.html), [Hightorque motors](https://www.seeedstudio.com/Hightorque-HTDW-4438-30-NE-Gear-Motor-p-6482.html), [Myactuator motors](https://www.seeedstudio.com/Myactuator-X4-P36-Planetary-Actuator-p-6469.html), Hexfellow, and more. It is also compatible with continuously updated robotic arm products like reBot. The platform is user-friendly for beginners and also provides a Python SDK with fully consistent functionality for developers.
-
-2. Experience the new features and details of MotorBridge specifically adapted for the reBot robotic arm, including one-click zero-point calibration, parameter writing, drag-and-drop motor control via the UI, and a built-in model visualization interface.
-
-3. This tool is fully compatible with **Windows, Ubuntu, and macOS** operating systems.
-
-:::tip
-1. It has been verified that virtual machine performance is insufficient for running demos and there are configuration issues. It is recommended to use an Ubuntu physical machine to control the robotic arm.
-
-2. (Beta version) Let an agent help you initialize the robotic arm. Copy the following content and send it to the agent:
-
-```text
-Please follow the process in AGENTS.md (https://github.com/Welt-liu/reBot-B601-Agent-Guide/blob/main/en/AGENTS.md) to help the user complete the initialization of a new robotic arm.
-```
-
-  Note: If you purchased a pre-assembled kit, please tell the agent during the motor ID writing step: "I purchased a pre-assembled kit, please scan motors 1–7 to verify they are all online, do not rewrite the motor IDs."
-
-3. The agent uses CLI commands to complete motor ID writing, while the wiki uses a web UI interaction method. Both approaches work.
-
-:::
+</div>
+</section>
+</div>
 
 You should have completed the preliminary preparation for the robotic arm assembly by following the video. Next, we will introduce the steps for writing motor IDs and calibrating the robotic arm.
 
@@ -134,11 +125,42 @@ Please refer to the video and text tutorial. Before controlling the robotic arm,
 <iframe width="900" height="600" src="https://www.youtube.com/embed/llSa6qn3yrY?si=hMuZKVDY9yqx3qHx" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
+## Use MotorBridge to Calibrate the Arm and Complete the First Run
 
+:::tip
+1. Explore our **MotorBridge** platform. This one-stop solution supports an expanding range of motors, including [Damiao](https://www.seeedstudio.com/DIP-Servo-Motor-24V-120RPM-Brushless-98-9mm-4P-L56-W56-H46mm-p-6660.html), [RobStride](https://www.seeedstudio.com/Robostride-00-Actuator-p-6664.html), [HighTorque](https://www.seeedstudio.com/Hightorque-HTDW-4438-30-NE-Gear-Motor-p-6482.html), [MyActuator](https://www.seeedstudio.com/Myactuator-X4-P36-Planetary-Actuator-p-6469.html), Hexfellow, and continuously updated robotic arms such as reBot. It is beginner-friendly and provides developers with a Python SDK matching the Web UI features.
 
-### 1. Install Miniforge (Recommended) (Supports Windows\Ubuntu\macOS\Jetson\Raspberry Pi)
+2. MotorBridge features tailored for reBot include one-click zero calibration, parameter writing, drag-and-drop motor control, and built-in model visualization.
 
-1. Install Miniforge and create a virtual environment to avoid conflicts with other environment packages that could cause demo failures.
+3. MotorBridge supports **Windows, Ubuntu, and macOS**.
+:::
+
+:::tip
+1. Virtual machines do not provide sufficient performance for reliable demo operation and may introduce configuration issues. Use a physical Ubuntu machine whenever possible.
+
+2. (Beta) You can ask an agent to initialize the robotic arm. Send it the following prompt:
+
+```text
+Please follow the process in AGENTS.md (https://github.com/Welt-liu/reBot-B601-Agent-Guide/blob/main/en/AGENTS.md) to help the user complete the initialization of a new robotic arm.
+```
+
+If you purchased a pre-assembled kit, tell the agent during the motor ID step: "I purchased a pre-assembled kit. Scan motors 1–7 and verify that they are online. Do not rewrite the motor IDs."
+
+3. The agent writes motor IDs through CLI commands, while this Wiki uses the Web UI. Both methods work.
+:::
+
+### Software Setup and Calibration Workflow
+
+Follow these steps in order to install Miniforge and create an isolated Python environment for reBot development.
+
+<div className="rebot-step-flow">
+<section className="rebot-step-item">
+    <span className="rebot-step-number">1</span>
+<div className="rebot-step-content">
+      <h4>Install Miniforge</h4>
+      <p className="rebot-step-label">Step 1</p>
+
+Download and install Miniforge for your operating system:
 
 <Tabs>
 <TabItem value="Ubuntu" label="Ubuntu\Jetson\Raspberry Pi">
@@ -147,6 +169,20 @@ Please refer to the video and text tutorial. Before controlling the robotic arm,
 wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 bash Miniforge3-$(uname)-$(uname -m).sh
 ```
+
+During installation, press <kbd>Enter</kbd> to continue, enter `yes` to accept the terms, and enter `yes` when asked whether to initialize Conda.
+
+Restart the terminal and verify the installation with `conda --version`.
+
+:::tip If `conda` is not found
+Load Miniforge and initialize Bash:
+
+```bash
+source ~/miniforge3/etc/profile.d/conda.sh
+conda init bash
+```
+:::
+
 </TabItem>
 <TabItem value="macOS" label="macOS">
 
@@ -155,51 +191,103 @@ curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mi
 bash Miniforge3-MacOSX-$(uname -m).sh
 ```
 
-</TabItem>
-<TabItem value="windows" label="windows">
+During installation, press <kbd>Enter</kbd> to continue, enter `yes` to accept the terms, and enter `yes` when asked whether to initialize Conda.
 
-Open the Miniforge Release page in your browser, find the latest version of `Miniforge3-Windows-x86_64.exe` and click to download:
+Restart the terminal and verify the installation with `conda --version`.
 
-```text
-https://github.com/conda-forge/miniforge/releases
+:::tip If `conda` is not found
+Load Miniforge and initialize Zsh, the default shell on current macOS versions:
+
+```bash
+source ~/miniforge3/etc/profile.d/conda.sh
+conda init zsh
 ```
+:::
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+Open the [Miniforge Releases page](https://github.com/conda-forge/miniforge/releases), find the latest `Miniforge3-Windows-x86_64.exe`, and download it.
+
+:::tip Initialize Conda for your terminal
+**Git Bash users:** If `conda` is not found, load Conda first:
+
+```bash
+# Temporary: replace <install_path> with the actual path
+source <install_path>/etc/profile.d/conda.sh
+
+# Permanent: add it to bashrc once
+echo 'source <install_path>/etc/profile.d/conda.sh' >> ~/.bashrc
+source ~/.bashrc
+```
+
+For PowerShell, initialize Conda with:
+
+```bash
+conda init powershell
+```
+:::
 
 </TabItem>
 </Tabs>
 
-2. Create a Python 3.12 virtual environment:
+</div>
+</section>
 
-:::tip
-  **Git Bash users**: If the `conda` command is not found, it means Git Bash has not loaded the conda environment. You need to initialize it first:
+<section className="rebot-step-item">
+    <span className="rebot-step-number">2</span>
+<div className="rebot-step-content">
+      <h4>Disable Automatic Base Activation (Optional)</h4>
+      <p className="rebot-step-label">Step 2</p>
 
-  ```bash
-  # Temporary (current terminal only), replace <install_path> with the actual path
-  source <install_path>/etc/profile.d/conda.sh
+After Miniforge initializes Conda, each new terminal automatically activates the `(base)` environment. If you prefer to start in the system environment, disable automatic base activation:
 
-  # Permanent (write to bashrc, run once)
-  echo 'source <install_path>/etc/profile.d/conda.sh' >> ~/.bashrc
-  source ~/.bashrc
-  ```
+```bash
+conda config --set auto_activate_base false
+```
 
-  To let PowerShell automatically activate the conda environment:
+**Verify:** Close the current terminal and open a new one. The `(base)` prefix should no longer appear. Activate the reBot environment manually when needed with `conda activate rebot`.
 
-  ```bash
-  conda init powershell
-  ```
+**Restore the default:** Run `conda config --set auto_activate_base true` to enable automatic base activation again.
 
-:::
+</div>
+</section>
+
+<section className="rebot-step-item">
+    <span className="rebot-step-number">3</span>
+<div className="rebot-step-content">
+      <h4>Create the Python Environment</h4>
+      <p className="rebot-step-label">Step 3</p>
+
+Create the Python 3.12 environment:
 
 ```bash
 conda create -y -n rebot python=3.12
 ```
 
-3. Activate the virtual environment. **You need to re-run this activation command every time you open a terminal to use reBot-related features**:
+</div>
+</section>
+
+<section className="rebot-step-item">
+    <span className="rebot-step-number">4</span>
+<div className="rebot-step-content">
+      <h4>Activate the Environment</h4>
+      <p className="rebot-step-label">Step 4</p>
+
+Run this command whenever you open a new terminal for reBot:
 
 ```bash
 conda activate rebot
 ```
 
-### 2. Install Motorbridge
+</div>
+</section>
+
+<section className="rebot-step-item">
+    <span className="rebot-step-number">5</span>
+<div className="rebot-step-content">
+      <h4>Install Motorbridge</h4>
+      <p className="rebot-step-label">Step 5</p>
 
 After activating the reBot virtual environment, run the following command to install motorbridge:
 
@@ -212,7 +300,14 @@ If you experience low frame rates during teleoperation on macOS, it may be cause
 pip install motorbridge
 ```
 
-### 3. PCAN-USB
+</div>
+</section>
+
+<section className="rebot-step-item">
+    <span className="rebot-step-number">6</span>
+<div className="rebot-step-content">
+      <h4>Configure PCAN-USB</h4>
+      <p className="rebot-step-label">Step 6</p>
 
 Get the PCAN-USB device working on the CAN bus at 1Mbps for robotic arm communication.
 
@@ -229,6 +324,45 @@ sudo ip link set can0 down 2>/dev/null
 sudo ip link set can0 type can bitrate 1000000
 sudo ip link set can0 up
 ```
+
+
+:::tip Attention
+If the PCAN device has incorrect firmware after driver installation, expand the section below, download the PCAN firmware, and follow the recovery steps.
+:::
+
+<details>
+<summary>PCAN Firmware Download &amp; Driver Repair Steps - Ubuntu</summary>
+
+Ubuntu users please refer to this guide
+
+1.> 📦 [Click to download USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.Switch USB2CAN to BOOT
+
+3.Please extract the USB2CAN.zip from step 1, and place flash_pcan_ubuntu.sh and pcan_canable_hw.bin (from inside USB2CAN.zip) in the same directory
+
+[Click to download flash_pcan_ubuntu.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_ubuntu.sh)
+
+If transferring from another computer (e.g. scp):
+
+```text
+scp flash_pcan_ubuntu.sh pcan_canable_hw.bin seeed@your_Ubuntu_IP:~/Downloads/
+```
+Or simply copy it onto a USB flash drive and plug it into the Ubuntu machine — as long as the files end up in ~/Downloads, the current directory, or /tmp, the script will find them automatically.
+
+4.Execute:
+
+```text
+bash flash_pcan_ubuntu.sh
+```
+
+Enter your password; wait for completion
+
+After completion, switch back to "120R"
+
+Re-plug the USB.
+
+</details>
 
 </TabItem>
 
@@ -350,7 +484,7 @@ sudo ip link set $PCAN_IF up
 ```
 
 </TabItem>
-<TabItem value="macos" label="macos">
+<TabItem value="macos" label="macOS">
 
 If `libPCBUSB.dylib` cannot be loaded, install PCBUSB first:
 ```zsh
@@ -401,26 +535,61 @@ python3 -c "import ctypes; ctypes.CDLL('PCBUSB'); print('PCBUSB load OK')"
 motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 --timeout-ms 300
 ```
 
+
+:::tip Attention
+If the PCAN device has incorrect firmware after driver installation, expand the section below, download the PCAN firmware, and follow the recovery steps.
+:::
+
+<details>
+<summary>PCAN Firmware Download &amp; Driver Repair Steps - macOS</summary>
+
+MAC users please refer to this guide
+
+1.> 📦 [Click to download USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.Switch USB2CAN to BOOT
+
+3.Please extract the USB2CAN.zip from step 1, and place flash_pcan_mac.sh and pcan_canable_hw.bin (from inside USB2CAN.zip) in the same directory
+
+[Click to download flash_pcan_mac.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_mac.sh)
+
+If transferring from another computer (e.g. scp):
+
+```text
+scp flash_pcan_mac.sh pcan_canable_hw.bin seeed@your_MAC_IP:~/Downloads/
+```
+
+Or simply copy it onto a USB flash drive and plug it into the MAC — as long as the files end up in ~/Downloads, the current directory, or /tmp, the script will find them automatically.
+
+4.Execute:
+
+```text
+bash /Users/"your_username"/Downloads/flash_pcan_mac.sh "/Users/"your_username"/Downloads/pcan_canable_hw.bin"
+```
+
+The above command assumes the files are placed in the Mac Downloads path; adjust according to your actual path
+
+Enter your password; wait for completion
+
+After completion, switch back to "120R"
+
+Re-plug the USB.
+
+</details>
+
 </TabItem>
-<TabItem value="windows" label="windows">
+<TabItem value="windows" label="Windows">
 
 Please visit [pcan-usb](https://www.peak-system.com/products/hardware/external-pc-interfaces/pcan-usb/) to install the PCAN-USB driver.
 
-</TabItem>
-
-
-
-</Tabs>
 
 :::tip Attention
 If **PCAN-USB** is not detected in Device Manager after installing the driver, expand the section below, download the PCAN firmware, and follow the recovery steps.
 :::
 
-
-
 <details>
 
-<summary>PCAN firmware download and driver recovery steps</summary>
+<summary>PCAN Firmware Download &amp; Driver Repair Steps - Windows</summary>
 
 If PCAN-USB still does not work after installing the driver and Device Manager does not show the **PCAN-USB** device illustrated below, download the PCAN firmware package and follow these steps to install the DFU driver and reflash the firmware.
 
@@ -479,77 +648,11 @@ Disconnect the USB2CAN module, set the DIP switch to **120R**, and reconnect it 
 
 </details>
 
-<details>
-<summary>PCAN Firmware Download & Driver Repair Steps - Ubuntu</summary>
+</TabItem>
 
-Ubuntu users please refer to this guide
 
-1.> 📦 [Click to download USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
 
-2.Switch USB2CAN to BOOT
-
-3.Please extract the USB2CAN.zip from step 1, and place flash_pcan_ubuntu.sh and pcan_canable_hw.bin (from inside USB2CAN.zip) in the same directory
-
-[Click to download flash_pcan_ubuntu.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_ubuntu.sh)
-
-If transferring from another computer (e.g. scp):
-
-```text
-scp flash_pcan_ubuntu.sh pcan_canable_hw.bin seeed@your_Ubuntu_IP:~/Downloads/
-```
-Or simply copy it onto a USB flash drive and plug it into the Ubuntu machine — as long as the files end up in ~/Downloads, the current directory, or /tmp, the script will find them automatically.
-
-4.Execute:
-
-```text
-bash flash_pcan_ubuntu.sh
-```
-
-Enter your password; wait for completion
-
-After completion, switch back to "120R"
-
-Re-plug the USB.
-
-</details>
-
-<details>
-<summary>PCAN Firmware Download & Driver Repair Steps - MAC</summary>
-
-MAC users please refer to this guide
-
-1.> 📦 [Click to download USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
-
-2.Switch USB2CAN to BOOT
-
-3.Please extract the USB2CAN.zip from step 1, and place flash_pcan_mac.sh and pcan_canable_hw.bin (from inside USB2CAN.zip) in the same directory
-
-[Click to download flash_pcan_mac.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_mac.sh)
-
-If transferring from another computer (e.g. scp):
-
-```text
-scp flash_pcan_mac.sh pcan_canable_hw.bin seeed@your_MAC_IP:~/Downloads/
-```
-
-Or simply copy it onto a USB flash drive and plug it into the MAC — as long as the files end up in ~/Downloads, the current directory, or /tmp, the script will find them automatically.
-
-4.Execute:
-
-```text
-bash /Users/"your_username"/Downloads/flash_pcan_mac.sh "/Users/"your_username"/Downloads/pcan_canable_hw.bin"
-```
-
-The above command assumes the files are placed in the Mac Downloads path; adjust according to your actual path
-
-Enter your password; wait for completion
-
-After completion, switch back to "120R"
-
-Re-plug the USB.
-
-</details>
-
+</Tabs>
 <!-- ### 3. Write Motor IDs
 
 :::tip Pre-assembled kit users, please skip this step
@@ -577,7 +680,14 @@ motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 -
 ``` -->
 
 
-### 4. Start MotorBridge-gateway to Write Zero Points and Debug
+</div>
+</section>
+
+<section className="rebot-step-item">
+    <span className="rebot-step-number">7</span>
+<div className="rebot-step-content">
+      <h4>Write Zero Points and Debug with MotorBridge Gateway</h4>
+      <p className="rebot-step-label">Step 7</p>
 
 #### Before Motor Reset
 
@@ -636,3 +746,7 @@ First select `rebot-arm-robstride` under **Robot Model** in [MotorBridge Studio]
 4. After writing is complete, MotorBridge Studio automatically reads the parameters back. Initialization is successful when the page reports that the post-write readback verification matches.
 
 :::
+
+</div>
+</section>
+</div>

--- a/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/en/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/reBot_Arm_B601_RS_Getting_Started.md
@@ -106,11 +106,40 @@ Assembly reference video:
       <h4>Assemble the reBot Arm</h4>
       <p className="rebot-step-label">Step 1</p>
 
+<Tabs>
+<TabItem value="unassembled" label="Unassembled Version">
+
+<div class="video-container">
+  <iframe width="900" height="600" src="https://www.youtube.com/embed/Bv60NPO0TRo?list=PLpH_4mf13-A38iXew5DxqswGLjPQ0BflR&amp;index=6" title="reBot Arm B601-RS assembly video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
 - Before assembly, please read the following instructions carefully. To ensure a smooth assembly process and a complete hands-on experience, please be patient, stay focused, and always follow these key points:
   1. This kit includes numerous screws and structural parts, some of which look similar. Please carefully verify the screw specifications and part models, and confirm the installation orientation before fastening.
   2. The video was recorded in early April. There may be minor adjustments to parts later, but this does not affect the assembly quality when following the video. The final parts are subject to what is shipped.
   3. For ease of screw installation and removal, the open-source BOM specifies standard screws. However, the screws shipped with the kit have thread-lock applied. You may also use your own preferred tools or an electric screwdriver (highly recommended to have one ready). If using an electric tool, be sure to set the torque to a low-to-medium level (3–6 kgf·cm) to avoid excessive torque that could strip the screws, causing irreversible damage where parts cannot be removed. If there is any sign of stripping, immediately replace the screw or realign and retry. Stripped thread-lock screws cannot be removed with a screw extractor and will scrap the entire part. Therefore, please proceed with caution.
   4. Please prioritize safety during assembly to avoid pinched fingers or crush injuries. Children should complete this project with the accompaniment of a parent or guardian.
+
+</TabItem>
+<TabItem value="assembled" label="Assembled Version">
+
+Connect the robotic arm cables, then use MotorBridge Studio to write the motor parameters and set the zero position.
+
+Refer to the reBot Arm B601-RS unboxing and getting-started video below for this step.
+
+Connect Motor 1 and Motor 2 as shown below.
+
+<div align="center">
+  <img width={400} src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/RS_m1m2_c.jpg" alt="Connect Motor 1 and Motor 2 on the reBot Arm B601-RS" />
+</div>
+
+Then connect the USB-to-CAN module, power-signal splitter board, XT30 power cable, and XT30 2+2 cable as shown below. Connect the other end of the XT30 2+2 cable to Motor 1 and connect the power cable to the 48 V power supply.
+
+<div align="center">
+  <img width={400} src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/rs_connecting_cable.jpg" alt="Connect the USB-to-CAN module and power cables to the reBot Arm B601-RS" />
+</div>
+
+</TabItem>
+</Tabs>
 
 </div>
 </section>

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
@@ -144,7 +144,7 @@ reBot Arm项目已经在[github](https://github.com/Seeed-Projects/reBot-DevArm)
 </div>
 
 相信你已经跟随上方视频完成了电源安装和机械臂组装前期准备工作,接下来开始介绍写入电机ID和校准机械臂的步骤。
-
+电源和机械臂的连接在下方视频
 
 使用请参考视频和文字教程,在控制机械臂运动之前，需要重新设置一次零点。
 
@@ -736,25 +736,24 @@ motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 -
 
 #### 写入零点和调试
 
-在浏览器中打开地址 [motorbridge-studio](https://motorbridge.github.io/motorbridge-studio/)，点击帮助选项，根据你的操作系统与所用驱动板复制对应指令，核对 IP 地址与端口号后，在终端中按下回车运行。
-
+在浏览器中打开地址 [motorbridge-studio（点击跳转）](https://motorbridge.github.io/motorbridge-studio/)，打开网页后点击帮助选项，根据你的操作系统与所用驱动板复制对应指令，核对 IP 地址与端口号后，在终端中按下回车运行。
+优先尝试
 
 ```bash
 motorbridge-gateway --bind 127.0.0.1:9002  
 ```
 
-macOS:
 
-```bash
-motorbridge-gateway --bind 127.0.0.1:9002 
-```
+**macOS：**
 
-or
+如果运行命令后提示找不到动态库，请根据 Mac 的硬件架构和 Homebrew 安装路径，使用对应的命令。
 
+这两条命令的核心区别在于搜索动态依赖库的目录不同，这直接对应了 macOS 下 Apple Silicon（M 系列芯片）与 Intel 芯片的 Homebrew 默认安装路径差异。
 
-```bash
-DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002 
-```
+| 命令 | 库搜索路径 | 对应的硬件架构与环境 |
+| --- | --- | --- |
+| `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib motorbridge-gateway --bind 127.0.0.1:9002` | `/opt/homebrew/lib` | **Apple Silicon（M1/M2/M3/M4 系列芯片）**：原生 ARM64 架构下，Homebrew 安装的软件和动态库所在目录。 |
+| `DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib motorbridge-gateway --bind 127.0.0.1:9002` | `/usr/local/lib` | **Intel（x86_64）芯片**，或在 Apple Silicon 上通过 Rosetta 2 模拟运行的 x86_64 环境。 |
 
 #### 写入电机控制参数
 

--- a/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
+++ b/sites/zh-CN/docs/Robotics/Robot_Kits/reBot_Arm/B601_RS/cn_reBot_Arm_B601_RS_Getting_Started.md
@@ -73,18 +73,25 @@ reBot Arm项目已经在[github](https://github.com/Seeed-Projects/reBot-DevArm)
 
   2. 如果你的家庭电压是220V，请把电源侧面拨码调至230V，如果你的家庭电压是110V，请把你电源的拨码调至115V。
 
-  | **220V** | **110V** |
-  |:---:|:---:|
-  | <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/230V.jpg" width="300" /> | <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/115V.jpg" width="300" /> |
-
-  <div align="center">
-    <img width={800}
-    src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/1/0/100054289-gallery-6.jpg" />
+<div className="rebot-power-gallery">
+  <figure className="rebot-power-gallery-item">
+    <figcaption>220V</figcaption>
+    <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/230V.jpg" alt="电源电压拨码调至 230V" />
+  </figure>
+  <figure className="rebot-power-gallery-item">
+    <figcaption>110V</figcaption>
+    <img src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/Getting_start/115V.jpg" alt="电源电压拨码调至 115V" />
+  </figure>
+  <figure className="rebot-power-gallery-item rebot-power-gallery-item--wide">
+    <img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/bb49d3ec4ee05b6f018e93f896b8a25d/1/0/100054289-gallery-6.jpg" alt="reBot Arm B601-RS MeanWell 电源适配器" />
+  </figure>
 </div>
 
-  3. 选择我们开源的24V14.6AMeanWell电源外壳进行自组装，文字步骤和BOM在[github仓库](https://github.com/Seeed-Projects/reBot-DevArm/blob/main/hardware/reBot_B601_RS/README_zh.md#%E5%85%B3%E4%BA%8E%E7%94%B5%E6%BA%90)中开源（只推荐有过相关电源组装经验的开发者使用）
+### 组装电源
 
-  组装参考视频：
+选择我们开源的24V14.6AMeanWell电源外壳进行自组装，文字步骤和BOM在[github仓库](https://github.com/Seeed-Projects/reBot-DevArm/blob/main/hardware/reBot_B601_RS/README_zh.md#%E5%85%B3%E4%BA%8E%E7%94%B5%E6%BA%90)中开源（只推荐有过相关电源组装经验的开发者使用）
+
+电源组装参考视频：
   
   <div class="video-container">
 <iframe width="900" height="600" src="//player.bilibili.com/player.html?isOutside=true&aid=116793196675417&bvid=BV15i7K69EnQ&cid=39314066536&p=1&autoplay=0&muted=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
@@ -92,7 +99,14 @@ reBot Arm项目已经在[github](https://github.com/Seeed-Projects/reBot-DevArm)
 
 
 
-## 第一步：组装机械臂
+## 组装机械臂
+
+<div className="rebot-step-flow">
+<section className="rebot-step-item">
+    <span className="rebot-step-number">1</span>
+<div className="rebot-step-content">
+      <h4>组装 reBot Arm</h4>
+      <p className="rebot-step-label">第 1 步</p>
 
 <Tabs>
 <TabItem value="unassembled" label="未组装版本">
@@ -112,7 +126,7 @@ reBot Arm项目已经在[github](https://github.com/Seeed-Projects/reBot-DevArm)
 
 机械臂需要连接线和使用motorbridge-studio写入参数和设置零点
 
-该步骤可以参考第二步中的视频来进行。
+该步骤可以参考下方（reBot Arm B601-RS机械臂开箱和上手）中的视频来进行。
 按照如下图示，连接 motor1 和 motor2
 <div align="center">
   <img width={400} src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/RS_m1m2_c.jpg" alt="确认写入 B601-RS 电机参数" />
@@ -125,8 +139,20 @@ reBot Arm项目已经在[github](https://github.com/Seeed-Projects/reBot-DevArm)
 </TabItem>
 </Tabs>
 
+</div>
+</section>
+</div>
 
-## 第二步：Motorbridge-studio 校准机械臂及参数写入
+相信你已经跟随上方视频完成了电源安装和机械臂组装前期准备工作,接下来开始介绍写入电机ID和校准机械臂的步骤。
+
+
+使用请参考视频和文字教程,在控制机械臂运动之前，需要重新设置一次零点。
+
+<div class="video-container">
+<iframe width="900" height="600" src="//player.bilibili.com/player.html?isOutside=true&bvid=BV1MEJV6TELk&p=1&autoplay=0&muted=1" title="Bilibili video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+## 使用 MotorBridge 平台校准机械臂并完成首次运行
 
 :::tip
 1. 探索我们的 **MotorBridge** 平台。该平台为一站式综合解决方案，支持电机种类持续扩充，涵盖[达妙电机](https://www.seeedstudio.com/DIP-Servo-Motor-24V-120RPM-Brushless-98-9mm-4P-L56-W56-H46mm-p-6660.html)、[Robstride电机](https://www.seeedstudio.com/Robostride-00-Actuator-p-6664.html)、[高擎电机](https://www.seeedstudio.com/Hightorque-HTDW-4438-30-NE-Gear-Motor-p-6482.html)、[脉塔电机](https://www.seeedstudio.com/Myactuator-X4-P36-Planetary-Actuator-p-6469.html)、Hexfellow 等多款电机，同时兼容 reBot 等持续更新迭代的机械臂产品。平台面向入门用户友好易用，同时也为开发者提供功能完全一致的 Python SDK。
@@ -137,33 +163,32 @@ reBot Arm项目已经在[github](https://github.com/Seeed-Projects/reBot-DevArm)
 :::
 
 :::tip
-1.已验证虚拟机的性能不足以支撑 demo 运行且存在配置问题，建议优先使用 ubuntu 物理机来控制机械臂
+1. 已验证虚拟机的性能不足以支撑 Demo 运行且存在配置问题，建议优先使用 Ubuntu 物理机控制机械臂。
 
-2.(Beta版)让 agent 来帮助你初始化机械臂，复制以下内容发送给 agent：
+2. （Beta）可以让 Agent 帮助你初始化机械臂。复制以下内容发送给 Agent：
 
 ```text
 请参考 AGENTS.md（https://github.com/Welt-liu/reBot-B601-Agent-Guide/blob/main/zh/AGENTS.md）中的流程，帮助用户完成新机械臂的初始化。
 ```
 
-  注意：如果你购买的是成品套件，请在写入电机id环节提示agent：我购买的是成品套件，帮我扫描1~7电机是否都在线，不要写入重新写入电机id。
+如果购买的是成品套件，请在写入电机 ID 环节告诉 Agent：我购买的是成品套件，帮我扫描 1～7 号电机是否全部在线，不要重新写入电机 ID。
 
-3.agent使用cli命令完成写入电机ID，wiki则是使用web ui交互的方式来完成。两者都可行。
-
+3. Agent 使用 CLI 命令写入电机 ID，本 Wiki 使用 Web UI 完成，两种方式都可行。
 :::
 
-相信你已经跟随视频完成了机械臂组装前期准备工作,接下来开始介绍写入电机ID和校准机械臂的步骤。
+### 软件配置与校准流程
 
+按照正确的先后顺序操作，即可安装 Miniforge 并为 reBot 创建独立的 Python 环境。
 
-使用请参考视频和文字教程,在控制机械臂运动之前，需要重新设置一次零点。
+<div className="rebot-step-flow">
+<section className="rebot-step-item">
+    <span className="rebot-step-number">1</span>
+<div className="rebot-step-content">
+      <h4>安装 Miniforge</h4>
+      <p className="rebot-step-label">第 1 步</p>
 
-<div class="video-container">
-<iframe width="900" height="600" src="//player.bilibili.com/player.html?isOutside=true&bvid=BV1MEJV6TELk&p=1&autoplay=0&muted=1" title="Bilibili video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
+根据操作系统下载并安装 Miniforge：
 
-
-### 1.安装 Miniforge（建议）（支持 Windows\Ubuntu\macOS\Jetson\树莓派）
-
-1. 安装miniforge，创建虚拟环境，避免其他环境包的干扰导致demo运行失败。
 <Tabs>
 <TabItem value="Ubuntu" label="Ubuntu\Jetson\树莓派">
 
@@ -171,6 +196,20 @@ reBot Arm项目已经在[github](https://github.com/Seeed-Projects/reBot-DevArm)
 wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 bash Miniforge3-$(uname)-$(uname -m).sh
 ```
+
+安装过程中按 <kbd>Enter</kbd> 确认，提示条款时输入 `yes`，询问是否初始化 Conda 时也输入 `yes`。
+
+重启终端后运行 `conda --version` 验证安装。
+
+:::tip 如果找不到 `conda`
+加载 Miniforge 并初始化 Bash：
+
+```bash
+source ~/miniforge3/etc/profile.d/conda.sh
+conda init bash
+```
+:::
+
 </TabItem>
 <TabItem value="macOS" label="macOS">
 
@@ -179,53 +218,105 @@ curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mi
 bash Miniforge3-MacOSX-$(uname -m).sh
 ```
 
-</TabItem>
-<TabItem value="windows" label="windows">
+安装过程中按 <kbd>Enter</kbd> 确认，提示条款时输入 `yes`，询问是否初始化 Conda 时也输入 `yes`。
 
-　　在浏览器中打开 Miniforge 的 Release 页面，找到最新版本的 `Miniforge3-Windows-x86_64.exe` 点击下载：
+重启终端后运行 `conda --version` 验证安装。
 
-```text
-https://github.com/conda-forge/miniforge/releases
+:::tip 如果找不到 `conda`
+加载 Miniforge，并为当前 macOS 默认使用的 Zsh 初始化 Conda：
+
+```bash
+source ~/miniforge3/etc/profile.d/conda.sh
+conda init zsh
 ```
+:::
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+打开 [Miniforge Releases 页面](https://github.com/conda-forge/miniforge/releases)，找到最新版本的 `Miniforge3-Windows-x86_64.exe` 并下载。
+
+:::tip 根据终端初始化 Conda
+**Git Bash 用户**：如果找不到 `conda`，请先加载 Conda：
+
+```bash
+# 临时生效：将 <安装路径> 替换为实际路径
+source <安装路径>/etc/profile.d/conda.sh
+
+# 永久生效：写入 bashrc，仅需执行一次
+echo 'source <安装路径>/etc/profile.d/conda.sh' >> ~/.bashrc
+source ~/.bashrc
+```
+
+PowerShell 用户可执行：
+
+```bash
+conda init powershell
+```
+:::
 
 </TabItem>
 </Tabs>
 
-2. 创建 Python 3.12 版本虚拟环境：
+</div>
+</section>
 
-:::tip
-  **Git Bash 用户**：如果 `conda` 命令找不到，说明 Git Bash 未加载 conda 环境。需要先初始化：
+<section className="rebot-step-item">
+    <span className="rebot-step-number">2</span>
+<div className="rebot-step-content">
+      <h4>关闭自动激活 base（可选）</h4>
+      <p className="rebot-step-label">第 2 步</p>
 
-  ```bash
-  # 临时生效（当前终端），<安装路径> 替换为实际路径
-  source <安装路径>/etc/profile.d/conda.sh
+Miniforge 完成 Conda 初始化后，每次打开新终端都会自动激活 `(base)` 环境。如果不想默认进入 `(base)`，可以关闭自动激活：
 
-  # 永久生效（写入 bashrc，执行一次即可）
-  echo 'source <安装路径>/etc/profile.d/conda.sh' >> ~/.bashrc
-  source ~/.bashrc
-  ```
+```bash
+conda config --set auto_activate_base false
+```
 
-  让 PowerShell 能够自动激活 conda 环境：
+**验证方式：** 关闭当前终端并重新打开，新终端的命令行提示符前不再出现 `(base)`。需要使用 Conda base环境时，手动运行 `conda activate base` 即可。
 
-  ```bash
-  conda init powershell
-  ```
+**恢复默认：** 如果后续想恢复自动激活 base，运行 `conda config --set auto_activate_base true`。
 
-:::
+</div>
+</section>
+
+<section className="rebot-step-item">
+    <span className="rebot-step-number">3</span>
+<div className="rebot-step-content">
+      <h4>创建 Python 环境</h4>
+      <p className="rebot-step-label">第 3 步</p>
+
+创建 Python 3.12 环境：
 
 ```bash
 conda create -y -n rebot python=3.12
 ```
 
-3. 激活虚拟环境。**每次打开终端使用 reBot 相关功能时，都需要重新执行该激活命令**：
+</div>
+</section>
+
+<section className="rebot-step-item">
+    <span className="rebot-step-number">4</span>
+<div className="rebot-step-content">
+      <h4>激活环境</h4>
+      <p className="rebot-step-label">第 4 步</p>
+
+每次打开新终端使用 rebot 时，都需要执行：
 
 ```bash
 conda activate rebot
 ```
 
-### 2.安装 Motorbridge
+</div>
+</section>
 
-激活 reBot 虚拟环境后，执行以下命令安装 motorbridge：
+<section className="rebot-step-item">
+    <span className="rebot-step-number">5</span>
+<div className="rebot-step-content">
+      <h4>安装 Motorbridge</h4>
+      <p className="rebot-step-label">第 5 步</p>
+
+激活 rebot 虚拟环境后，执行以下命令安装 motorbridge：
 
 :::tip 提示 macOS 用户注意
 如果您在 macOS 上遥操时帧率偏低，可能是沁恒（WCH）CH34x 驱动版本过旧导致。对于 **macOS 10.14 及以上版本**，系统已内置 AppleUSBCHC0M 驱动，您可以先卸载旧版驱动，改用 macOS 内置驱动，通常能有效提升帧率。
@@ -236,7 +327,14 @@ conda activate rebot
 pip install motorbridge
 ```
 
-### 3.pcan-usb
+</div>
+</section>
+
+<section className="rebot-step-item">
+    <span className="rebot-step-number">6</span>
+<div className="rebot-step-content">
+      <h4>配置 PCAN-USB</h4>
+      <p className="rebot-step-label">第 6 步</p>
 
 让 PCAN-USB 设备以 1Mbps 速率工作在 CAN 总线上，供机械臂通信使用
 
@@ -253,6 +351,44 @@ sudo ip link set can0 down 2>/dev/null
 sudo ip link set can0 type can bitrate 1000000
 sudo ip link set can0 up
 ```
+
+
+:::tip 注意！！！
+电脑安装驱动后，发现pcan设备固件错误，请展开以下内容，下载 PCAN 固件并按照步骤进行修复。
+:::
+
+<details>
+
+<summary>PCAN 固件下载与驱动修复步骤 - Ubuntu</summary>
+
+Ubuntu 用户请参考本指南
+
+1.> 📦 [点击下载 USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.USB2CAN 拨到 BOOT
+
+3.请将第一步的USB2CAN.zip压缩包解压，将flash_pcan_ubuntu.sh 和 USB2CAN.zip里面的pcan_canable_hw.bin 放同一目录
+
+[点击下载 flash_pcan_ubuntu.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_ubuntu.sh)
+
+如果是从别的电脑传过去的（比如 scp）：
+
+```text
+scp flash_pcan.sh pcan_canable_hw.bin seeed@你的Ubuntu的IP:~/Downloads/
+```
+或者直接拖进优盘再插到 Ubuntu 上复制过去，都行——只要最后落在 、当前目录，或者 里任意一个，脚本都能自动找到。~/Downloads~/下载/tmp
+
+4.执行：
+
+```text
+bash flash_pcan_ubuntu.sh
+```
+ 输入密码；等待完成
+
+完成后重新拨回"120R"
+
+重新插 USB。
+</details>
 
 </TabItem>
 
@@ -374,7 +510,7 @@ sudo ip link set $PCAN_IF up
 ```
 
 </TabItem>
-<TabItem value="macos" label="macos">
+<TabItem value="macos" label="macOS">
 `libPCBUSB.dylib` 无法加载时，请先安装 PCBUSB：
 
 ```bash
@@ -425,22 +561,51 @@ python3 -c "import ctypes; ctypes.CDLL('PCBUSB'); print('PCBUSB load OK')"
 motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 --timeout-ms 300
 ```
 
+
+:::tip 注意！！！
+电脑安装驱动后，发现pcan设备固件错误，请展开以下内容，下载 PCAN 固件并按照步骤进行修复。
+:::
+
+<details>
+
+<summary>PCAN 固件下载与驱动修复步骤 - macOS</summary>
+
+MAC 用户请参考本指南
+
+1.> 📦 [点击下载 USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+
+2.USB2CAN 拨到 BOOT
+
+3.请将第一步的USB2CAN.zip压缩包解压，将flash_pcan_mac.sh 和 USB2CAN.zip里面的pcan_canable_hw.bin 放同一目录
+
+[点击下载 flash_pcan_mac.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_mac.sh)
+
+如果是从别的电脑传过去的（比如 scp）：
+
+```text
+scp flash_pcan.sh pcan_canable_hw.bin seeed@你的MAC的IP:~/Downloads/
+```
+
+或者直接拖进优盘再插到 MAC 上复制过去，都行——只要最后落在 、当前目录，或者 里任意一个，脚本都能自动找到。~/Downloads~/下载/tmp
+
+4.执行：
+
+```text
+ bash /Users/"你的用户名"/Downloads/pcan_flash_mac.sh "/Users/"你的用户名"/Downloads/pcan_canable_hw.bin"
+```
+以上命令为文件放置在mac下载路径，按实际路径更改
+
+输入密码；等待完成
+
+完成后重新拨回"120R"
+
+重新插 USB。
+</details>
+
 </TabItem>
-<TabItem value="windows" label="windows">
+<TabItem value="windows" label="Windows">
 
 请访问 [pcan-usb](https://www.peak-system.com/products/hardware/external-pc-interfaces/pcan-usb/)，安装pcan-usb驱动。
-
-</TabItem>
-
-
-
-</Tabs>
-
-
-
-
-
-
 
 
 :::tip 注意！！！
@@ -449,7 +614,7 @@ motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 -
 
 <details>
 
-<summary>PCAN 固件下载与驱动修复步骤</summary>
+<summary>PCAN 固件下载与驱动修复步骤 - Windows</summary>
 
 如果安装驱动后仍然无法使用 PCAN-USB，并且设备管理器中没有识别到如下图所示的 **PCAN-USB** 设备，请下载 PCAN 固件压缩包，并按照以下步骤安装 DFU 驱动和重新烧录固件。
 
@@ -509,74 +674,17 @@ C:\Program Files (x86)\STMicroelectronics\Software\DfuSe v3.0.6\Bin\Driver
 
 </details>
 
-<details>
+</TabItem>
 
-<summary>PCAN 固件下载与驱动修复步骤-Ubuntu</summary>
 
-Ubuntu 用户请参考本指南
 
-1.> 📦 [点击下载 USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
+</Tabs>
 
-2.USB2CAN 拨到 BOOT
 
-3.请将第一步的USB2CAN.zip压缩包解压，将flash_pcan_ubuntu.sh 和 USB2CAN.zip里面的pcan_canable_hw.bin 放同一目录
 
-[点击下载 flash_pcan_ubuntu.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_ubuntu.sh)
 
-如果是从别的电脑传过去的（比如 scp）：
 
-```text
-scp flash_pcan.sh pcan_canable_hw.bin seeed@你的Ubuntu的IP:~/Downloads/
-```
-或者直接拖进优盘再插到 Ubuntu 上复制过去，都行——只要最后落在 、当前目录，或者 里任意一个，脚本都能自动找到。~/Downloads~/下载/tmp
 
-4.执行：
-
-```text
-bash flash_pcan_ubuntu.sh
-```
- 输入密码；等待完成
-
-完成后重新拨回"120R"
-
-重新插 USB。
-</details>
-
-<details>
-
-<summary>PCAN 固件下载与驱动修复步骤-MAC</summary>
-
-MAC 用户请参考本指南
-
-1.> 📦 [点击下载 USB2CAN.zip](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/USB2CAN.zip)
-
-2.USB2CAN 拨到 BOOT
-
-3.请将第一步的USB2CAN.zip压缩包解压，将flash_pcan_mac.sh 和 USB2CAN.zip里面的pcan_canable_hw.bin 放同一目录
-
-[点击下载 flash_pcan_mac.sh](https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/pcan_firmware/flash_pcan_mac.sh)
-
-如果是从别的电脑传过去的（比如 scp）：
-
-```text
-scp flash_pcan.sh pcan_canable_hw.bin seeed@你的MAC的IP:~/Downloads/
-```
-
-或者直接拖进优盘再插到 MAC 上复制过去，都行——只要最后落在 、当前目录，或者 里任意一个，脚本都能自动找到。~/Downloads~/下载/tmp
-
-4.执行：
-
-```text
- bash /Users/"你的用户名"/Downloads/pcan_flash_mac.sh "/Users/"你的用户名"/Downloads/pcan_canable_hw.bin"
-```
-以上命令为文件放置在mac下载路径，按实际路径更改
-
-输入密码；等待完成
-
-完成后重新拨回"120R"
-
-重新插 USB。
-</details>
 
 <!-- ### 3.写入电机id
 
@@ -605,7 +713,14 @@ motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7 -
 ``` -->
 
 
-### 4.启动 MotorBridge-gateway写入零点和调试
+</div>
+</section>
+
+<section className="rebot-step-item">
+    <span className="rebot-step-number">7</span>
+<div className="rebot-step-content">
+      <h4>使用 MotorBridge Gateway 写入零点和调试</h4>
+      <p className="rebot-step-label">第 7 步</p>
 
 #### 电机复位前须知
 
@@ -673,3 +788,7 @@ reBot Arm B601-RS 的大多数示例使用 MIT 模式运行。
 1. 在机械臂零点校准完成后，点击读取参数，如读取成功，网页会下载 tsv 文件，该文件可以使用文本或表格打开，其内提供的参数与电机厂商提供的参数功能一致，将该文件修改后，再写入机械臂。
 
 2. 如您正在寻求技术支持，请将该文件提供给工程师，更有助于工程师分析问题。
+
+</div>
+</section>
+</div>

--- a/src/css/rebot-wiki-style.css
+++ b/src/css/rebot-wiki-style.css
@@ -271,6 +271,111 @@
   font-size: 0.86rem;
 }
 
+/* 简洁的纵向操作步骤 */
+.rebot-step-flow {
+  --rebot-step-line: var(--ifm-color-emphasis-400);
+  --rebot-step-muted: var(--ifm-color-emphasis-700);
+  margin: 1.5rem 0 2rem;
+}
+
+.rebot-step-item {
+  position: relative;
+  min-width: 0;
+  padding: 0 0 2.75rem 4rem;
+}
+
+.rebot-step-item:last-child {
+  padding-bottom: 0.25rem;
+}
+
+.rebot-step-item:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 2.75rem;
+  bottom: 0.55rem;
+  left: 1.14rem;
+  border-left: 2px dotted var(--rebot-step-line);
+}
+
+.rebot-step-number {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  display: inline-flex;
+  width: 2.35rem;
+  height: 2.35rem;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--ifm-font-color-base);
+  border-radius: 999px;
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-color);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.rebot-step-content {
+  min-width: 0;
+}
+
+.rebot-step-content > h4 {
+  margin: 0 0 0.35rem;
+  font-size: 1.28rem;
+  line-height: 1.5;
+}
+
+.rebot-step-label {
+  margin: 0 0 1.6rem;
+  color: var(--rebot-step-muted);
+  font-style: italic;
+}
+
+.rebot-step-content .tabs-container {
+  margin: 1.1rem 0 1.35rem;
+}
+
+.rebot-step-content pre {
+  border-radius: 16px;
+}
+
+/* 电源图片：上方双列，下方通栏并保持左右边缘对齐 */
+.rebot-power-gallery {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 900px;
+  margin: 1.5rem auto 2rem;
+}
+
+.rebot-power-gallery-item {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 14px;
+  background: var(--ifm-background-surface-color, var(--ifm-background-color));
+}
+
+.rebot-power-gallery-item figcaption {
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  font-weight: 700;
+  text-align: center;
+}
+
+.rebot-power-gallery-item img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.rebot-power-gallery-item--wide {
+  grid-column: 1 / -1;
+}
+
 /* details 卡片 */
 .content-details {
   margin: 0.9rem 0;
@@ -540,5 +645,29 @@ html[data-theme='dark'] .course-path-item.active {
 
   .safety-alert {
     grid-template-columns: 1fr;
+  }
+
+  .rebot-step-item {
+    padding-left: 3.25rem;
+  }
+
+  .rebot-step-number {
+    width: 2rem;
+    height: 2rem;
+    font-size: 0.88rem;
+  }
+
+  .rebot-step-item:not(:last-child)::after {
+    top: 2.4rem;
+    left: 0.96rem;
+  }
+
+  .rebot-power-gallery {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .rebot-power-gallery-item--wide {
+    grid-column: auto;
   }
 }


### PR DESCRIPTION
## Summary

- refresh the English and Chinese B601-RS getting started guides with a cleaner step-by-step layout
- add OS-specific Miniforge, MotorBridge, and PCAN-USB instructions
- improve power-supply image alignment and organize PCAN recovery guidance by platform

## Validation

- Not run (manual validation requested)